### PR TITLE
Release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.2 - 2026-07-07
+
+### Fixed
+- fix: boot screen shows real version; drop startup PWA rebuild phase (#27) (`e7d68f3`)
+
 ## v0.4.1 - 2026-07-07
 
 ### Added

--- a/ciao/__init__.py
+++ b/ciao/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciaobot"
-version = "0.4.1"
+version = "0.4.2"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-pwa",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-pwa",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
         "dompurify": "^3.4.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-pwa",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Prepare Ciaobot v0.4.2
- Update package, PWA, and package-lock versions
- Add changelog notes for the release range

## Release notes
## v0.4.2 - 2026-07-07

### Fixed
- fix: boot screen shows real version; drop startup PWA rebuild phase (#27) (`e7d68f3`)

## Testing
- pytest tests/
- cd web && npm run test
- cd web && npm run build
- ciao package-smoke --skip-frontend

## After approval
- Merge this PR
- Create and push tag `v0.4.2`
- Publish the package artifact from the tagged commit
