### PR TITLE
feat: folder picker + one-folder setup wizard

### DIFF
--- a/PWA_API.md
+++ b/PWA_API.md
@@ -10,8 +10,9 @@ The route source of truth is `ciao/web/app.py`. This file is kept in sync by `te
 - `GET /?setup=<token>` is the local first-launch shortcut path. It is accepted only on `localhost`, `127.0.0.1`, or `::1`; when the token matches `.runtime/setup-token`, the server sets the same signed `ciao_session` cookie, deletes the token file, and redirects to `/`.
 - Production cookies are `Secure`, `SameSite=Lax`, and host-only (scoped to the exact host that served them).
 - `POST /api/auth/logout` clears the same host-only cookie.
-- All `/api/*` routes except `POST /api/auth`, `GET /api/startup-status`, `GET /api/setup-status`, and `POST /api/setup/finish` require the signed session cookie. All `/ws/*` routes require the signed session cookie.
+- All `/api/*` routes except `POST /api/auth`, `GET /api/startup-status`, `GET /api/setup-status`, `POST /api/setup/finish`, `GET /api/setup/list-dirs`, and `POST /api/setup/mkdir` require the signed session cookie. All `/ws/*` routes require the signed session cookie.
 - `POST /api/setup/finish` is only accepted in bootstrap mode from localhost with a matching browser origin/referer. It writes the real workspace config, creates local launch artifacts, and asks the supervisor to restart into the configured workspace.
+- `GET /api/setup/list-dirs` and `POST /api/setup/mkdir` back the setup wizard's folder picker. They are only accepted in bootstrap mode from localhost with a matching browser origin/referer (404 outside bootstrap mode, 403 off-localhost), list directories only, and never read file contents.
 - State-changing `/api/*` requests with an `Origin` or `Referer` header must match the request host. Missing headers are accepted for non-browser clients.
 - HTTP responses include baseline security headers, including CSP, `X-Content-Type-Options`, `Referrer-Policy`, and frame denial.
 
@@ -74,6 +75,8 @@ The route source of truth is `ciao/web/app.py`. This file is kept in sync by `te
 | POST | `/api/package/update` | Upgrade ciao package from the latest GitHub release wheel and restart |
 | POST | `/api/voice/install-local` | Install local voice transcription dependencies and restart |
 | POST | `/api/setup/finish` | Finish first-run setup from bootstrap mode |
+| GET | `/api/setup/list-dirs` | List local subdirectories for the setup wizard folder picker (bootstrap mode, localhost only) |
+| POST | `/api/setup/mkdir` | Create a folder from the setup wizard folder picker (bootstrap mode, localhost only) |
 | GET | `/api/stats` | Read CLI stats |
 | GET | `/api/workspaces` | List configured logical workspaces |
 | POST | `/api/workspaces/{name}` | Add or update a logical workspace config |

--- a/ciao/web/app.py
+++ b/ciao/web/app.py
@@ -69,6 +69,8 @@ from ciao.web.routes_api import (
     provider_config_settings,
     settings_routines,
     setup_finish_endpoint,
+    setup_list_dirs_endpoint,
+    setup_mkdir_endpoint,
     setup_status_endpoint,
     list_automation,
     list_completed_projects,
@@ -211,6 +213,8 @@ def create_app(config, app_settings=None) -> Starlette:
         Route("/api/package/update", package_update_endpoint, methods=["POST"]),
         Route("/api/voice/install-local", voice_install_local_endpoint, methods=["POST"]),
         Route("/api/setup/finish", setup_finish_endpoint, methods=["POST"]),
+        Route("/api/setup/list-dirs", setup_list_dirs_endpoint, methods=["GET"]),
+        Route("/api/setup/mkdir", setup_mkdir_endpoint, methods=["POST"]),
         Route("/api/stats", cli_stats, methods=["GET"]),
         # Push notifications
         Route("/api/push/public-key", push_public_key, methods=["GET"]),

--- a/ciao/web/auth.py
+++ b/ciao/web/auth.py
@@ -169,6 +169,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
             "/api/startup-status",
             "/api/setup-status",
             "/api/setup/finish",
+            "/api/setup/list-dirs",
+            "/api/setup/mkdir",
         }
         protected = (
             (path.startswith("/api/") and path not in public_api)

--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -3168,6 +3168,104 @@ async def setup_finish_endpoint(request: Request) -> JSONResponse:
     })
 
 
+def _setup_fs_guard(request: Request) -> JSONResponse | None:
+    """Bootstrap-mode + localhost guard shared by the setup folder-picker routes."""
+    config = request.app.state.config
+    if not getattr(config, "bootstrap_mode", False):
+        return JSONResponse({"error": "not found"}, status_code=404)
+    if not _localhost_request(request) or not _setup_finish_origin_allowed(request):
+        return JSONResponse({"error": "setup filesystem access is localhost-only"}, status_code=403)
+    return None
+
+
+def _setup_dir_listing(target: Path) -> dict:
+    """Return the folder-picker listing payload for a resolved directory."""
+    home = Path.home().resolve()
+    dirs: list[dict[str, str]] = []
+    for entry in target.iterdir():
+        if entry.name.startswith("."):
+            continue
+        try:
+            if not entry.is_dir():
+                continue
+        except OSError:
+            continue
+        dirs.append({"name": entry.name, "path": str(entry)})
+    dirs.sort(key=lambda row: row["name"].lower())
+    display = str(target)
+    if target == home:
+        display = "~"
+    elif str(target).startswith(str(home) + os.sep):
+        display = "~" + str(target)[len(str(home)):]
+    parent = target.parent
+    return {
+        "path": str(target),
+        "display_path": display,
+        "parent": str(parent) if parent != target else None,
+        "dirs": dirs,
+        "home": str(home),
+    }
+
+
+def _resolve_setup_dir(raw: str) -> Path | None:
+    """Expand and resolve a picker path; None when it is not an existing directory."""
+    try:
+        target = Path(raw).expanduser().resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+    if not target.is_dir():
+        return None
+    return target
+
+
+async def setup_list_dirs_endpoint(request: Request) -> JSONResponse:
+    """List local subdirectories for the first-run setup folder picker."""
+    guard = _setup_fs_guard(request)
+    if guard is not None:
+        return guard
+    raw = str(request.query_params.get("path") or "~").strip() or "~"
+    target = _resolve_setup_dir(raw)
+    if target is None:
+        return JSONResponse({"error": f"not a directory: {raw}"}, status_code=400)
+    try:
+        return JSONResponse(_setup_dir_listing(target))
+    except PermissionError:
+        return JSONResponse({"error": f"permission denied: {target}"}, status_code=400)
+    except OSError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+
+
+async def setup_mkdir_endpoint(request: Request) -> JSONResponse:
+    """Create a folder from the first-run setup folder picker and return the refreshed listing."""
+    guard = _setup_fs_guard(request)
+    if guard is not None:
+        return guard
+    try:
+        body = await request.json()
+    except ValueError:
+        return JSONResponse({"error": "invalid json"}, status_code=400)
+    if not isinstance(body, dict):
+        return JSONResponse({"error": "json object is required"}, status_code=400)
+    name = str(body.get("name", "")).strip()
+    if not name:
+        return JSONResponse({"error": "name is required"}, status_code=400)
+    if "/" in name or "\\" in name or os.sep in name or name.startswith("."):
+        return JSONResponse({"error": "folder name must not contain path separators or start with a dot"}, status_code=400)
+    parent = _resolve_setup_dir(str(body.get("path", "")).strip())
+    if parent is None:
+        return JSONResponse({"error": "path must be an existing directory"}, status_code=400)
+    try:
+        (parent / name).mkdir()
+    except FileExistsError:
+        return JSONResponse({"error": f"already exists: {name}"}, status_code=400)
+    except OSError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    try:
+        return JSONResponse(_setup_dir_listing(parent))
+    except OSError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+
+
 # ── Admin ────────────────────────────────────────────────────────────────
 
 async def admin_snapshot(request: Request) -> JSONResponse:

--- a/ciao/web/static/index.html
+++ b/ciao/web/static/index.html
@@ -13,7 +13,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-180.png" />
     <title>Ciaobot</title>
-    <script type="module" crossorigin src="/assets/index-CbEArbPD.js"></script>
+    <script type="module" crossorigin src="/assets/index-DR8JnTPD.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-D7rCIRej.css">
   </head>
   <body>

--- a/tests/test_pwa_api_docs.py
+++ b/tests/test_pwa_api_docs.py
@@ -11,6 +11,7 @@ BROWSER_OR_INTERNAL_ROUTES: dict[str, str] = {
     "/api/auth": "browser login flow; the recipe's auth step covers this",
     "/api/auth/logout": "browser logout; clears the session cookie",
     "/api/setup/finish": "browser first-run setup handoff; writes local config and requests restart",
+    "/api/setup/mkdir": "browser first-run setup folder picker; creates a local folder (bootstrap + localhost only)",
     "/api/projects/{project_id}/files": "browser multipart upload; agents edit vault files directly",
     "/api/chats/{chat_id}/voice": "browser voice upload",
     "/api/chats/{chat_id}/images": "browser image upload",

--- a/tests/test_setup_status.py
+++ b/tests/test_setup_status.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from itsdangerous import URLSafeTimedSerializer
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
@@ -9,7 +11,12 @@ from starlette.testclient import TestClient
 from ciao.config import CiaoConfig
 from ciao.setup_status import setup_status
 from ciao.web.auth import AuthMiddleware
-from ciao.web.routes_api import setup_finish_endpoint, setup_status_endpoint
+from ciao.web.routes_api import (
+    setup_finish_endpoint,
+    setup_list_dirs_endpoint,
+    setup_mkdir_endpoint,
+    setup_status_endpoint,
+)
 
 
 def _config(tmp_path, env_extra: dict[str, str] | None = None) -> CiaoConfig:
@@ -241,3 +248,108 @@ def test_setup_finish_is_localhost_only(tmp_path) -> None:
     )
 
     assert resp.status_code == 403
+
+
+def _folder_picker_client(tmp_path, *, bootstrap: bool = True, base_url: str = "http://localhost:8443") -> TestClient:
+    if bootstrap:
+        config = CiaoConfig.from_env({"CIAO_BOOTSTRAP_WORKSPACE": str(tmp_path / "boot")})
+    else:
+        config = _config(tmp_path)
+    serializer = URLSafeTimedSerializer("test-secret")
+    app = Starlette(
+        routes=[
+            Route("/api/setup/list-dirs", setup_list_dirs_endpoint, methods=["GET"]),
+            Route("/api/setup/mkdir", setup_mkdir_endpoint, methods=["POST"]),
+        ],
+        middleware=[Middleware(AuthMiddleware, serializer=serializer)],
+    )
+    app.state.config = config
+    app.state.serializer = serializer
+    return TestClient(app, base_url=base_url)
+
+
+def test_setup_list_dirs_requires_bootstrap_mode(tmp_path) -> None:
+    client = _folder_picker_client(tmp_path, bootstrap=False)
+
+    resp = client.get("/api/setup/list-dirs", params={"path": str(tmp_path)})
+
+    assert resp.status_code == 404
+
+
+def test_setup_list_dirs_is_localhost_only(tmp_path) -> None:
+    client = _folder_picker_client(tmp_path, base_url="https://ciao.example")
+
+    resp = client.get("/api/setup/list-dirs", params={"path": str(tmp_path)})
+
+    assert resp.status_code == 403
+
+
+def test_setup_list_dirs_lists_visible_directories_only(tmp_path) -> None:
+    (tmp_path / "beta").mkdir()
+    (tmp_path / "Alpha").mkdir()
+    (tmp_path / ".hidden").mkdir()
+    (tmp_path / "notes.txt").write_text("nope", encoding="utf-8")
+    client = _folder_picker_client(tmp_path)
+
+    resp = client.get("/api/setup/list-dirs", params={"path": str(tmp_path)})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["path"] == str(tmp_path.resolve())
+    assert body["parent"] == str(tmp_path.resolve().parent)
+    assert [d["name"] for d in body["dirs"]] == ["Alpha", "beta", "boot"]
+    assert body["dirs"][0]["path"] == str(tmp_path.resolve() / "Alpha")
+    assert body["home"] == str(Path.home().resolve())
+
+
+def test_setup_list_dirs_defaults_to_home_and_abbreviates_display_path(tmp_path) -> None:
+    client = _folder_picker_client(tmp_path)
+
+    resp = client.get("/api/setup/list-dirs")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["path"] == str(Path.home().resolve())
+    assert body["display_path"] == "~"
+
+
+def test_setup_list_dirs_rejects_missing_or_file_path(tmp_path) -> None:
+    (tmp_path / "notes.txt").write_text("nope", encoding="utf-8")
+    client = _folder_picker_client(tmp_path)
+
+    assert client.get("/api/setup/list-dirs", params={"path": str(tmp_path / "nope")}).status_code == 400
+    assert client.get("/api/setup/list-dirs", params={"path": str(tmp_path / "notes.txt")}).status_code == 400
+
+
+def test_setup_mkdir_creates_folder_and_returns_parent_listing(tmp_path) -> None:
+    client = _folder_picker_client(tmp_path)
+
+    resp = client.post("/api/setup/mkdir", json={"path": str(tmp_path), "name": "workspace"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert (tmp_path / "workspace").is_dir()
+    assert body["path"] == str(tmp_path.resolve())
+    assert "workspace" in [d["name"] for d in body["dirs"]]
+
+
+def test_setup_mkdir_rejects_invalid_names_and_paths(tmp_path) -> None:
+    client = _folder_picker_client(tmp_path)
+
+    for name in ["", "a/b", "a\\b", ".hidden", "../escape"]:
+        resp = client.post("/api/setup/mkdir", json={"path": str(tmp_path), "name": name})
+        assert resp.status_code == 400, name
+    assert client.post("/api/setup/mkdir", json={"path": str(tmp_path / "nope"), "name": "ok"}).status_code == 400
+
+    (tmp_path / "taken").mkdir()
+    resp = client.post("/api/setup/mkdir", json={"path": str(tmp_path), "name": "taken"})
+    assert resp.status_code == 400
+
+
+def test_setup_mkdir_requires_bootstrap_mode(tmp_path) -> None:
+    client = _folder_picker_client(tmp_path, bootstrap=False)
+
+    resp = client.post("/api/setup/mkdir", json={"path": str(tmp_path), "name": "workspace"})
+
+    assert resp.status_code == 404
+    assert not (tmp_path / "workspace").exists()

--- a/web/src/components/LoginView.vue
+++ b/web/src/components/LoginView.vue
@@ -59,31 +59,25 @@
 
         <div class="form-group">
           <label for="setup-workspace">Workspace Folder</label>
-          <input
-            id="setup-workspace"
-            v-model="workspace"
-            type="text"
-            class="form-input"
-            placeholder="~/ciaobot"
-            required
-            :disabled="loading"
-          />
+          <div class="input-row">
+            <input
+              id="setup-workspace"
+              v-model="workspace"
+              type="text"
+              class="form-input"
+              placeholder="~/ciaobot"
+              required
+              :disabled="loading"
+            />
+            <button
+              id="setup-workspace-browse"
+              type="button"
+              class="btn-small"
+              :disabled="loading"
+              @click="openPicker('workspace')"
+            >Browse…</button>
+          </div>
           <span class="hint">The local app workspace. It stores config, runtime state, generated assets, and chat metadata.</span>
-        </div>
-
-        <div class="form-group">
-          <label for="setup-vault">Second-brain Vault Folder</label>
-          <input
-            id="setup-vault"
-            v-model="vaultRoot"
-            type="text"
-            class="form-input"
-            placeholder="~/ciaobot/memory-vault"
-            required
-            :disabled="loading"
-            @input="userEditedVault = true"
-          />
-          <span class="hint">Durable markdown memory: projects, people, references, archived chats, and reviewed insights.</span>
         </div>
 
         <div class="form-group">
@@ -111,6 +105,44 @@
             </label>
           </div>
           <span class="hint">Starting fresh builds the scaffold; existing asks Ciaobot to adapt your notes into the project structure.</span>
+        </div>
+
+        <div v-if="showVaultInput" class="form-group">
+          <label for="setup-vault">{{ vaultMode === 'existing' ? 'Existing Notes Folder' : 'Second-brain Vault Folder' }}</label>
+          <div class="input-row">
+            <input
+              id="setup-vault"
+              v-model="vaultRoot"
+              type="text"
+              class="form-input"
+              placeholder="~/ciaobot/memory-vault"
+              required
+              :disabled="loading"
+              @input="userEditedVault = true"
+            />
+            <button
+              id="setup-vault-browse"
+              type="button"
+              class="btn-small"
+              :disabled="loading"
+              @click="openPicker('vault')"
+            >Browse…</button>
+          </div>
+          <span class="hint">{{ vaultMode === 'existing'
+            ? 'Point this at the notes folder you already have; Ciaobot adapts it into the vault structure.'
+            : 'Durable markdown memory: projects, people, references, archived chats, and reviewed insights.' }}</span>
+        </div>
+        <div v-else class="form-group">
+          <span class="hint vault-derived-hint">
+            Your second-brain vault will be created at <code>{{ vaultRoot }}</code>
+            <button
+              id="setup-vault-change"
+              type="button"
+              class="link-btn"
+              :disabled="loading"
+              @click="vaultRevealed = true"
+            >change location</button>
+          </span>
         </div>
 
         <div class="form-group">
@@ -222,6 +254,73 @@
             <span class="prompt prompt--err">!</span>{{ error }}
           </p>
         </div>
+
+        <!-- FOLDER PICKER MODAL -->
+        <div v-if="pickerOpen" class="picker-overlay" @click.self="closePicker">
+          <div
+            class="picker-modal"
+            role="dialog"
+            :aria-label="pickerTarget === 'workspace' ? 'Choose workspace folder' : 'Choose vault folder'"
+          >
+            <div class="picker-head">
+              <span class="picker-title">{{ pickerTarget === 'workspace' ? 'Choose Workspace Folder' : 'Choose Vault Folder' }}</span>
+              <code class="picker-path">{{ pickerDisplayPath || '…' }}</code>
+            </div>
+            <div class="picker-toolbar">
+              <button
+                type="button"
+                class="btn-small"
+                :disabled="!pickerParent || pickerLoading"
+                @click="loadPickerDirs(pickerParent!)"
+              >↑ Up</button>
+              <button
+                type="button"
+                class="btn-small"
+                :disabled="pickerLoading"
+                @click="loadPickerDirs()"
+              >~ Home</button>
+            </div>
+            <ul class="picker-list">
+              <li v-for="dir in pickerDirs" :key="dir.path">
+                <button
+                  type="button"
+                  class="picker-dir"
+                  :disabled="pickerLoading"
+                  @click="loadPickerDirs(dir.path)"
+                >{{ dir.name }}/</button>
+              </li>
+              <li v-if="!pickerLoading && !pickerDirs.length" class="picker-empty">no subfolders</li>
+            </ul>
+            <div class="picker-new">
+              <input
+                v-model="newFolderName"
+                type="text"
+                class="form-input"
+                placeholder="new folder name"
+                :disabled="pickerLoading"
+                @keydown.enter.prevent="createPickerFolder"
+              />
+              <button
+                type="button"
+                class="btn-small"
+                :disabled="!newFolderName.trim() || pickerLoading"
+                @click="createPickerFolder"
+              >New folder</button>
+            </div>
+            <p v-if="pickerError" class="line line--error">
+              <span class="prompt prompt--err">!</span>{{ pickerError }}
+            </p>
+            <div class="picker-footer">
+              <button type="button" class="btn-small" @click="closePicker">Cancel</button>
+              <button
+                type="button"
+                class="prompt-submit picker-select"
+                :disabled="!pickerPath || pickerLoading"
+                @click="selectPickerFolder"
+              >Select this folder</button>
+            </div>
+          </div>
+        </div>
       </form>
 
       <!-- STANDARD LOGIN FORM -->
@@ -288,7 +387,120 @@ const authRequired = ref(true)
 const isRestarting = ref(false)
 const userEditedVault = ref(false)
 const vaultMode = ref('scratch')
+const vaultRevealed = ref(false)
 const copyStatus = ref('')
+
+// The vault path stays hidden while it is just the derived default: only a
+// custom split ("change location") or pointing at existing notes shows it.
+const showVaultInput = computed(() => vaultMode.value === 'existing' || vaultRevealed.value)
+
+// Folder picker modal (server-backed: browsers cannot give absolute paths)
+interface DirListing {
+  path: string
+  display_path: string
+  parent: string | null
+  dirs: Array<{ name: string; path: string }>
+  home: string
+}
+const pickerOpen = ref(false)
+const pickerTarget = ref<'workspace' | 'vault'>('workspace')
+const pickerPath = ref('')
+const pickerDisplayPath = ref('')
+const pickerParent = ref<string | null>(null)
+const pickerDirs = ref<Array<{ name: string; path: string }>>([])
+const pickerError = ref('')
+const pickerLoading = ref(false)
+const newFolderName = ref('')
+
+function fetchListing(path?: string): Promise<DirListing> {
+  const query = path ? `?path=${encodeURIComponent(path)}` : ''
+  return api.get<DirListing>(`/api/setup/list-dirs${query}`)
+}
+
+function applyPickerListing(listing: DirListing) {
+  pickerPath.value = listing.path
+  pickerDisplayPath.value = listing.display_path
+  pickerParent.value = listing.parent
+  pickerDirs.value = listing.dirs || []
+}
+
+async function openPicker(target: 'workspace' | 'vault') {
+  pickerTarget.value = target
+  pickerOpen.value = true
+  pickerPath.value = ''
+  pickerDisplayPath.value = ''
+  pickerParent.value = null
+  pickerDirs.value = []
+  pickerError.value = ''
+  newFolderName.value = ''
+  pickerLoading.value = true
+  try {
+    const current = (target === 'workspace' ? workspace.value : vaultRoot.value).trim()
+    let listing: DirListing
+    if (current) {
+      try {
+        listing = await fetchListing(current)
+      } catch {
+        // field value is not an existing folder on the server: start at home
+        listing = await fetchListing()
+      }
+    } else {
+      listing = await fetchListing()
+    }
+    applyPickerListing(listing)
+  } catch (e: any) {
+    pickerError.value = e.message || 'failed to list folder'
+  } finally {
+    pickerLoading.value = false
+  }
+}
+
+async function loadPickerDirs(path?: string) {
+  pickerLoading.value = true
+  pickerError.value = ''
+  try {
+    applyPickerListing(await fetchListing(path))
+  } catch (e: any) {
+    pickerError.value = e.message || 'failed to list folder'
+  } finally {
+    pickerLoading.value = false
+  }
+}
+
+async function createPickerFolder() {
+  const name = newFolderName.value.trim()
+  if (!name || !pickerPath.value) return
+  pickerLoading.value = true
+  pickerError.value = ''
+  try {
+    const listing = await api.post<DirListing>('/api/setup/mkdir', {
+      path: pickerPath.value,
+      name,
+    })
+    applyPickerListing(listing)
+    newFolderName.value = ''
+  } catch (e: any) {
+    pickerError.value = e.message || 'failed to create folder'
+  } finally {
+    pickerLoading.value = false
+  }
+}
+
+function selectPickerFolder() {
+  if (!pickerPath.value) return
+  if (pickerTarget.value === 'workspace') {
+    // assignment triggers the workspace watcher, keeping the derived vault path in sync
+    workspace.value = pickerPath.value
+  } else {
+    vaultRoot.value = pickerPath.value
+    userEditedVault.value = true
+  }
+  pickerOpen.value = false
+}
+
+function closePicker() {
+  pickerOpen.value = false
+}
 
 const providerInstruction = computed(() => {
   if (provider.value === 'openrouter') {
@@ -646,6 +858,144 @@ onUnmounted(() => {
   color: var(--fg3);
   font-size: var(--text-xs);
   line-height: 1.4;
+}
+
+.input-row {
+  display: flex;
+  gap: 6px;
+  align-items: stretch;
+}
+.input-row .form-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.vault-derived-hint code {
+  color: var(--fg2);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 5px;
+  font-family: inherit;
+  font-size: var(--text-xs);
+  word-break: break-all;
+}
+.link-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  margin-left: 6px;
+  color: var(--accent);
+  font-family: inherit;
+  font-size: var(--text-xs);
+  text-decoration: underline;
+  cursor: pointer;
+}
+.link-btn:disabled {
+  color: var(--fg3);
+  cursor: not-allowed;
+}
+
+/* Folder picker modal */
+.picker-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.55);
+}
+.picker-modal {
+  width: 100%;
+  max-width: 460px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px 16px 16px;
+  background: var(--bg2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
+}
+.picker-head {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.picker-title {
+  color: var(--fg2);
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+.picker-path {
+  font-family: inherit;
+  font-size: var(--text-xs);
+  color: var(--accent);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 6px;
+  word-break: break-all;
+}
+.picker-toolbar {
+  display: flex;
+  gap: 6px;
+}
+.picker-list {
+  list-style: none;
+  margin: 0;
+  padding: 4px;
+  max-height: 240px;
+  overflow-y: auto;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.picker-dir {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  padding: 5px 8px;
+  color: var(--fg);
+  font-family: inherit;
+  font-size: var(--text-sm);
+  cursor: pointer;
+}
+.picker-dir:hover:not(:disabled) {
+  background: var(--bg3);
+}
+.picker-dir:disabled {
+  color: var(--fg3);
+  cursor: not-allowed;
+}
+.picker-empty {
+  padding: 5px 8px;
+  color: var(--fg3);
+  font-size: var(--text-xs);
+}
+.picker-new {
+  display: flex;
+  gap: 6px;
+}
+.picker-new .form-input {
+  flex: 1;
+  min-width: 0;
+}
+.picker-footer {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+}
+.picker-select {
+  font-size: var(--text-sm);
 }
 
 .form-grid {

--- a/web/src/components/__tests__/LoginView.test.ts
+++ b/web/src/components/__tests__/LoginView.test.ts
@@ -97,9 +97,99 @@ describe('LoginView setup wizard tests', () => {
     const wrapper = await mountLoginView()
     expect(wrapper.find('input[type="password"]').exists()).toBe(false)
     expect(wrapper.find('#setup-workspace').exists()).toBe(true)
-    expect(wrapper.find('#setup-vault').exists()).toBe(true)
+    expect(wrapper.find('#setup-workspace-browse').exists()).toBe(true)
+    // scratch mode hides the vault input behind the derived-path hint
+    expect(wrapper.find('#setup-vault').exists()).toBe(false)
     expect(wrapper.find('#setup-push').exists()).toBe(true)
     expect(wrapper.text()).toContain('ciao auth claude')
+  })
+
+  it('shows a live derived vault hint in scratch mode and reveals the input via change location', async () => {
+    mockApiGet.mockResolvedValue({
+      configured: false,
+      bootstrap: true,
+      mode: 'bootstrap',
+      providers: {}
+    })
+
+    const wrapper = await mountLoginView()
+    // hidden by default, hint shows the derived path
+    expect(wrapper.find('#setup-vault').exists()).toBe(false)
+    expect(wrapper.text()).toContain('Your second-brain vault will be created at')
+    expect(wrapper.text()).toContain('~/ciaobot/memory-vault')
+
+    // hint live-updates when the workspace changes
+    await wrapper.find('#setup-workspace').setValue('/tmp/space')
+    await nextTick()
+    expect(wrapper.text()).toContain('/tmp/space/memory-vault')
+
+    // "change location" reveals the vault input with its Browse button
+    await wrapper.find('#setup-vault-change').trigger('click')
+    await nextTick()
+    const vaultInput = wrapper.find('#setup-vault')
+    expect(vaultInput.exists()).toBe(true)
+    expect(wrapper.find('#setup-vault-browse').exists()).toBe(true)
+    expect((vaultInput.element as HTMLInputElement).value).toBe('/tmp/space/memory-vault')
+  })
+
+  it('shows the vault input when vault mode is existing', async () => {
+    mockApiGet.mockResolvedValue({
+      configured: false,
+      bootstrap: true,
+      mode: 'bootstrap',
+      providers: {}
+    })
+
+    const wrapper = await mountLoginView()
+    expect(wrapper.find('#setup-vault').exists()).toBe(false)
+
+    await wrapper.find('input[type="radio"][value="existing"]').setValue()
+    await nextTick()
+    expect(wrapper.find('#setup-vault').exists()).toBe(true)
+    expect(wrapper.find('#setup-vault-browse').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Existing Notes Folder')
+  })
+
+  it('opens the folder picker, lists directories, and writes the selection into the workspace field', async () => {
+    const listing = {
+      path: '/Users/me/ciaobot',
+      display_path: '~/ciaobot',
+      parent: '/Users/me',
+      dirs: [
+        { name: 'memory-vault', path: '/Users/me/ciaobot/memory-vault' },
+        { name: 'projects', path: '/Users/me/ciaobot/projects' },
+      ],
+      home: '/Users/me',
+    }
+    mockApiGet.mockImplementation((path: string) => {
+      if (path.startsWith('/api/setup/list-dirs')) return Promise.resolve(listing)
+      return Promise.resolve({
+        configured: false,
+        bootstrap: true,
+        mode: 'bootstrap',
+        providers: {}
+      })
+    })
+
+    const wrapper = await mountLoginView()
+    expect(wrapper.find('.picker-modal').exists()).toBe(false)
+
+    await wrapper.find('#setup-workspace-browse').trigger('click')
+    await flushPromises()
+    expect(mockApiGet).toHaveBeenCalledWith(
+      `/api/setup/list-dirs?path=${encodeURIComponent('~/ciaobot')}`
+    )
+    expect(wrapper.find('.picker-modal').exists()).toBe(true)
+    expect(wrapper.find('.picker-path').text()).toBe('~/ciaobot')
+    const dirButtons = wrapper.findAll('.picker-dir')
+    expect(dirButtons.map(b => b.text())).toEqual(['memory-vault/', 'projects/'])
+
+    await wrapper.find('.picker-select').trigger('click')
+    await nextTick()
+    expect(wrapper.find('.picker-modal').exists()).toBe(false)
+    expect((wrapper.find('#setup-workspace').element as HTMLInputElement).value).toBe('/Users/me/ciaobot')
+    // workspace selection re-derives the hidden vault suggestion
+    expect(wrapper.text()).toContain('/Users/me/ciaobot/memory-vault')
   })
 
   it('validates required fields and enables Finish on valid form', async () => {


### PR DESCRIPTION
## What

1. **Folder picker in the setup wizard** — "Browse…" on the folder fields opens a modal backed by two new bootstrap-mode + localhost-only endpoints: `GET /api/setup/list-dirs` (directories only, hidden entries and unreadable paths skipped, never reads contents) and `POST /api/setup/mkdir` (validated names, returns refreshed listing). Modal: current path with ~ abbreviation, Up/Home, clickable subfolders, inline new-folder creation, Select.
2. **One-folder wizard** — only "Workspace Folder" is always asked. Fresh-vault mode hides the vault input behind a live hint ("created at `<workspace>/memory-vault`") with a change-location reveal; "use existing notes folder" mode shows it as a required field. Submitted payload unchanged.

## Verification

- `pytest tests/`: 865 passed (8 new endpoint tests: bootstrap/localhost guards, listing semantics, mkdir validation).
- `cd web && npm run test`: 58 passed; `npm run build` green (menu-bar PNGs intact, see #12).
- Live API smoke on a tmp tree: guards, listing, mkdir, and error paths all behave.
- `PWA_API.md` updated (doc-sync test green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)