### PR TITLE
feat: ciao-capabilities stock skill + onboarding capabilities tour

### DIFF
--- a/ciao/stock/skills/ciao-capabilities/SKILL.md
+++ b/ciao/stock/skills/ciao-capabilities/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: ciao-capabilities
+description: Authoritative catalog of what Ciaobot can do, for capability questions and feature tours. Use whenever the user asks what Ciaobot is, what it can do, what features are available, whether it can do something specific, or how one of its features works (memory, vault, archiving, schedules, routines, workspaces, projects, skills, voice, models, providers, notifications, menu bar, files) — and when onboarding or giving a tour or walkthrough to a new user. Trigger on phrasings like "what can you do", "what can ciaobot do", "help me get started", "give me a tour", "can you remind me / remember / schedule", even when the word "Ciaobot" is not mentioned.
+---
+
+# Ciaobot Capabilities
+
+You are running inside Ciaobot. The app's feature surface is not otherwise visible from a chat session — the system prompt covers behavior, not features — so answer capability questions from this catalog instead of guessing from generic Claude knowledge. If the running app visibly disagrees with something here (features evolve), trust the app and say so.
+
+## How to answer
+
+- **Specific question** ("can you schedule things?", "where do my archived chats go?") → answer from the relevant section only. Don't recite the whole catalog.
+- **Broad question** ("what can you do?") → give the one-paragraph pitch plus the six pillars in a few lines each, then offer to go deeper on any of them.
+- **New user / onboarding** → offer the guided tour below.
+- Distinguish the **app** from **you**: this catalog is what the Ciaobot app provides. On top of it you have your normal agent abilities plus whatever skills, subagents, and slash commands are installed in this workspace (`.claude/skills/`, `.claude/agents/`, `.claude/commands/`).
+
+## The one-paragraph pitch
+
+Ciaobot is a local-first UI and UX layer for using Claude Code (and other backends) as a personal assistant and second brain. Chats, projects, files, schedules, memory, and archived knowledge live in one web app instead of being scattered across terminal sessions — and everything durable is plain markdown that works with any other tool even when Ciaobot is not running.
+
+## Capability catalog
+
+### 1. Chats, projects, and workspaces
+
+- Hierarchy: **workspace → project → chat**. A workspace is a life area (personal, work, a client); each workspace holds projects; each project holds chats plus durable context (files, notes, decisions) that Ciaobot injects into every chat inside it — the agent doesn't rediscover what you're working on each time.
+- Workspaces can have their own vault root, default model, integration profile, and tool deny-list.
+- Each chat can override the workspace's model/provider from the picker.
+- Voice transcription for chat input; push notifications; the PWA is installable on desktop and mobile.
+- Chats can be spawned programmatically from within a chat (see the `create-chat` skill).
+
+### 2. Memory and the vault (second brain)
+
+- Chats are **archived into a markdown vault** (e.g. `memory-vault/Logs/Chats/`). From archived sessions Ciaobot extracts insights and drafts **memory proposals** — the user reviews and approves them before anything is promoted into durable memory (`MEMORY.md`). Nothing is memorized silently.
+- The vault is standard, open markdown: notes, project folders, `CLAUDE.md`, `MEMORY.md`, a generated `INDEX.md` from frontmatter and wikilinks. It is agent-agnostic and remains useful without Ciaobot.
+- Vault tooling: `ciao vault-search` (search before adding duplicate facts), `ciao vault-index` (rebuild the index after larger edits). Reading conventions live in the `vault-read` skill.
+
+### 3. Schedules and automations
+
+- A native scheduler dispatches recurring or one-off prompts as fresh chat turns into a target project or chat — daily/weekly/monthly/once, timezone-aware. Configure from the **Schedules page** or directly in chat (the `ciao-schedules` skill has the full recipe).
+- System maintenance schedules ship with the app; the Automation page shows background job runs.
+
+### 4. Files
+
+- Create, preview, edit, and **restore** workspace and vault files from the PWA, with history — no terminal needed.
+
+### 5. Skills, subagents, and commands (extensibility)
+
+- **Stock skills** ship with the app and are synced into `.claude/skills/` (`ciao sync-skills`, runs at startup). A same-named skill in the workspace's `skills/` folder overrides the packaged copy.
+- **Custom** skills, subagents, and slash commands are authored in the workspace (`skills/`, `subagents/`, `commands/`) and mirrored automatically.
+- **GitHub-sourced skills** can be installed and are refreshed automatically on restart when upstream changes.
+- **Skill evolution**: a background loop analyzes usage and proposes skill improvements — as reviewable proposals, never silent edits.
+
+### 6. Models and providers
+
+- Backends: **Claude Code** (Claude subscription or Anthropic API key), **Ollama** (cloud or local daemon), **OpenRouter**. No provider lock-in — chats and schedules can route through any configured backend.
+- Per-workspace default model and model bucket (which controls how aliases like `opus`/`sonnet` resolve), per-chat override in the picker.
+
+### App and system surface
+
+- **Settings page**: provider keys, model lists, skill/agent inventory, the injected system prompt (read-only), and local package updates from the UI.
+- **macOS extras**: a menu bar companion (`ciao menubar`) with server status and open/restart/logs actions (the Ciaobot face turns scared when the server is down), a `Ciaobot.app` shortcut, and LaunchAgents so everything starts on login.
+- **Local HTTP API**: the app exposes an API an in-chat agent can drive (create chats, subagents, commands) — recipes are in `PWA_API.md`, which ships with every release.
+
+### Privacy and trust posture
+
+Local-first: the server, vault, and runtime state live on the user's machine; traffic leaves only toward the configured model providers. Memory is opt-in via reviewed proposals, an existing notes folder is never discarded or rewritten during onboarding, and the vault stays portable plain markdown.
+
+## Guided tour (new users)
+
+When onboarding someone, walk these in order, hands-on rather than as a lecture — one short step at a time, checking in between:
+
+1. **Orient**: workspaces in the sidebar, projects inside them, chats inside projects. Create or rename a project for something they're actually working on.
+2. **Chat**: show the model picker and voice input; explain that project files and notes are context the agent always sees.
+3. **Files**: open the Files surface, create or edit a note, show restore/history.
+4. **Memory**: explain archive → insights → memory proposals, and that nothing becomes durable memory without their approval.
+5. **Schedules**: set up one small routine they'd find useful (a weekly review, a daily check).
+6. **Settings & extras**: providers and models, package updates, and on macOS the menu bar companion.
+
+Close with: they can ask "what can Ciaobot do?" (or about any specific feature) in any chat, anytime.
+
+## Where the details live
+
+- Workspace customization surface (env vars, workspaces registry, tool deny-lists, model routing): `CIAO_CUSTOMIZATION.md` in the workspace root.
+- Schedules how-to: the `ciao-schedules` skill. Spawning chats: the `create-chat` skill. Vault conventions: the `vault-read` skill.
+- Canonical docs (shipped with releases and in the source repo): `README.md`, `docs/ARCHITECTURE.md`, and `PWA_API.md` (routes, auth, agent recipes).

--- a/ciao/stock/skills/ciao-capabilities/SKILL.md
+++ b/ciao/stock/skills/ciao-capabilities/SKILL.md
@@ -59,7 +59,7 @@ Ciaobot is a local-first UI and UX layer for using Claude Code (and other backen
 
 - **Settings page**: provider keys, model lists, skill/agent inventory, the injected system prompt (read-only), and local package updates from the UI.
 - **macOS extras**: a menu bar companion (`ciao menubar`) with server status and open/restart/logs actions (the Ciaobot face turns scared when the server is down), a `Ciaobot.app` shortcut, and LaunchAgents so everything starts on login.
-- **Local HTTP API**: the app exposes an API an in-chat agent can drive (create chats, subagents, commands) — recipes are in `PWA_API.md`, which ships with every release.
+- **Local HTTP API**: the app exposes an API an in-chat agent can drive (create chats, subagents, commands) — recipes are in `PWA_API.md` in the Ciaobot GitHub repo (`raffaelefarinaro/ciaobot`); fetch it when you need the raw API surface. For the common cases, the shipped `create-chat` and `ciao-schedules` skills already contain the working recipes.
 
 ### Privacy and trust posture
 
@@ -82,4 +82,4 @@ Close with: they can ask "what can Ciaobot do?" (or about any specific feature) 
 
 - Workspace customization surface (env vars, workspaces registry, tool deny-lists, model routing): `CIAO_CUSTOMIZATION.md` in the workspace root.
 - Schedules how-to: the `ciao-schedules` skill. Spawning chats: the `create-chat` skill. Vault conventions: the `vault-read` skill.
-- Canonical docs (shipped with releases and in the source repo): `README.md`, `docs/ARCHITECTURE.md`, and `PWA_API.md` (routes, auth, agent recipes).
+- Canonical docs in the Ciaobot GitHub repo (`raffaelefarinaro/ciaobot`, also present in source checkouts): `README.md`, `docs/ARCHITECTURE.md`, and `PWA_API.md` (routes, auth, agent recipes).

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -905,13 +905,15 @@ class ProjectChatManager:
                 f"1. **Analyze Folder**: Scan the existing vault directory to see what directories and files are present.\n"
                 f"2. **Structure Verification**: Check if the standard directories (`personal/`, `work/`, `Templates/`) exist. If not, plan to create them.\n"
                 f"3. **Hygiene & Scaffolding**: Verify if `CLAUDE.md` (defining identity, memory, styles) and `MEMORY.md` exist. If missing, plan to create them using clean Markdown structures (no em-dashes, no horizontal rules `---` as section dividers).\n"
-                f"4. **Onboarding Interview**: Ask the user 2-3 important questions to collect basic info (their name, their role/work context, key people, and active projects) to populate `CLAUDE.md` and `MEMORY.md` correctly.\n\n"
+                f"4. **Onboarding Interview**: Ask the user 2-3 important questions to collect basic info (their name, their role/work context, key people, and active projects) to populate `CLAUDE.md` and `MEMORY.md` correctly.\n"
+                f"5. **Capabilities Tour**: Once the interview is done, offer a short guided tour of what Ciaobot can do (use the `ciao-capabilities` skill) and mention they can ask \"what can Ciaobot do?\" in any chat, anytime.\n\n"
                 f"Introduce yourself to the user, tell them you've scanned their vault at `{vault_root}`, outline your findings, and ask the first onboarding questions to fill out their profile."
             )
             assistant_msg = (
                 f"Hello! I am Ciaobot, your agentic second brain. 👋\n\n"
                 f"I've initialized our session and connected to your existing folder at `{vault_root}`. "
                 f"I'm ready to inspect your vault, organize it into Ciaobot's structure, and bootstrap our core notes. "
+                f"You can also ask me **\"what can Ciaobot do?\"** anytime for a tour of the app. "
                 f"To get started, tell me: **What is your name, and what is your primary focus (work/personal) right now?**"
             )
         else:
@@ -923,13 +925,15 @@ class ProjectChatManager:
                 f"Your task is to bootstrap the vault structure and core documentation:\n"
                 f"1. **Create Directory Structure**: Plan to create: `personal/`, `work/`, and `Templates/` (scaffold markdown templates for logs, projects, and people).\n"
                 f"2. **Generate Core Files**: Plan to generate clean initial templates for `CLAUDE.md` (defining instructions, memory rules, styles) and `MEMORY.md`.\n"
-                f"3. **Onboarding Interview**: Ask the user 2-3 important questions to collect basic info (their name, GWS profiles, key projects) to customize `CLAUDE.md` and `MEMORY.md`.\n\n"
+                f"3. **Onboarding Interview**: Ask the user 2-3 important questions to collect basic info (their name, GWS profiles, key projects) to customize `CLAUDE.md` and `MEMORY.md`.\n"
+                f"4. **Capabilities Tour**: Once the interview is done, offer a short guided tour of what Ciaobot can do (use the `ciao-capabilities` skill) and mention they can ask \"what can Ciaobot do?\" in any chat, anytime.\n\n"
                 f"Introduce yourself to the user, explain that you are starting fresh at `{vault_root}`, and ask the first onboarding questions to bootstrap your profile."
             )
             assistant_msg = (
                 f"Hello! I am Ciaobot, your agentic second brain. 👋\n\n"
                 f"Welcome! I've initialized our workspace at `{vault_root}` from scratch. "
                 f"I'm ready to create our core structure (`personal/`, `work/`, `Templates/`) and customize our settings. "
+                f"You can also ask me **\"what can Ciaobot do?\"** anytime for a tour of the app. "
                 f"To begin, tell me: **What is your name, and what is your primary focus (work/personal) right now?**"
             )
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -60,7 +60,7 @@ ciao/                          Python backend (Starlette).
   package_version.py           Best-effort version probe: reads ciao.__version__ and queries the package index for the latest published version. Powers GET /api/package/status.
   package_smoke.py             Wheel smoke target: build web, build wheel, install in a clean venv, and probe the installed app. CLI: `ciao package-smoke`.
   stock/                       Generic package-data assets for public installs: stock agents, commands, skills, launchd template, workspace docs, and system schedules.
-    skills/                    Packaged generic skills (ciao-schedules, create-chat, web-research, vault-read, workspace-authoring, adversarial-review). Installed into every workspace's `.claude/skills/` by `ciao sync-skills`; a same-named workspace skill overrides the packaged copy.
+    skills/                    Packaged generic skills (ciao-capabilities, ciao-schedules, create-chat, web-research, vault-read, workspace-authoring, adversarial-review). Installed into every workspace's `.claude/skills/` by `ciao sync-skills`; a same-named workspace skill overrides the packaged copy.
     workspace/                 Agent-readable docs copied into installed workspaces (`CLAUDE.md`, `CIAO_CUSTOMIZATION.md`).
     schedules.json             System schedules (memory curation, skill evolution, dependency review, error triage, weekly review).
     schedules/                 Long-form schedule assets (weekly-review-template.md).


### PR DESCRIPTION
## What

- **New stock skill `ciao-capabilities`** (`ciao/stock/skills/ciao-capabilities/SKILL.md`): an authoritative, self-contained catalog of Ciaobot's feature surface (hierarchy, memory/vault flow, schedules, files, skills/extensibility, providers, app/system extras, privacy posture) plus a guided-tour script. Triggers on "what can you do", tour/getting-started requests, and specific feature questions.
- **Onboarding chat** (`ciao/web/project_chats.py`): both seeded variants now end the interview by offering a capabilities tour via the skill, and the seeded greeting tells the user they can ask "what can Ciaobot do?" anytime.
- **Docs**: added the skill to the packaged-skills list in `docs/ARCHITECTURE.md`.

## Why

The injected system prompt has no capabilities catalog and `PWA_API.md` is never loaded into agent context, so "what can Ciaobot do?" produced partial, model-inferred answers. The skill closes that gap through the existing stock-skill sync pipeline; `PWA_API.md` stays the test-enforced API contract the skill points to.

## Verification

- `pytest tests/`: 839 passed.
- Sync check: `sync_workspace_skills` installs the skill into a fresh workspace with the stock marker (7 stock skills).
- skill-creator benchmark (3 realistic prompts, with-skill vs no-skill baseline, graded on 14 assertions): **100% pass with the skill vs 36% baseline** (+2.6s, ~+3k tokens per answer). Baseline notably invented a wrong memory model when asked about privacy; the skill answer described the real archive→insights→reviewed-proposals flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)