### PR TITLE
macOS menu bar companion with server status

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ I'm sharing it because the patterns may be useful to you, and because I'm happy 
 - Archives chats into a markdown vault, then extracts session insights and drafts memory proposals for review.
 - Keeps durable project context separate from short-lived chat state.
 - Supports voice transcription, push notifications, model/provider settings, and local package updates from the UI.
+- Shows a macOS menu bar icon (`ciao menubar`) with server status and open/restart/logs actions — the Ciaobot face turns scared when the server is down.
 
 What it does **not** do automatically: it never promotes memory proposals into your long-term memory files without review, never discards or rewrites an existing notes folder during onboarding, and never locks you into one provider; chats and routines can route through any configured backend.
 
@@ -62,7 +63,7 @@ ciao setup --workspace ~/ciao-workspace
 ciao run
 ```
 
-`ciao setup` is idempotent: it writes the initial `.env`, seeds the workspace docs and vault, and (on macOS) renders a LaunchAgent plus a `Ciaobot.app` shortcut that opens the local PWA. Full setup details, optional Node tooling, and the Homebrew formula: [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
+`ciao setup` is idempotent: it writes the initial `.env`, seeds the workspace docs and vault, and (on macOS) renders LaunchAgents for the server and the menu bar companion plus a `Ciaobot.app` shortcut that opens the local PWA. The menu bar icon needs the optional extra (`pip install 'ciao[menubar]'` — the Homebrew install includes it). Full setup details, optional Node tooling, and the Homebrew formula: [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
 
 Optional capabilities (Google Workspace, Apple Intelligence titles, MCP connectors) each have their own setup in [INTEGRATIONS.md](INTEGRATIONS.md).
 

--- a/ciao/cli.py
+++ b/ciao/cli.py
@@ -61,9 +61,10 @@ def _render_launchd_plist(
     python_path: str,
     port: int,
     path: str = "",
+    template_name: str = "com.ciao.server.plist.tmpl",
 ) -> str:
     template = resources.files("ciao.stock").joinpath(
-        "deploy", "com.ciao.server.plist.tmpl"
+        "deploy", template_name
     ).read_text(encoding="utf-8")
     # Under launchd the default PATH omits Homebrew, so subprocess calls to
     # npm/node/git fail. Bake the user's PATH from setup time into the plist.
@@ -86,8 +87,9 @@ def _write_launchd_plist(
     python_path: str,
     port: int,
     path: str = "",
+    plist_name: str = "com.ciao.server.plist",
 ) -> Path:
-    plist = launch_agents_dir.expanduser() / "com.ciao.server.plist"
+    plist = launch_agents_dir.expanduser() / plist_name
     plist.parent.mkdir(parents=True, exist_ok=True)
     plist.write_text(
         _render_launchd_plist(
@@ -95,6 +97,7 @@ def _write_launchd_plist(
             python_path=python_path,
             port=port,
             path=path,
+            template_name=f"{plist_name}.tmpl",
         ),
         encoding="utf-8",
     )
@@ -239,13 +242,15 @@ def setup_workspace(
 
     launch_dir = Path(launch_agents_dir) if launch_agents_dir is not None else Path.home() / "Library" / "LaunchAgents"
     app_root_dir = Path(app_dir) if app_dir is not None else Path.home() / "Applications"
-    written.append(_write_launchd_plist(
-        workspace=root,
-        launch_agents_dir=launch_dir,
-        python_path=python_path or sys.executable,
-        port=port,
-        path=os.environ.get("PATH", ""),
-    ))
+    for plist_name in ("com.ciao.server.plist", "com.ciao.menubar.plist"):
+        written.append(_write_launchd_plist(
+            workspace=root,
+            launch_agents_dir=launch_dir,
+            python_path=python_path or sys.executable,
+            port=port,
+            path=os.environ.get("PATH", ""),
+            plist_name=plist_name,
+        ))
     written.append(_write_app_shortcut(
         workspace=root,
         app_dir=app_root_dir,
@@ -267,12 +272,27 @@ def _setup_command(args: argparse.Namespace) -> int:
     )
     for path in written:
         print(path)
-    plist = Path(args.launch_agents_dir).expanduser() / "com.ciao.server.plist"
+    plists = [
+        Path(args.launch_agents_dir).expanduser() / name
+        for name in ("com.ciao.server.plist", "com.ciao.menubar.plist")
+    ]
     if args.load_launchd:
-        subprocess.run(["launchctl", "unload", str(plist)], check=False)
-        return subprocess.run(["launchctl", "load", "-w", str(plist)], check=False).returncode
-    print(f"LaunchAgent not loaded. To load it: launchctl load -w {plist}")
+        rc = 0
+        for plist in plists:
+            subprocess.run(["launchctl", "unload", str(plist)], check=False)
+            rc = subprocess.run(
+                ["launchctl", "load", "-w", str(plist)], check=False
+            ).returncode or rc
+        return rc
+    for plist in plists:
+        print(f"LaunchAgent not loaded. To load it: launchctl load -w {plist}")
     return 0
+
+
+def _menubar_command(args: argparse.Namespace) -> int:
+    from ciao.menubar import run_menubar
+
+    return run_menubar(Path(args.workspace).expanduser().resolve(), args.port)
 
 
 def _auth_command_for_provider(provider: str) -> list[str]:
@@ -692,6 +712,24 @@ def build_parser() -> argparse.ArgumentParser:
 
     run_parser = subparsers.add_parser("run", help="Run the Ciaobot server.")
     run_parser.set_defaults(func=lambda _args: _run_server())
+
+    menubar_parser = subparsers.add_parser(
+        "menubar",
+        help="Run the macOS menu bar companion (requires `pip install 'ciao[menubar]'`).",
+    )
+    menubar_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path(os.environ.get("CIAO_WORKSPACE", ".")),
+        help="Workspace directory (defaults to $CIAO_WORKSPACE or cwd).",
+    )
+    menubar_parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("CIAO_PORT", "8443")),
+        help="Localhost port the server listens on (defaults to $CIAO_PORT or 8443).",
+    )
+    menubar_parser.set_defaults(func=_menubar_command)
 
     setup_parser = subparsers.add_parser(
         "setup",

--- a/ciao/menubar.py
+++ b/ciao/menubar.py
@@ -1,0 +1,136 @@
+"""macOS menu bar companion for the Ciaobot server.
+
+Puts the Ciaobot face in the status bar (the scared face when the local
+server is unreachable) with quick actions: open the PWA, restart the
+launchd-managed server, and view logs. The Cocoa dependency (rumps) is
+optional so the base package stays slim; install with
+``pip install 'ciao[menubar]'``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+
+
+SERVER_LAUNCHD_LABEL = "com.ciao.server"
+POLL_SECONDS = 10.0
+
+
+@dataclass(frozen=True, slots=True)
+class ServerStatus:
+    reachable: bool
+    ready: bool
+
+
+def fetch_server_status(port: int, *, timeout: float = 2.0) -> ServerStatus:
+    """Poll the unauthenticated startup-status endpoint of the local server."""
+
+    url = f"http://localhost:{port}/api/startup-status"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, ValueError):
+        return ServerStatus(reachable=False, ready=False)
+    if not isinstance(payload, dict):
+        return ServerStatus(reachable=True, ready=False)
+    return ServerStatus(reachable=True, ready=bool(payload.get("overall_ready", True)))
+
+
+def status_label(status: ServerStatus) -> str:
+    if not status.reachable:
+        return "Server: not running"
+    if not status.ready:
+        return "Server: starting…"
+    return "Server: running"
+
+
+def open_url(workspace: Path, port: int) -> str:
+    """URL the menu bar opens; reuses the Ciaobot.app setup token when present."""
+
+    token = ""
+    token_path = workspace / ".runtime" / "setup-token"
+    try:
+        token = token_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        pass
+    base = f"http://localhost:{port}/"
+    return f"{base}?setup={token}" if token else base
+
+
+def open_app_command(workspace: Path, port: int) -> list[str]:
+    return ["open", open_url(workspace, port)]
+
+
+def restart_server_command(uid: int | None = None) -> list[str]:
+    resolved = os.getuid() if uid is None else uid
+    return ["launchctl", "kickstart", "-k", f"gui/{resolved}/{SERVER_LAUNCHD_LABEL}"]
+
+
+def view_logs_command(workspace: Path) -> list[str]:
+    return ["open", str(workspace / ".runtime" / "ciao.stderr.log")]
+
+
+def icon_path(name: str) -> str:
+    return str(resources.files("ciao.web").joinpath("static", name))
+
+
+def run_menubar(workspace: Path, port: int) -> int:
+    """Run the rumps status-bar app. Returns 1 if rumps is not installed."""
+
+    try:
+        import rumps
+    except ImportError:
+        print(
+            "The Ciaobot menu bar app needs the optional 'rumps' dependency.\n"
+            "Install it with: pip install 'ciao[menubar]'",
+            file=sys.stderr,
+        )
+        return 1
+
+    face = icon_path("face.png")
+    face_scared = icon_path("face_scared.png")
+
+    app = rumps.App("Ciaobot", icon=face, quit_button=None)
+    status_item = rumps.MenuItem(status_label(ServerStatus(False, False)))
+    status_item.set_callback(None)
+
+    def refresh(_timer=None) -> None:
+        status = fetch_server_status(port)
+        status_item.title = status_label(status)
+        app.icon = face if status.reachable else face_scared
+
+    def on_open(_sender) -> None:
+        subprocess.run(open_app_command(workspace, port), check=False)
+
+    def on_restart(_sender) -> None:
+        subprocess.run(restart_server_command(), check=False)
+        refresh()
+
+    def on_logs(_sender) -> None:
+        subprocess.run(view_logs_command(workspace), check=False)
+
+    app.menu = [
+        rumps.MenuItem("Open Ciaobot", callback=on_open),
+        status_item,
+        None,
+        rumps.MenuItem("Restart Server", callback=on_restart),
+        rumps.MenuItem("View Logs", callback=on_logs),
+        None,
+        rumps.MenuItem(
+            "Quit Menu Bar Icon",
+            callback=lambda _sender: rumps.quit_application(),
+        ),
+    ]
+
+    rumps.Timer(refresh, POLL_SECONDS).start()
+    refresh()
+    app.run()
+    return 0

--- a/ciao/stock/deploy/com.ciao.menubar.plist.tmpl
+++ b/ciao/stock/deploy/com.ciao.menubar.plist.tmpl
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.ciao.menubar</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{CIAO_PYTHON}}</string>
+        <string>-m</string>
+        <string>ciao.cli</string>
+        <string>menubar</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>{{CIAO_WORKSPACE}}</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>CIAO_WORKSPACE</key>
+        <string>{{CIAO_WORKSPACE}}</string>
+        <key>CIAO_PORT</key>
+        <string>{{CIAO_PORT}}</string>
+        <key>PATH</key>
+        <string>{{CIAO_PATH}}</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>{{CIAO_WORKSPACE}}/.runtime/ciao.menubar.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{CIAO_WORKSPACE}}/.runtime/ciao.menubar.stderr.log</string>
+</dict>
+</plist>

--- a/deploy/homebrew/ciao.rb
+++ b/deploy/homebrew/ciao.rb
@@ -16,6 +16,8 @@ class Ciao < Formula
     python = Formula["python@3.12"].opt_bin/"python3.12"
     venv = virtualenv_create(libexec, python)
     venv.pip_install_and_link buildpath
+    # Menu bar companion (rumps/pyobjc); optional extra kept out of the base wheel.
+    venv.pip_install "#{buildpath}[menubar]"
   end
 
   def post_install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ test = [
 voice-local = [
   "mlx-whisper==0.4.3",
 ]
+# macOS menu bar companion (`ciao menubar`).
+menubar = [
+  "rumps==0.4.0",
+]
 
 [project.scripts]
 ciao = "ciao.cli:main"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -200,6 +200,14 @@ def test_setup_scaffolds_workspace_from_stock(tmp_path: Path) -> None:
     assert f"<string>{workspace.resolve()}</string>" in plist_text
     assert "<string>9443</string>" in plist_text
     assert f"<string>{workspace.resolve()}/.runtime/ciao.stdout.log</string>" in plist_text
+    menubar_plist = launch_agents / "com.ciao.menubar.plist"
+    assert menubar_plist.is_file()
+    menubar_text = menubar_plist.read_text(encoding="utf-8")
+    assert "<string>com.ciao.menubar</string>" in menubar_text
+    assert "<string>/opt/ciao/bin/python</string>" in menubar_text
+    assert "<string>menubar</string>" in menubar_text
+    assert "<string>9443</string>" in menubar_text
+    assert f"<string>{workspace.resolve()}/.runtime/ciao.menubar.stdout.log</string>" in menubar_text
     app_exe = apps / "Ciaobot.app" / "Contents" / "MacOS" / "Ciaobot"
     assert app_exe.is_file()
     assert app_exe.stat().st_mode & 0o111

--- a/tests/test_homebrew_formula.py
+++ b/tests/test_homebrew_formula.py
@@ -18,6 +18,7 @@ def test_homebrew_formula_installs_python312_virtualenv_package() -> None:
     assert 'Formula["python@3.12"].opt_bin/"python3.12"' in text
     assert "virtualenv_create(libexec, python)" in text
     assert "venv.pip_install_and_link buildpath" in text
+    assert 'venv.pip_install "#{buildpath}[menubar]"' in text
     assert 'bin/"ciao"' in text
 
 

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+from pathlib import Path
+
+from ciao import menubar
+
+
+class _FakeResponse:
+    def __init__(self, payload: object) -> None:
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+
+def test_fetch_server_status_ready(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_urlopen(url: str, timeout: float):
+        calls["url"] = url
+        calls["timeout"] = timeout
+        return _FakeResponse({"phases": [], "overall_ready": True})
+
+    monkeypatch.setattr(menubar.urllib.request, "urlopen", fake_urlopen)
+
+    status = menubar.fetch_server_status(9443)
+
+    assert calls["url"] == "http://localhost:9443/api/startup-status"
+    assert status == menubar.ServerStatus(reachable=True, ready=True)
+
+
+def test_fetch_server_status_starting(monkeypatch) -> None:
+    monkeypatch.setattr(
+        menubar.urllib.request,
+        "urlopen",
+        lambda url, timeout: _FakeResponse({"phases": [], "overall_ready": False}),
+    )
+
+    assert menubar.fetch_server_status(8443) == menubar.ServerStatus(
+        reachable=True, ready=False
+    )
+
+
+def test_fetch_server_status_unreachable(monkeypatch) -> None:
+    def fake_urlopen(url: str, timeout: float):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(menubar.urllib.request, "urlopen", fake_urlopen)
+
+    assert menubar.fetch_server_status(8443) == menubar.ServerStatus(
+        reachable=False, ready=False
+    )
+
+
+def test_status_labels() -> None:
+    assert menubar.status_label(menubar.ServerStatus(True, True)) == "Server: running"
+    assert menubar.status_label(menubar.ServerStatus(True, False)) == "Server: starting…"
+    assert (
+        menubar.status_label(menubar.ServerStatus(False, False))
+        == "Server: not running"
+    )
+
+
+def test_open_app_command_uses_setup_token(tmp_path: Path) -> None:
+    token_path = tmp_path / ".runtime" / "setup-token"
+    token_path.parent.mkdir(parents=True)
+    token_path.write_text("tok123\n", encoding="utf-8")
+
+    assert menubar.open_app_command(tmp_path, 9443) == [
+        "open",
+        "http://localhost:9443/?setup=tok123",
+    ]
+
+
+def test_open_app_command_without_token_falls_back_to_plain_url(tmp_path: Path) -> None:
+    assert menubar.open_app_command(tmp_path, 8443) == [
+        "open",
+        "http://localhost:8443/",
+    ]
+
+
+def test_restart_server_command_targets_launchd_label() -> None:
+    assert menubar.restart_server_command(uid=501) == [
+        "launchctl",
+        "kickstart",
+        "-k",
+        "gui/501/com.ciao.server",
+    ]
+
+
+def test_view_logs_command_opens_stderr_log(tmp_path: Path) -> None:
+    assert menubar.view_logs_command(tmp_path) == [
+        "open",
+        str(tmp_path / ".runtime" / "ciao.stderr.log"),
+    ]
+
+
+def test_icon_paths_resolve_to_packaged_faces() -> None:
+    assert Path(menubar.icon_path("face.png")).is_file()
+    assert Path(menubar.icon_path("face_scared.png")).is_file()
+
+
+def test_run_menubar_without_rumps_explains_the_extra(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    monkeypatch.setitem(sys.modules, "rumps", None)
+
+    assert menubar.run_menubar(tmp_path, 8443) == 1
+    assert "ciao[menubar]" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- New `ciao menubar` command: Ciaobot face in the macOS status bar, polling the unauthenticated `/api/startup-status` endpoint every 10s. Face turns scared while the server is unreachable.
- Menu: Open Ciaobot (reuses the setup token like Ciaobot.app), status line (running / starting… / not running), Restart Server (`launchctl kickstart -k`), View Logs, Quit.
- `ciao setup` writes and loads a `com.ciao.menubar` LaunchAgent alongside the server agent.
- `rumps` is an optional `ciao[menubar]` extra so the base wheel avoids pyobjc; the Homebrew formula installs it. Without the extra the command exits with an install hint.

## Testing
- `pytest tests/` — 837 passed (12 new menubar tests, setup/formula tests extended)
- Verified live against a running instance: status poll returns reachable+ready, rumps app and menu construct cleanly
- `ciao menubar --help` parses; friendly error path covered when rumps is absent