### PR TITLE
Release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.2.3 - 2026-07-07
+
+### Added
+- feat: folder picker + one-folder setup wizard (#18) (`8e8de47`)
+
+### Maintenance
+- docs: bump README install URL to v0.2.2 (`81100ed`)
+
 ## v0.2.2 - 2026-07-07
 
 ### Added

--- a/ciao/__init__.py
+++ b/ciao/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciao"
-version = "0.2.2"
+version = "0.2.3"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-pwa",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-pwa",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
         "dompurify": "^3.4.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-pwa",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Prepare Ciaobot v0.2.3
- Update package, PWA, and package-lock versions
- Add changelog notes for the release range

## Release notes
## v0.2.3 - 2026-07-07

### Added
- feat: folder picker + one-folder setup wizard (#18) (`8e8de47`)

### Maintenance
- docs: bump README install URL to v0.2.2 (`81100ed`)

## Testing
- pytest tests/
- cd web && npm run test
- cd web && npm run build
- ciao package-smoke --skip-frontend

## After approval
- Merge this PR
- Create and push tag `v0.2.3`
- Publish the package artifact from the tagged commit
