### PR TITLE
Set Homebrew formula sha256 for v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,33 @@ Use the access you already have:
 
 The model is project-first: a workspace represents a life area (personal, work, a client), each workspace contains projects, and each project carries files, notes, decisions, and context that Ciaobot injects when you work inside it, so the agent does not rediscover what you are talking about every time.
 
-## Quickstart
+## Install
+
+Install from the [latest release](https://github.com/raffaelefarinaro/ciaobot/releases/latest) — the wheel ships with the pre-built PWA:
+
+```bash
+python3.12 -m venv ~/.ciaobot-venv
+~/.ciaobot-venv/bin/pip install https://github.com/raffaelefarinaro/ciaobot/releases/download/v0.2.0/ciao-0.2.0-py3-none-any.whl
+~/.ciaobot-venv/bin/ciao setup --workspace ~/ciao-workspace
+~/.ciaobot-venv/bin/ciao run
+```
+
+On macOS you can use the Homebrew formula instead:
+
+```bash
+curl -fsSLO https://raw.githubusercontent.com/raffaelefarinaro/ciaobot/main/deploy/homebrew/ciao.rb
+brew install --formula ./ciao.rb
+```
+
+## Quickstart (from source)
+
+A git checkout does not include the built PWA bundle, so build it once before running:
 
 ```bash
 python3.12 -m venv .venv
 source .venv/bin/activate
 python -m pip install -e '.[test]'
+(cd web && npm ci && npm run build)
 ciao setup --workspace ~/ciao-workspace
 ciao run
 ```

--- a/ciao/release.py
+++ b/ciao/release.py
@@ -111,7 +111,7 @@ def read_versions(root: Path | str) -> RepoVersions:
     web_package = _read_json(files.web_package)
     web_lock = _read_json(files.web_lock)
 
-    formula_match = re.search(r"/refs/tags/v([^/]+)\.tar\.gz", formula_text)
+    formula_match = re.search(r"/releases/download/v([^/]+)/", formula_text)
     return RepoVersions(
         pyproject=_extract_one(
             r'^version\s*=\s*"([^"]+)"',
@@ -246,9 +246,9 @@ def apply_release_files(
 
     formula_text = files.homebrew_formula.read_text(encoding="utf-8")
     formula_text = _replace_once(
-        r'url "https://github\.com/raffaelefarinaro/ciaobot/archive/refs/tags/v[^"]+\.tar\.gz"',
+        r'url "https://github\.com/raffaelefarinaro/ciaobot/releases/download/v[^"]+/ciao-[^"]+\.tar\.gz"',
         formula_text,
-        f'url "https://github.com/raffaelefarinaro/ciaobot/archive/refs/tags/v{version}.tar.gz"',
+        f'url "https://github.com/raffaelefarinaro/ciaobot/releases/download/v{version}/ciao-{version}.tar.gz"',
         path=files.homebrew_formula,
     )
     formula_text = _replace_once(

--- a/deploy/homebrew/ciao.rb
+++ b/deploy/homebrew/ciao.rb
@@ -7,7 +7,7 @@ class Ciao < Formula
   homepage "https://github.com/raffaelefarinaro/ciaobot"
   license "Apache-2.0"
   url "https://github.com/raffaelefarinaro/ciaobot/archive/refs/tags/v0.2.0.tar.gz"
-  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  sha256 "9d210014a49f25451518cf2c1f35aee28a6e8fa76fa8b045d560c4428f228391"
   head "https://github.com/raffaelefarinaro/ciaobot.git", branch: "main"
 
   depends_on "python@3.12"

--- a/deploy/homebrew/ciao.rb
+++ b/deploy/homebrew/ciao.rb
@@ -6,8 +6,8 @@ class Ciao < Formula
   desc "Local-first personal assistant server"
   homepage "https://github.com/raffaelefarinaro/ciaobot"
   license "Apache-2.0"
-  url "https://github.com/raffaelefarinaro/ciaobot/archive/refs/tags/v0.2.0.tar.gz"
-  sha256 "9d210014a49f25451518cf2c1f35aee28a6e8fa76fa8b045d560c4428f228391"
+  url "https://github.com/raffaelefarinaro/ciaobot/releases/download/v0.2.0/ciao-0.2.0.tar.gz"
+  sha256 "5686c005477ff6c547b4966bec8a0f9a79b2f64960ed807756fe5a17b5d4728d"
   head "https://github.com/raffaelefarinaro/ciaobot.git", branch: "main"
 
   depends_on "python@3.12"

--- a/tests/test_homebrew_formula.py
+++ b/tests/test_homebrew_formula.py
@@ -44,7 +44,7 @@ def test_homebrew_formula_points_at_canonical_public_repo() -> None:
     text = _formula_text()
 
     assert f'homepage "{CANONICAL_REPO}"' in text
-    assert f'url "{CANONICAL_REPO}/archive/refs/tags/v' in text
+    assert f'url "{CANONICAL_REPO}/releases/download/v' in text
     assert f'head "{CANONICAL_REPO}.git", branch: "main"' in text
     # Every GitHub reference must be the canonical public repo.
     for line in text.splitlines():

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -47,7 +47,7 @@ def _write_release_tree(root: Path) -> None:
     )
     (root / "deploy" / "homebrew" / "ciao.rb").write_text(
         'class Ciao < Formula\n'
-        '  url "https://github.com/raffaelefarinaro/ciaobot/archive/refs/tags/v0.2.0.tar.gz"\n'
+        '  url "https://github.com/raffaelefarinaro/ciaobot/releases/download/v0.2.0/ciao-0.2.0.tar.gz"\n'
         f'  sha256 "{PLACEHOLDER_SHA256}"\n'
         'end\n',
         encoding="utf-8",


### PR DESCRIPTION
Points the Homebrew formula at the published v0.2.0 release sdist (built with the PWA bundle) instead of the auto-generated source tarball, which lacks `ciao/web/static/assets/` and would serve a blank frontend.

- url: `releases/download/v0.2.0/ciao-0.2.0.tar.gz`
- sha256: `5686c005477ff6c547b4966bec8a0f9a79b2f64960ed807756fe5a17b5d4728d`
- release tooling regexes and tests updated to the new URL shape