### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.2.1 - 2026-07-07
+
+### Added
+- feat: macOS menu bar companion showing Ciaobot server status (`7f7973b`)
+- feat: menu bar notifications, open chats, reachable addresses; app bundle icon (`f7753a3`)
+- feat: install Ciaobot.app to /Applications; open chats inline in menu bar (`ce5fbf1`)
+- feat: mute-banners toggle in menu bar; drop Open Chats header (`0ca7323`)
+- feat: backfill WebSearch on OpenRouter-routed chats via web plugin (#8) (`f20dabe`)
+- feat: monochrome template icon for the macOS menu bar (#9) (`f1ed5ea`)
+- feat: ciao-capabilities stock skill + onboarding capabilities tour (#10) (`ec62913`)
+
+### Fixed
+- fix: install Homebrew formula from the release sdist, not the source tarball (`c4ff29e`)
+
+### Maintenance
+- chore: set Homebrew formula sha256 for v0.2.0 tarball (`b50e045`)
+- docs: add release install instructions to README; note PWA build for source installs (`8b90d0b`)
+
 ## v0.2.0 - 2026-07-06
 
 First public release of Ciaobot: a local-first web app that turns Claude Code into a personal assistant and second brain, with chats, projects, files, schedules, and memory in one interface.

--- a/ciao/__init__.py
+++ b/ciao/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/deploy/homebrew/ciao.rb
+++ b/deploy/homebrew/ciao.rb
@@ -6,8 +6,8 @@ class Ciao < Formula
   desc "Local-first personal assistant server"
   homepage "https://github.com/raffaelefarinaro/ciaobot"
   license "Apache-2.0"
-  url "https://github.com/raffaelefarinaro/ciaobot/releases/download/v0.2.0/ciao-0.2.0.tar.gz"
-  sha256 "5686c005477ff6c547b4966bec8a0f9a79b2f64960ed807756fe5a17b5d4728d"
+  url "https://github.com/raffaelefarinaro/ciaobot/releases/download/v0.2.1/ciao-0.2.1.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
   head "https://github.com/raffaelefarinaro/ciaobot.git", branch: "main"
 
   depends_on "python@3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciao"
-version = "0.2.0"
+version = "0.2.1"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-pwa",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-pwa",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
         "dompurify": "^3.4.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-pwa",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Prepare Ciaobot v0.2.1
- Update package, PWA, package-lock, and Homebrew formula versions
- Add changelog notes for the release range

## Release notes
## v0.2.1 - 2026-07-07

### Added
- feat: macOS menu bar companion showing Ciaobot server status (`7f7973b`)
- feat: menu bar notifications, open chats, reachable addresses; app bundle icon (`f7753a3`)
- feat: install Ciaobot.app to /Applications; open chats inline in menu bar (`ce5fbf1`)
- feat: mute-banners toggle in menu bar; drop Open Chats header (`0ca7323`)
- feat: backfill WebSearch on OpenRouter-routed chats via web plugin (#8) (`f20dabe`)
- feat: monochrome template icon for the macOS menu bar (#9) (`f1ed5ea`)
- feat: ciao-capabilities stock skill + onboarding capabilities tour (#10) (`ec62913`)

### Fixed
- fix: install Homebrew formula from the release sdist, not the source tarball (`c4ff29e`)

### Maintenance
- chore: set Homebrew formula sha256 for v0.2.0 tarball (`b50e045`)
- docs: add release install instructions to README; note PWA build for source installs (`8b90d0b`)

## Testing
- pytest tests/
- cd web && npm run test
- cd web && npm run build
- ciao package-smoke --skip-frontend

## After approval
- Merge this PR
- Create and push tag `v0.2.1`
- Replace the Homebrew formula sha256 after the tag archive exists
- Publish the package artifact from the tagged commit
