### PR TITLE
fix: setup_workspace honors existing .env vault root on re-run

### DIFF
--- a/ciao/cli.py
+++ b/ciao/cli.py
@@ -407,6 +407,20 @@ def setup_workspace(
     root.mkdir(parents=True, exist_ok=True)
     written: list[Path] = []
     vault_value = str(vault_root) if vault_root is not None else "memory-vault"
+
+    env_path = root / ".env"
+    env_exists = env_path.exists()
+    if env_exists:
+        # An existing .env is the source of truth for where the vault lives.
+        # Re-running setup with a stale or blank vault_root argument must not
+        # relocate scaffolding away from the real vault (and thus re-scatter
+        # MEMORY.md/INDEX.md at a bogus location).
+        from dotenv import dotenv_values
+
+        existing_root = (dotenv_values(env_path).get("CIAO_VAULT_ROOT") or "").strip()
+        if existing_root:
+            vault_value = existing_root
+
     vault_path = Path(vault_value).expanduser()
     if vault_path.is_absolute():
         # Record the expanded path so .env stays unambiguous when the vault
@@ -415,8 +429,7 @@ def setup_workspace(
     else:
         vault_path = root / vault_path
 
-    env_path = root / ".env"
-    if not env_path.exists():
+    if not env_exists:
         token = auth_token or secrets.token_urlsafe(32)
         # Empty contact = Web Push disabled until configured in Settings;
         # never invent a fake default.

--- a/tests/test_workspace_git.py
+++ b/tests/test_workspace_git.py
@@ -219,3 +219,36 @@ def test_setup_workspace_git_inits_external_vault(tmp_path: Path) -> None:
     # The workspace repo neither tracks nor contains the external vault.
     ws_tracked = _git(ws, "ls-files").stdout.splitlines()
     assert not any(path.startswith("memory-vault/") for path in ws_tracked)
+
+
+def test_setup_workspace_rerun_honors_existing_env_vault_root(
+    tmp_path: Path,
+) -> None:
+    """Re-running setup with a wrong/blank vault_root must not relocate the
+    vault: the existing .env's CIAO_VAULT_ROOT wins, so scaffolding is not
+    re-scattered at the argument's location."""
+    ws = tmp_path / "workspace"
+    setup_workspace(
+        ws,
+        vault_root="brain-a",
+        launch_agents_dir=tmp_path / "LaunchAgents",
+        app_dir=tmp_path / "Applications",
+    )
+    assert (ws / "brain-a" / "MEMORY.md").is_file()
+    env_before = (ws / ".env").read_text(encoding="utf-8")
+
+    # Re-run with a bogus vault_root; .env already exists so it is the source
+    # of truth for where the vault lives.
+    setup_workspace(
+        ws,
+        vault_root="wrong-b",
+        launch_agents_dir=tmp_path / "LaunchAgents",
+        app_dir=tmp_path / "Applications",
+    )
+
+    # Scaffolding stays in the real vault and is not re-scattered under wrong-b.
+    assert (ws / "brain-a" / "MEMORY.md").is_file()
+    assert not (ws / "wrong-b").exists()
+    # .env is left untouched and still points at the original vault.
+    assert (ws / ".env").read_text(encoding="utf-8") == env_before
+    assert "CIAO_VAULT_ROOT=brain-a" in env_before


### PR DESCRIPTION
## Problem

`setup_workspace` (`ciao/cli.py`) computed `vault_path` solely from the `vault_root` argument. The `.env`-writing block is correctly skipped when a `.env` already exists, but the scaffolding writes (`MEMORY.md`, `INDEX.md`, `projects/.../general.md`, `Logs/Chats/`) always used the *argument's* location.

Consequently, re-running `ciao setup` on an existing workspace with a wrong or blank `vault_root` would re-scatter vault scaffolding at a bogus location while leaving the (correct) `.env` untouched — the only way the stray-`MEMORY.md`-at-root symptom recurs.

## Fix

When `.env` already exists, read `CIAO_VAULT_ROOT` from it and let that value override the argument before computing `vault_path`. An existing workspace is thus the source of truth for where its vault lives; a stale/blank argument on re-run can no longer relocate scaffolding.

## Test

Added `test_setup_workspace_rerun_honors_existing_env_vault_root`: sets up a workspace with `vault_root=brain-a`, re-runs with a bogus `vault_root=wrong-b`, and asserts scaffolding stays under `brain-a`, nothing is written under `wrong-b`, and `.env` is byte-for-byte unchanged. Verified it fails on the pre-fix code and passes with the fix.

## Verification

- `pytest tests/` — 883 passed.
- No frontend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)