### PR TITLE
Ciaobot.app in /Applications; open chats inline in the menu bar

### DIFF
--- a/ciao/cli.py
+++ b/ciao/cli.py
@@ -120,18 +120,40 @@ def _ensure_setup_token(workspace: Path) -> str:
     return token
 
 
-def _remove_legacy_app_shortcut(app_dir: Path) -> None:
-    """Remove the pre-rename Ciao.app launcher, but only if it is ours."""
+def _default_app_dir() -> Path:
+    """Prefer /Applications (what Finder's sidebar shows) when writable;
+    non-admin accounts fall back to the per-user folder."""
 
-    legacy = app_dir / "Ciao.app"
-    plist = legacy / "Contents" / "Info.plist"
-    try:
-        if not plist.is_file() or "local.ciao.app" not in plist.read_text(encoding="utf-8"):
-            return
-        shutil.rmtree(legacy)
-    except OSError:
-        logger_msg = f"Could not remove legacy app shortcut at {legacy}"
-        print(logger_msg, file=sys.stderr)
+    system_apps = Path("/Applications")
+    if os.access(system_apps, os.W_OK):
+        return system_apps
+    return Path.home() / "Applications"
+
+
+_OUR_BUNDLE_IDS = ("local.ciao.app", "local.ciaobot.app")
+
+
+def _remove_legacy_app_shortcuts(app_dir: Path) -> None:
+    """Remove stale launcher bundles we wrote earlier: the pre-rename
+    Ciao.app next to the target, and both names in ~/Applications when the
+    target moved to /Applications. Only bundles with our bundle id are
+    touched."""
+
+    candidates = {app_dir / "Ciao.app"}
+    home_apps = Path.home() / "Applications"
+    if app_dir != home_apps:
+        candidates.update({home_apps / "Ciao.app", home_apps / "Ciaobot.app"})
+    for legacy in candidates:
+        plist = legacy / "Contents" / "Info.plist"
+        try:
+            if not plist.is_file():
+                continue
+            text = plist.read_text(encoding="utf-8")
+            if not any(bundle_id in text for bundle_id in _OUR_BUNDLE_IDS):
+                continue
+            shutil.rmtree(legacy)
+        except OSError:
+            print(f"Could not remove legacy app shortcut at {legacy}", file=sys.stderr)
 
 
 def _write_app_shortcut(
@@ -141,7 +163,7 @@ def _write_app_shortcut(
     port: int,
 ) -> Path:
     token = _ensure_setup_token(workspace)
-    _remove_legacy_app_shortcut(app_dir.expanduser())
+    _remove_legacy_app_shortcuts(app_dir.expanduser())
     app_root = app_dir.expanduser() / "Ciaobot.app"
     contents = app_root / "Contents"
     macos = contents / "MacOS"
@@ -262,7 +284,7 @@ def setup_workspace(
     written.append(vault_path)
 
     launch_dir = Path(launch_agents_dir) if launch_agents_dir is not None else Path.home() / "Library" / "LaunchAgents"
-    app_root_dir = Path(app_dir) if app_dir is not None else Path.home() / "Applications"
+    app_root_dir = Path(app_dir) if app_dir is not None else _default_app_dir()
     for plist_name in ("com.ciao.server.plist", "com.ciao.menubar.plist"):
         written.append(_write_launchd_plist(
             workspace=root,
@@ -784,8 +806,8 @@ def build_parser() -> argparse.ArgumentParser:
     setup_parser.add_argument(
         "--app-dir",
         type=Path,
-        default=Path.home() / "Applications",
-        help="Directory where Ciaobot.app is written.",
+        default=None,
+        help="Directory where Ciaobot.app is written. Defaults to /Applications when writable, else ~/Applications.",
     )
     setup_parser.add_argument(
         "--load-launchd",

--- a/ciao/menubar.py
+++ b/ciao/menubar.py
@@ -267,17 +267,9 @@ def run_menubar(workspace: Path, port: int) -> int:
     face_scared = icon_path("face_scared.png")
 
     app = rumps.App("Ciaobot", icon=face, quit_button=None)
-    status_item = rumps.MenuItem(status_label(ServerStatus(False, False)))
-    status_item.set_callback(None)
-    notifications_menu = rumps.MenuItem("Notifications")
-    notifications_menu.add(_disabled_item(rumps, "No notifications yet"))
-    chats_menu = rumps.MenuItem("Open Chats")
-    chats_menu.add(_disabled_item(rumps, "No open chats"))
-    addresses_menu = rumps.MenuItem("Addresses (click to copy)")
-    addresses_menu.add(_disabled_item(rumps, "Detecting…"))
 
     # Only notify for entries newer than launch, not the whole backlog.
-    state = {"last_seen_ts": time.time()}
+    state = {"last_seen_ts": time.time(), "fingerprint": None}
 
     def _open_chat_callback(chat_id: str):
         def _callback(_sender) -> None:
@@ -291,45 +283,6 @@ def run_menubar(workspace: Path, port: int) -> int:
 
         return _callback
 
-    def refresh(_timer=None) -> None:
-        status = fetch_server_status(port)
-        status_item.title = status_label(status)
-        app.icon = face if status.reachable else face_scared
-
-        entries = read_notifications(workspace)
-        notifications_menu.clear()
-        if not entries:
-            notifications_menu.add(_disabled_item(rumps, "No notifications yet"))
-        for entry in entries:
-            notifications_menu.add(
-                rumps.MenuItem(
-                    notification_menu_title(entry),
-                    callback=_open_chat_callback(entry.chat_id),
-                )
-            )
-
-        chats = read_open_chats(workspace)
-        chats_menu.clear()
-        if not chats:
-            chats_menu.add(_disabled_item(rumps, "No open chats"))
-        for chat in chats:
-            chats_menu.add(
-                rumps.MenuItem(
-                    chat.title if len(chat.title) <= 60 else chat.title[:59] + "…",
-                    callback=_open_chat_callback(chat.chat_id),
-                )
-            )
-
-        addresses_menu.clear()
-        for url in server_addresses(port):
-            addresses_menu.add(rumps.MenuItem(url, callback=_copy_address_callback(url)))
-
-        fresh = [e for e in entries if e.ts > state["last_seen_ts"]]
-        if fresh:
-            state["last_seen_ts"] = max(e.ts for e in fresh)
-            for entry in fresh[:3]:
-                subprocess.run(notify_command(entry.title, entry.body), check=False)
-
     def on_open(_sender) -> None:
         subprocess.run(open_app_command(workspace, port), check=False)
 
@@ -340,22 +293,77 @@ def run_menubar(workspace: Path, port: int) -> int:
     def on_logs(_sender) -> None:
         subprocess.run(view_logs_command(workspace), check=False)
 
-    app.menu = [
-        rumps.MenuItem("Open Ciaobot", callback=on_open),
-        status_item,
-        None,
-        notifications_menu,
-        chats_menu,
-        addresses_menu,
-        None,
-        rumps.MenuItem("Restart Server", callback=on_restart),
-        rumps.MenuItem("View Logs", callback=on_logs),
-        None,
-        rumps.MenuItem(
-            "Quit Menu Bar Icon",
-            callback=lambda _sender: rumps.quit_application(),
-        ),
-    ]
+    def _rebuild_menu(
+        status: ServerStatus,
+        chats: list[OpenChat],
+        entries: list[Notification],
+        addresses: list[str],
+    ) -> None:
+        notifications_menu = rumps.MenuItem("Notifications")
+        if not entries:
+            notifications_menu.add(_disabled_item(rumps, "No notifications yet"))
+        for entry in entries:
+            notifications_menu.add(
+                rumps.MenuItem(
+                    notification_menu_title(entry),
+                    callback=_open_chat_callback(entry.chat_id),
+                )
+            )
+
+        addresses_menu = rumps.MenuItem("Addresses (click to copy)")
+        for url in addresses:
+            addresses_menu.add(rumps.MenuItem(url, callback=_copy_address_callback(url)))
+
+        # Open chats live directly in the menu under a section header.
+        chat_items = [
+            rumps.MenuItem(
+                chat.title if len(chat.title) <= 60 else chat.title[:59] + "…",
+                callback=_open_chat_callback(chat.chat_id),
+            )
+            for chat in chats
+        ] or [_disabled_item(rumps, "No open chats")]
+
+        app.menu.clear()
+        app.menu = [
+            rumps.MenuItem("Open Ciaobot", callback=on_open),
+            _disabled_item(rumps, status_label(status)),
+            None,
+            _disabled_item(rumps, "Open Chats"),
+            *chat_items,
+            None,
+            notifications_menu,
+            addresses_menu,
+            None,
+            rumps.MenuItem("Restart Server", callback=on_restart),
+            rumps.MenuItem("View Logs", callback=on_logs),
+            None,
+            rumps.MenuItem("Quit", callback=lambda _sender: rumps.quit_application()),
+        ]
+
+    def refresh(_timer=None) -> None:
+        status = fetch_server_status(port)
+        app.icon = face if status.reachable else face_scared
+
+        entries = read_notifications(workspace)
+        chats = read_open_chats(workspace)
+        addresses = server_addresses(port)
+
+        # Rebuild only when content changed so an open menu doesn't flicker.
+        fingerprint = (
+            status,
+            tuple((c.chat_id, c.title) for c in chats),
+            tuple((e.ts, e.title, e.body) for e in entries),
+            tuple(addresses),
+        )
+        if fingerprint != state["fingerprint"]:
+            state["fingerprint"] = fingerprint
+            _rebuild_menu(status, chats, entries, addresses)
+
+        fresh = [e for e in entries if e.ts > state["last_seen_ts"]]
+        if fresh:
+            state["last_seen_ts"] = max(e.ts for e in fresh)
+            for entry in fresh[:3]:
+                subprocess.run(notify_command(entry.title, entry.body), check=False)
 
     rumps.Timer(refresh, POLL_SECONDS).start()
     refresh()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -248,6 +248,40 @@ def test_setup_removes_our_legacy_ciao_app_only(tmp_path: Path) -> None:
     assert not foreign.exists()  # untouched (never created); guard for typos
 
 
+def test_default_app_dir_prefers_system_applications(monkeypatch) -> None:
+    monkeypatch.setattr(cli.os, "access", lambda path, mode: True)
+    assert cli._default_app_dir() == Path("/Applications")
+
+    monkeypatch.setattr(cli.os, "access", lambda path, mode: False)
+    assert cli._default_app_dir() == Path.home() / "Applications"
+
+
+def test_setup_cleans_our_bundles_from_home_applications(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    home_apps = tmp_path / "home" / "Applications"
+    for name, bundle_id in (("Ciao.app", "local.ciao.app"), ("Ciaobot.app", "local.ciaobot.app")):
+        contents = home_apps / name / "Contents"
+        contents.mkdir(parents=True)
+        (contents / "Info.plist").write_text(
+            f"<plist><string>{bundle_id}</string></plist>", encoding="utf-8"
+        )
+    system_apps = tmp_path / "SystemApplications"
+
+    assert cli.main([
+        "setup",
+        "--workspace",
+        str(tmp_path / "workspace"),
+        "--launch-agents-dir",
+        str(tmp_path / "LaunchAgents"),
+        "--app-dir",
+        str(system_apps),
+    ]) == 0
+
+    assert not (home_apps / "Ciao.app").exists()
+    assert not (home_apps / "Ciaobot.app").exists()
+    assert (system_apps / "Ciaobot.app").is_dir()
+
+
 def test_setup_keeps_unrelated_ciao_app(tmp_path: Path) -> None:
     apps = tmp_path / "Applications"
     unrelated = apps / "Ciao.app" / "Contents"


### PR DESCRIPTION
## Summary
- `ciao setup` writes `Ciaobot.app` to **/Applications** when writable (Finder sidebar location), else `~/Applications`; `--app-dir` still overrides. Our legacy bundles in `~/Applications` are removed by bundle id when the target moves.
- Menu bar: open chats are a **direct section** in the menu (header + items) rather than a submenu; the menu rebuilds only when content changes; quit label simplified to 'Quit'.

## Testing
- `pytest tests/` — 862 passed (2 new)
- Verified live: relaunched menu bar shows inline chats section, addresses submenu, Quit label