### PR TITLE
fix: evaluate provider-alias tier placeholder instead of showing raw template

### DIFF
--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -702,8 +702,8 @@
                     :model-value="tierOverrideValue(selectedTierProviderSection.key as TierProviderKey, tier.key)"
                     :sections="tierModelSections"
                     :disabled="routinesSaving || !selectedTierProviderSection.available"
-                    placeholder="Default ({{ tierEffectiveValue(selectedTierProviderSection.key as TierProviderKey, tier.key) || 'automatic' }})"
-                    empty-placeholder="Default ({{ tierEffectiveValue(selectedTierProviderSection.key as TierProviderKey, tier.key) || 'automatic' }})"
+                    :placeholder="`Default (${tierEffectiveValue(selectedTierProviderSection.key as TierProviderKey, tier.key) || 'automatic'})`"
+                    :empty-placeholder="`Default (${tierEffectiveValue(selectedTierProviderSection.key as TierProviderKey, tier.key) || 'automatic'})`"
                     @update:model-value="saveTierModel(selectedTierProviderSection.key as TierProviderKey, tier.key, $event)"
                   />
                   <input


### PR DESCRIPTION
## Problem

In Settings → **Provider alias models**, the Haiku / Sonnet / Opus model selectors showed the literal text:

```
Default ({{ tierEffectiveValue(selectedTierProviderSe…
```

instead of the resolved model name.

## Cause

`web/src/components/SettingsView.vue` passed the placeholders as **static attributes**:

```html
placeholder="Default ({{ tierEffectiveValue(...) }})"
empty-placeholder="Default ({{ tierEffectiveValue(...) }})"
```

Vue mustache (`{{ }}`) interpolation is only processed in text nodes, not inside attribute values, so the raw template string was passed straight through to `ModelSelector` and rendered verbatim.

## Fix

Bind the attributes and use a template literal so the expression is evaluated:

```html
:placeholder="`Default (${tierEffectiveValue(...) || 'automatic'})`"
:empty-placeholder="`Default (${tierEffectiveValue(...) || 'automatic'})`"
```

## Verification

- `cd web && npm run build` passes (includes `vue-tsc --noEmit` type check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)