### PR TITLE
feat: wizard polish, macOS menubar by default, PyPI 'ciaobot' distribution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # --- Ciaobot Server (required) ---
 PWA_AUTH_TOKEN=                # Pre-shared token for PWA auth (required)
-CIAO_PUSH_CONTACT=mailto:you@example.com # Required VAPID contact for push notifications
+CIAO_PUSH_CONTACT=mailto:you@example.com # Optional VAPID contact; empty disables Web Push until set
 
 # --- Ciaobot Server (optional) ---
 PWA_PORT=8443                  # PWA server port (default: 8443)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # PyPI trusted publishing
+      contents: write   # upload artifacts to the GitHub release
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build PWA
+        working-directory: web
+        run: |
+          npm ci
+          npm run build
+      - name: Restore committed static assets clobbered by the PWA build
+        # The Vite build empties ciao/web/static and deletes the committed
+        # menu bar template icons (see issue #12).
+        run: git checkout -- ciao/web/static/face_scared_template.png ciao/web/static/face_template.png
+      - name: Build wheel and sdist
+        run: |
+          python -m pip install --quiet build
+          python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Attach artifacts to the GitHub release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" dist/* --clobber

--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -99,7 +99,7 @@ If a connector's tools don't show up, the fix is on the claude.ai side: toggle t
 
 Copy `.env.example` to `.env` and fill in the app-level settings first:
 
-**Required for a configured workspace:** `PWA_AUTH_TOKEN`, `CIAO_PUSH_CONTACT`
+**Required for a configured workspace:** `PWA_AUTH_TOKEN`. `CIAO_PUSH_CONTACT` is optional: leave it empty to run without Web Push notifications until you set a contact in Settings.
 
 `ciao setup` writes the initial `.env` into the selected workspace, seeds stock agents, commands, schedules, agent-readable workspace docs (`CLAUDE.md`, `CIAO_CUSTOMIZATION.md`), and the default vault, renders `~/Library/LaunchAgents/com.ciao.server.plist`, and creates `~/Applications/Ciaobot.app`. The app shortcut opens `http://localhost:<port>/?setup=<token>`; the server redeems `.runtime/setup-token` once on localhost, sets the signed session cookie, then deletes the token. By default setup prints the launchd load command without starting the service; use `--load-launchd` to run `launchctl`. `ciao auth <claude|ollama>` runs the provider login command in Terminal; `--print-only` shows the command for the setup wizard. `GET /api/setup-status` reports required local config plus Claude Code, Ollama, and OpenRouter readiness so the wizard can poll after terminal OAuth commands or `.env` edits. In bootstrap mode, `POST /api/setup/finish` accepts the wizard's final local choices, writes the real workspace `.env`, scaffolds the configured `CIAO_VAULT_ROOT`, refreshes the LaunchAgent and `Ciaobot.app` shortcut, and requests the restart exit for supervisor relaunch.
 
@@ -145,7 +145,7 @@ Runtime config for the Ciaobot server itself (PWA, schedules, deploy).
 ### Required env vars
 
 - `PWA_AUTH_TOKEN` (required): pre-shared token for PWA auth.
-- `CIAO_PUSH_CONTACT` (required): push notification contact string for the Web Push VAPID subject, for example `mailto:you@example.com`.
+- `CIAO_PUSH_CONTACT` (optional): push notification contact string for the Web Push VAPID subject, for example `mailto:you@example.com`. Empty = Web Push disabled until set (in `.env` or Settings); nothing else breaks.
 - `PWA_PORT` (default `8443`), `PWA_HOST` (default `0.0.0.0`).
 - Session cookies are HttpOnly. Production/domain-scoped cookies are also Secure, and state-changing browser requests must come from the same host via `Origin` or `Referer`.
 - Ciaobot sends baseline security headers from the Starlette app, including CSP, `X-Content-Type-Options`, `Referrer-Policy`, and frame denial.
@@ -202,7 +202,7 @@ Runtime config for the Ciaobot server itself (PWA, schedules, deploy).
 - `CIAO_OPENROUTER_MODELS`: comma-separated allowlist of extra OpenRouter model IDs (owner/model) to surface in the picker on top of the tier defaults and the discovered anthropic-family catalogue. Leave empty to rely on dynamic discovery.
 - `CIAO_OPENROUTER_WEBSEARCH_HOOK`: kill switch for the PostToolUse hook that backfills WebSearch on OpenRouter-routed chats, mirroring `CIAO_OLLAMA_WEBSEARCH_HOOK`. OpenRouter's Anthropic-compat endpoint doesn't execute the server-side `web_search` tool, so Claude Code's built-in WebSearch returns an empty boilerplate; the hook reruns the query as a one-shot chat-completions call with OpenRouter's `web` plugin (on the configured haiku-tier model) and injects the `url_citation` sources as `additionalContext`. Default `1` (enabled). Set `0` to disable. See `ciao/observability/hooks.py`.
 - `CIAO_DISPATCH_SCHEDULES`: `1`/`true`/`on` to make this instance dispatch scheduled automations. Off by default (opt-in), so an occasional dev box never double-fires schedules. Set it on only for the always-on "main" device.
-- `CIAO_PUSH_CONTACT`: push notification contact string. Required, no default. Used for VAPID subject.
+- `CIAO_PUSH_CONTACT`: push notification contact string. Optional, no default; empty disables Web Push delivery. Used for VAPID subject.
 - `CIAO_PUSH_DELAY_SECONDS`: delay before sending push notifications after a completed turn (default `30`). Rapid replies to the same chat cancel the previous timer and start a new one (coalesce into a single push). Permission requests and model questions push immediately (no delay). Unanswered permission requests re-fire every 30 seconds, up to 3 times, until the user approves/denies or the turn ends.
 - `CIAO_PYTHON`: path to a specific Python binary for `scripts/dev.sh` (e.g. when Homebrew breaks `ensurepip`).
 - `CIAO_PATH`: baked into the launchd plist's `EnvironmentVariables` at setup time so the server's subprocesses (npm, node, Homebrew git/pip) are found despite launchd's minimal default PATH. Not an operator env var; it's a `com.ciao.server.plist.tmpl` placeholder rendered from the user's shell PATH.

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ The model is project-first: a workspace represents a life area (personal, work, 
 
 ## Install
 
-Install from the [latest release](https://github.com/raffaelefarinaro/ciaobot/releases/latest) — the wheel ships with the pre-built PWA:
+Install from [PyPI](https://pypi.org/project/ciaobot/) — the wheel ships with the pre-built PWA (the same wheel is attached to each [GitHub release](https://github.com/raffaelefarinaro/ciaobot/releases/latest)):
 
 Requires Python 3.12 or newer (use whichever `python3.X` you have, e.g. `brew install python@3.13`):
 
 ```bash
 python3.13 -m venv ~/.ciaobot-venv
-~/.ciaobot-venv/bin/pip install https://github.com/raffaelefarinaro/ciaobot/releases/download/v0.2.2/ciao-0.2.2-py3-none-any.whl
+~/.ciaobot-venv/bin/pip install ciaobot
 ~/.ciaobot-venv/bin/ciao run
 ```
 
@@ -61,7 +61,7 @@ ciao setup --workspace ~/ciao-workspace
 ciao run
 ```
 
-`ciao setup` is idempotent: it writes the initial `.env`, seeds the workspace docs and vault, and (on macOS) renders LaunchAgents for the server and the menu bar companion plus a `Ciaobot.app` shortcut that opens the local PWA. The menu bar icon needs the optional extra (`pip install 'ciao[menubar]'`). Full setup details and optional Node tooling: [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
+`ciao setup` is idempotent: it writes the initial `.env`, seeds the workspace docs and vault, and (on macOS) renders LaunchAgents for the server and the menu bar companion plus a `Ciaobot.app` shortcut that opens the local PWA. The menu bar companion is included automatically on macOS installs (no extra needed). Full setup details and optional Node tooling: [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
 
 Optional capabilities (Google Workspace, Apple Intelligence titles, MCP connectors) each have their own setup in [INTEGRATIONS.md](INTEGRATIONS.md).
 

--- a/ciao/cli.py
+++ b/ciao/cli.py
@@ -294,7 +294,9 @@ def setup_workspace(
     env_path = root / ".env"
     if not env_path.exists():
         token = auth_token or secrets.token_urlsafe(32)
-        contact = push_contact or "mailto:you@example.com"
+        # Empty contact = Web Push disabled until configured in Settings;
+        # never invent a fake default.
+        contact = (push_contact or "").strip()
         lines = [
             f"PWA_AUTH_TOKEN={token}",
         ]
@@ -822,7 +824,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     menubar_parser = subparsers.add_parser(
         "menubar",
-        help="Run the macOS menu bar companion (requires `pip install 'ciao[menubar]'`).",
+        help="Run the macOS menu bar companion (installed automatically on macOS).",
     )
     menubar_parser.add_argument(
         "--workspace",

--- a/ciao/main.py
+++ b/ciao/main.py
@@ -156,11 +156,13 @@ def _rebuild_pwa(workspace: Path) -> bool:
 
 
 def _push_subject_from_env(env: dict[str, str] | None = None) -> str:
+    """Web Push VAPID subject, or "" when CIAO_PUSH_CONTACT is unset.
+
+    An empty subject means Web Push delivery stays disabled until the
+    operator sets a contact in Settings; everything else keeps working.
+    """
     source = env if env is not None else os.environ
-    subject = source.get("CIAO_PUSH_CONTACT", "").strip()
-    if not subject:
-        raise ValueError("CIAO_PUSH_CONTACT is required for Web Push VAPID subject")
-    return subject
+    return source.get("CIAO_PUSH_CONTACT", "").strip()
 
 
 def _push_subject_for_config(config: CiaoConfig) -> str:
@@ -352,6 +354,11 @@ async def _async_main() -> int:
         dev_mode=config.dev_mode,
     )
     push_subject = _push_subject_for_config(config)
+    if not push_subject:
+        logger.info(
+            "CIAO_PUSH_CONTACT is not set; Web Push notifications stay "
+            "disabled until a contact is configured in Settings."
+        )
     app.state.push_manager = PushManager(config.state_path.parent, subject=push_subject)
     app.state.focused_chats = {}
     pcm._push_manager = app.state.push_manager

--- a/ciao/menubar.py
+++ b/ciao/menubar.py
@@ -2,9 +2,9 @@
 
 Puts the Ciaobot face in the status bar (the scared face when the local
 server is unreachable) with quick actions: open the PWA, restart the
-launchd-managed server, and view logs. The Cocoa dependency (rumps) is
-optional so the base package stays slim; install with
-``pip install 'ciao[menubar]'``.
+launchd-managed server, and view logs. The Cocoa dependency (rumps) installs
+automatically on macOS (platform marker in pyproject); on other platforms —
+or if the install is missing it — the command degrades gracefully.
 """
 
 from __future__ import annotations
@@ -266,8 +266,9 @@ def run_menubar(workspace: Path, port: int) -> int:
         import rumps
     except ImportError:
         print(
-            "The Ciaobot menu bar app needs the optional 'rumps' dependency.\n"
-            "Install it with: pip install 'ciao[menubar]'",
+            "The Ciaobot menu bar app needs the 'rumps' dependency (installed\n"
+            "automatically with ciao on macOS). Reinstall ciao or run:\n"
+            "pip install rumps",
             file=sys.stderr,
         )
         return 1

--- a/ciao/setup_status.py
+++ b/ciao/setup_status.py
@@ -237,7 +237,8 @@ def setup_status(
             check_id="push_contact",
             label="Push contact",
             ok=bool(source.get("CIAO_PUSH_CONTACT", "").strip()),
-            required=True,
+            # Optional: without it Web Push stays disabled, nothing else breaks.
+            required=False,
             detail="CIAO_PUSH_CONTACT",
         ),
     ]
@@ -246,7 +247,7 @@ def setup_status(
         "ollama": _ollama_status(config, source),
         "openrouter": _openrouter_status(source),
     }
-    configured = all(row["ok"] for row in checks)
+    configured = all(row["ok"] for row in checks if row["required"])
     provider_ready = any(row["ok"] for row in providers.values())
     bootstrap = bool(getattr(config, "bootstrap_mode", False))
     return {

--- a/ciao/web/push.py
+++ b/ciao/web/push.py
@@ -157,6 +157,12 @@ class PushManager:
         self._log_notification(payload)
         if not self._subs:
             return
+        if not self._subject:
+            # No CIAO_PUSH_CONTACT configured: the Web Push standard requires
+            # a VAPID subject, so skip delivery (the notification log above
+            # still feeds local companions like the menu bar app).
+            logger.debug("CIAO_PUSH_CONTACT unset; skipping Web Push delivery")
+            return
         try:
             from pywebpush import WebPushException, webpush
         except Exception:

--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -3130,9 +3130,9 @@ async def setup_finish_endpoint(request: Request) -> JSONResponse:
     workspace = str(body.get("workspace", "")).strip()
     if not workspace:
         return JSONResponse({"error": "workspace is required"}, status_code=400)
+    # Optional: an empty push contact leaves Web Push disabled until the
+    # operator configures one in Settings.
     push_contact = str(body.get("push_contact", "")).strip()
-    if not push_contact:
-        return JSONResponse({"error": "push_contact is required"}, status_code=400)
     try:
         port = int(body.get("port") or config.pwa_port)
     except (TypeError, ValueError):

--- a/ciao/web/static/index.html
+++ b/ciao/web/static/index.html
@@ -13,7 +13,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-180.png" />
     <title>Ciaobot</title>
-    <script type="module" crossorigin src="/assets/index-DR8JnTPD.js"></script>
+    <script type="module" crossorigin src="/assets/index-BuPeRjw_.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-D7rCIRej.css">
   </head>
   <body>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "ciao"
+name = "ciaobot"
 version = "0.2.2"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
@@ -23,6 +23,9 @@ dependencies = [
   "python-pptx==1.0.2",
   "notebooklm-py==0.7.3",
   "playwright==1.61.0",
+  # macOS menu bar companion (`ciao menubar`): installed automatically on
+  # macOS so a plain wheel install includes the status-bar app.
+  "rumps==0.4.0; platform_system == 'Darwin'",
 ]
 
 [project.optional-dependencies]
@@ -35,7 +38,8 @@ test = [
 voice-local = [
   "mlx-whisper==0.4.3",
 ]
-# macOS menu bar companion (`ciao menubar`).
+# macOS menu bar companion (`ciao menubar`). Kept for compatibility: the same
+# pin ships in the main dependencies with a Darwin platform marker.
 menubar = [
   "rumps==0.4.0",
 ]

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -247,10 +247,12 @@ def test_banners_muted_tolerates_corrupt_settings(tmp_path: Path) -> None:
     assert menubar.read_banners_muted(tmp_path) is False
 
 
-def test_run_menubar_without_rumps_explains_the_extra(
+def test_run_menubar_without_rumps_explains_the_dependency(
     monkeypatch, tmp_path: Path, capsys
 ) -> None:
     monkeypatch.setitem(sys.modules, "rumps", None)
 
     assert menubar.run_menubar(tmp_path, 8443) == 1
-    assert "ciao[menubar]" in capsys.readouterr().err
+    err = capsys.readouterr().err
+    assert "rumps" in err
+    assert "pip install rumps" in err

--- a/tests/test_public_package_metadata.py
+++ b/tests/test_public_package_metadata.py
@@ -47,7 +47,7 @@ def test_env_example_is_generic_public_app_config() -> None:
         assert marker not in env_example
 
 
-def test_push_contact_is_required_without_private_default() -> None:
+def test_push_contact_is_optional_without_private_default() -> None:
     from types import SimpleNamespace
 
     from ciao.main import _push_subject_for_config, _push_subject_from_env
@@ -58,9 +58,7 @@ def test_push_contact_is_required_without_private_default() -> None:
         == "mailto:bootstrap@localhost"
     )
 
-    try:
-        _push_subject_from_env({})
-    except ValueError as exc:
-        assert "CIAO_PUSH_CONTACT" in str(exc)
-    else:
-        raise AssertionError("missing CIAO_PUSH_CONTACT should fail")
+    # Missing contact yields an empty subject (Web Push disabled), never a
+    # private fallback and never an error.
+    assert _push_subject_from_env({}) == ""
+    assert _push_subject_from_env({"CIAO_PUSH_CONTACT": "  "}) == ""

--- a/tests/test_push_notification_log.py
+++ b/tests/test_push_notification_log.py
@@ -24,6 +24,21 @@ def test_send_logs_notification_even_without_subscriptions(tmp_path: Path) -> No
     assert entries[0]["ts"] > 0
 
 
+def test_send_with_empty_subject_skips_webpush_but_still_logs(tmp_path: Path) -> None:
+    """No CIAO_PUSH_CONTACT: Web Push delivery is skipped without errors and
+    the local notification log (menu bar companion) still gets the entry."""
+    manager = PushManager(tmp_path, subject="")
+    manager.add({"endpoint": "https://push.example/sub-1"})
+
+    manager.send({"title": "Ciaobot", "body": "Turn finished", "chat_id": "c1"})
+
+    entries = _read_log(tmp_path)
+    assert len(entries) == 1
+    assert entries[0]["body"] == "Turn finished"
+    # the subscription is kept (not pruned) for when a contact is configured
+    assert manager.count() == 1
+
+
 def test_notification_log_is_trimmed(tmp_path: Path) -> None:
     manager = PushManager(tmp_path)
 

--- a/tests/test_setup_status.py
+++ b/tests/test_setup_status.py
@@ -55,6 +55,21 @@ def test_setup_status_reports_workspace_and_required_config(tmp_path) -> None:
     assert data["configured"] is True
 
 
+def test_setup_status_configured_without_push_contact(tmp_path) -> None:
+    """An empty CIAO_PUSH_CONTACT never blocks a configured workspace."""
+    config = _config(tmp_path, {"CIAO_PUSH_CONTACT": ""})
+    (tmp_path / "memory-vault").mkdir()
+
+    data = setup_status(
+        config,
+        env={"PWA_AUTH_TOKEN": "test-token", "ANTHROPIC_API_KEY": "sk-anthropic"},
+    )
+
+    checks = {row["id"]: row for row in data["checks"]}
+    assert checks["push_contact"]["ok"] is False
+    assert data["configured"] is True
+
+
 def test_setup_status_reports_missing_required_config(tmp_path) -> None:
     config = _config(tmp_path, {"CIAO_PUSH_CONTACT": ""})
 
@@ -63,7 +78,9 @@ def test_setup_status_reports_missing_required_config(tmp_path) -> None:
     checks = {row["id"]: row for row in data["checks"]}
     assert checks["vault"]["ok"] is False
     assert checks["pwa_auth_token"]["ok"] is True
+    # push contact is optional: reported as not ok, but never blocks setup
     assert checks["push_contact"]["ok"] is False
+    assert checks["push_contact"]["required"] is False
     assert data["configured"] is False
 
 
@@ -210,7 +227,41 @@ def test_setup_finish_writes_real_workspace_and_requests_restart(tmp_path) -> No
     assert (apps / "Ciaobot.app" / "Contents" / "MacOS" / "Ciaobot").is_file()
 
 
-def test_setup_finish_requires_bootstrap_mode_and_push_contact(tmp_path) -> None:
+def test_setup_finish_accepts_empty_push_contact(tmp_path) -> None:
+    """Push contact is optional: setup finishes and writes an empty value
+    (Web Push stays disabled until configured in Settings)."""
+    config = CiaoConfig.from_env({"CIAO_BOOTSTRAP_WORKSPACE": str(tmp_path / "boot")})
+    serializer = URLSafeTimedSerializer("test-secret")
+    app = Starlette(
+        routes=[Route("/api/setup/finish", setup_finish_endpoint, methods=["POST"])],
+        middleware=[Middleware(AuthMiddleware, serializer=serializer)],
+    )
+    app.state.config = config
+    app.state.serializer = serializer
+
+    workspace = tmp_path / "workspace"
+    resp = TestClient(app, base_url="http://localhost:8443").post(
+        "/api/setup/finish",
+        json={
+            "workspace": str(workspace),
+            "push_contact": "",
+            "launch_agents_dir": str(tmp_path / "LaunchAgents"),
+            "app_dir": str(tmp_path / "Applications"),
+            "restart": False,
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+    env_lines = (workspace / ".env").read_text(encoding="utf-8").splitlines()
+    assert "CIAO_PUSH_CONTACT=" in env_lines
+    assert not any(
+        line.startswith("CIAO_PUSH_CONTACT=") and line != "CIAO_PUSH_CONTACT="
+        for line in env_lines
+    )
+
+
+def test_setup_finish_requires_bootstrap_mode(tmp_path) -> None:
     config = _config(tmp_path)
     serializer = URLSafeTimedSerializer("test-secret")
     app = Starlette(

--- a/web/src/components/LoginView.vue
+++ b/web/src/components/LoginView.vue
@@ -54,6 +54,10 @@
               <strong>Archive into a second brain.</strong>
               <span>Archived chats produce session insights, trajectories, and memory proposals for review.</span>
             </li>
+            <li>
+              <strong>Files, with history.</strong>
+              <span>Create, preview, edit, and restore workspace files right from the UI.</span>
+            </li>
           </ul>
         </section>
 
@@ -146,47 +150,61 @@
         </div>
 
         <div class="form-group">
-          <label for="setup-push">Push Contact</label>
+          <label for="setup-push">Notification Email (Optional)</label>
           <input
             id="setup-push"
             v-model="pushContact"
             type="text"
+            inputmode="email"
+            autocomplete="email"
             class="form-input"
-            placeholder="mailto:you@example.com"
-            required
+            placeholder="you@example.com"
             :disabled="loading"
           />
-          <span class="hint">Required. Used to register push notifications and security certificates.</span>
+          <span class="hint">Optional — enables push notifications. The Web Push standard requires an operator contact; nothing is ever emailed to you. You can set it later in Settings.</span>
         </div>
 
-        <div class="form-grid">
-          <div class="form-group">
-            <label for="setup-port">Port</label>
-            <input
-              id="setup-port"
-              v-model.number="port"
-              type="number"
-              class="form-input"
-              placeholder="8443"
-              required
-              :disabled="loading"
-            />
-          </div>
-          <div class="form-group">
-            <label for="setup-python">Python Path (Optional)</label>
-            <input
-              id="setup-python"
-              v-model="python"
-              type="text"
-              class="form-input"
-              placeholder="blank for default"
-              :disabled="loading"
-            />
+        <div class="advanced-section">
+          <button
+            id="setup-advanced-toggle"
+            type="button"
+            class="advanced-toggle"
+            :aria-expanded="advancedOpen"
+            :disabled="loading"
+            @click="advancedOpen = !advancedOpen"
+          >
+            <span class="advanced-caret">{{ advancedOpen ? '▾' : '▸' }}</span> Advanced
+          </button>
+          <div v-if="advancedOpen" class="form-grid">
+            <div class="form-group">
+              <label for="setup-port">Port</label>
+              <input
+                id="setup-port"
+                v-model.number="port"
+                type="number"
+                class="form-input"
+                placeholder="8443"
+                required
+                :disabled="loading"
+              />
+            </div>
+            <div class="form-group">
+              <label for="setup-python">Python Path (Optional)</label>
+              <input
+                id="setup-python"
+                v-model="python"
+                type="text"
+                class="form-input"
+                placeholder="blank for default"
+                :disabled="loading"
+              />
+            </div>
           </div>
         </div>
 
         <div class="form-group">
           <label>AI Provider Choice</label>
+          <span class="hint">Pick one to get started — you can add more providers later in Settings.</span>
           <div class="provider-choices">
             <label class="choice-label">
               <input type="radio" v-model="provider" value="claude" :disabled="loading" /> Claude Code
@@ -389,6 +407,7 @@ const userEditedVault = ref(false)
 const vaultMode = ref('scratch')
 const vaultRevealed = ref(false)
 const copyStatus = ref('')
+const advancedOpen = ref(false)
 
 // The vault path stays hidden while it is just the derived default: only a
 // custom split ("change location") or pointing at existing notes shows it.
@@ -531,6 +550,23 @@ async function fetchSetupStatus() {
   }
 }
 
+// The field reads as a plain email input: show "you@example.com" even when a
+// mailto: URI is pasted in (the prefix is re-added on submit). Full mailto:/
+// https: URIs typed by power users stay valid either way.
+watch(pushContact, (value) => {
+  if (value.toLowerCase().startsWith('mailto:')) {
+    pushContact.value = value.slice('mailto:'.length)
+  }
+})
+
+// Web Push VAPID subjects are mailto:/https: URIs: wrap a plain email on
+// submit, pass URIs through, and send '' to leave push unconfigured.
+function normalizedPushContact(): string {
+  const value = pushContact.value.trim()
+  if (!value || /^(mailto:|https:)/i.test(value)) return value
+  return `mailto:${value}`
+}
+
 // Watch workspace path changes to automatically update vault root if user hasn't touched it
 watch(workspace, (newVal) => {
   if (!userEditedVault.value) {
@@ -544,7 +580,7 @@ watch(workspace, (newVal) => {
 })
 
 const canFinish = computed(() => {
-  if (!workspace.value.trim() || !vaultRoot.value.trim() || !pushContact.value.trim()) {
+  if (!workspace.value.trim() || !vaultRoot.value.trim()) {
     return false
   }
   const currentProvider = provider.value
@@ -574,7 +610,7 @@ async function doFinish() {
       workspace: workspace.value,
       vault_root: vaultRoot.value,
       vault_mode: vaultMode.value,
-      push_contact: pushContact.value,
+      push_contact: normalizedPushContact(),
       port: Number(port.value),
       python: python.value || undefined,
       auth_required: authRequired.value,
@@ -1002,6 +1038,35 @@ onUnmounted(() => {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 12px;
+}
+
+.advanced-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.advanced-toggle {
+  align-self: flex-start;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--fg3);
+  font-family: inherit;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  cursor: pointer;
+}
+.advanced-toggle:hover:not(:disabled) {
+  color: var(--fg2);
+}
+.advanced-toggle:disabled {
+  cursor: not-allowed;
+}
+.advanced-caret {
+  color: var(--accent);
 }
 
 .provider-choices {

--- a/web/src/components/__tests__/LoginView.test.ts
+++ b/web/src/components/__tests__/LoginView.test.ts
@@ -102,6 +102,31 @@ describe('LoginView setup wizard tests', () => {
     expect(wrapper.find('#setup-vault').exists()).toBe(false)
     expect(wrapper.find('#setup-push').exists()).toBe(true)
     expect(wrapper.text()).toContain('ciao auth claude')
+
+    // feature tour fills the 2-column grid: six tiles, no empty slot
+    const tourItems = wrapper.findAll('.tour-list li')
+    expect(tourItems.length).toBe(6)
+    expect(tourItems[5].text()).toContain('Files, with history.')
+    expect(tourItems[5].text()).toContain('Create, preview, edit, and restore workspace files right from the UI.')
+  })
+
+  it('hides port and python inputs behind the Advanced toggle', async () => {
+    mockApiGet.mockResolvedValue({
+      configured: false,
+      bootstrap: true,
+      mode: 'bootstrap',
+      providers: {}
+    })
+
+    const wrapper = await mountLoginView()
+    expect(wrapper.find('#setup-port').exists()).toBe(false)
+    expect(wrapper.find('#setup-python').exists()).toBe(false)
+
+    await wrapper.find('#setup-advanced-toggle').trigger('click')
+    await nextTick()
+    expect(wrapper.find('#setup-port').exists()).toBe(true)
+    expect(wrapper.find('#setup-python').exists()).toBe(true)
+    expect((wrapper.find('#setup-port').element as HTMLInputElement).value).toBe('8443')
   })
 
   it('shows a live derived vault hint in scratch mode and reveals the input via change location', async () => {
@@ -192,7 +217,7 @@ describe('LoginView setup wizard tests', () => {
     expect(wrapper.text()).toContain('/Users/me/ciaobot/memory-vault')
   })
 
-  it('validates required fields and enables Finish on valid form', async () => {
+  it('enables Finish without a push contact and wraps a plain email on submit', async () => {
     mockApiGet.mockResolvedValue({
       configured: false,
       bootstrap: true,
@@ -210,15 +235,13 @@ describe('LoginView setup wizard tests', () => {
 
     const wrapper = await mountLoginView()
     const submitBtn = wrapper.find('button[type="submit"]')
-    expect(submitBtn.element.hasAttribute('disabled')).toBe(true)
-
-    // fill push contact
-    const pushInput = wrapper.find('#setup-push')
-    await pushInput.setValue('mailto:owner@example.com')
-    await nextTick()
-
-    // should be enabled now since workspace & vault default are filled, provider is ok
+    // push contact is optional: workspace & vault defaults + ready provider suffice
     expect(submitBtn.element.hasAttribute('disabled')).toBe(false)
+
+    // a plain email is accepted and wrapped into a mailto: URI on submit
+    const pushInput = wrapper.find('#setup-push')
+    await pushInput.setValue('owner@example.com')
+    await nextTick()
 
     // submit the form
     mockApiPost.mockResolvedValue({ ok: true })
@@ -236,5 +259,36 @@ describe('LoginView setup wizard tests', () => {
       restart: true,
     })
     expect(wrapper.text()).toContain('restarting')
+  })
+
+  it('strips mailto: for display and submits an empty push contact untouched', async () => {
+    mockApiGet.mockResolvedValue({
+      configured: false,
+      bootstrap: true,
+      mode: 'bootstrap',
+      providers: {
+        claude: { name: 'claude', ok: true, auth: 'oauth', command: 'ciao auth claude', detail: 'Ready' }
+      }
+    })
+
+    const wrapper = await mountLoginView()
+
+    // pasting a mailto: URI shows as a plain email
+    const pushInput = wrapper.find('#setup-push')
+    await pushInput.setValue('mailto:owner@example.com')
+    await nextTick()
+    expect((pushInput.element as HTMLInputElement).value).toBe('owner@example.com')
+
+    // clearing it submits an empty contact (push disabled until Settings)
+    await pushInput.setValue('')
+    await nextTick()
+    mockApiPost.mockResolvedValue({ ok: true })
+    await wrapper.find('form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(mockApiPost).toHaveBeenCalledWith(
+      '/api/setup/finish',
+      expect.objectContaining({ push_contact: '' })
+    )
   })
 })


### PR DESCRIPTION
## What

**Setup wizard polish**
- Push contact → "Notification Email (Optional)": plain email (`mailto:` handled automatically), optional; empty = Web Push delivery disabled until set (previously an empty value crashed startup and `ciao setup` wrote a fake `mailto:you@example.com`). It's only the VAPID `sub` operator contact — nothing is ever emailed to the user; the old "security certificates" hint claim was false (VAPID keys are contact-independent).
- Port + Python path → collapsed **Advanced** section.
- Provider hint: "Pick one to get started — you can add more providers later in Settings."
- Sixth tour tile ("Files, with history.") completes the 2-column grid and matches the six capability pillars.

**Packaging**
- `rumps` installs automatically on macOS (`platform_system == 'Darwin'` marker) so the menu bar companion works after a plain wheel install; `[menubar]` extra kept for compat.
- Distribution renamed `ciao` → `ciaobot` (PyPI name is free; PyPI's `ciao` is an unrelated project). Import path, both CLI commands, and `CIAO_*` env vars unchanged.
- New `.github/workflows/publish.yml`: on release publish, builds the PWA + wheel/sdist (restoring the two committed icons the build wipes, #12), publishes to PyPI via trusted publishing (environment `pypi`, pending publisher already configured by the owner), and attaches artifacts to the GitHub release.

## Verification

- `pytest tests/`: 868 passed.
- `cd web && npm run test`: 60 passed; `npm run build` green, menu-bar PNGs intact.
- `pip install -e .` resolves; rumps pulled automatically on this Mac.
- Push smoke: empty subject → send skipped without exception, subscriptions retained, notification log (menu bar feed) still written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)