### PR TITLE
Default skills auto-update off and theme to system

### DIFF
--- a/ciao/config.py
+++ b/ciao/config.py
@@ -288,7 +288,7 @@ class CiaoConfig:
     restart_exit_code: int = 75
     auto_sync_on_start: bool = True
     auto_vault_index: bool = True
-    auto_update_github_skills: bool = True
+    auto_update_github_skills: bool = False
     pwa_port: int = 8443
     pwa_host: str = "0.0.0.0"
     gws_default_profile: str = "personal"
@@ -666,7 +666,7 @@ class CiaoConfig:
             ).lower() not in {"0", "false", "no", "off"},
             auto_vault_index=source.get("CIAO_AUTO_VAULT_INDEX", "true").strip().lower()
             not in {"0", "false", "no", "off"},
-            auto_update_github_skills=source.get("CIAO_AUTO_UPDATE_GITHUB_SKILLS", "true").strip().lower()
+            auto_update_github_skills=source.get("CIAO_AUTO_UPDATE_GITHUB_SKILLS", "false").strip().lower()
             not in {"0", "false", "no", "off"},
             pwa_port=int(source.get("PWA_PORT", "8443")),
             pwa_host=source.get("PWA_HOST", "0.0.0.0").strip(),

--- a/ciao/sync_skills.py
+++ b/ciao/sync_skills.py
@@ -91,7 +91,7 @@ def _refresh_upstream_skills(
 ) -> tuple[int, int]:
     lockfile = workspace / "skills-lock.json"
     claude_skills = workspace / ".claude" / "skills"
-    if os.environ.get("CIAO_AUTO_UPDATE_GITHUB_SKILLS", "true").strip().lower() in {"0", "false", "no", "off"}:
+    if os.environ.get("CIAO_AUTO_UPDATE_GITHUB_SKILLS", "false").strip().lower() in {"0", "false", "no", "off"}:
         print("Skills: automatic GitHub updates disabled, skipping refresh.")
         return 0, 0
     if not lockfile.is_file():

--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -938,7 +938,7 @@ def _provider_config_payload(config) -> dict:
         }
     return {
         "keys": keys,
-        "auto_update_github_skills": getattr(config, "auto_update_github_skills", True),
+        "auto_update_github_skills": getattr(config, "auto_update_github_skills", False),
         "requires_restart": True,
         "env_path": str(_env_path(config)),
         "connections": {},

--- a/tests/test_workspace_settings_routes.py
+++ b/tests/test_workspace_settings_routes.py
@@ -277,7 +277,7 @@ def test_provider_config_status_and_write_only_patch(tmp_path):
     assert data["keys"]["ANTHROPIC_API_KEY"]["configured"] is True
     assert data["keys"]["OPENAI_API_KEY"]["configured"] is True
     assert data["keys"]["CIAO_OLLAMA_API_KEY"]["configured"] is False
-    assert data["auto_update_github_skills"] is True
+    assert data["auto_update_github_skills"] is False
     assert "sk-anthropic" not in json.dumps(data)
     assert "OPENAI_API_KEY=old" not in json.dumps(data)
 

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -1384,12 +1384,12 @@ const expandedSubagents = ref<Record<string, boolean>>({})
 const expandedInstructions = ref<Record<string, boolean>>({})
 
 // ── Appearance settings ────────────────────────────────────────────────────
-const activeTheme = ref('dark')
+const activeTheme = ref('system')
 const fontScale = ref(1.0)
 
 function loadAppearanceSettings() {
   try {
-    activeTheme.value = localStorage.getItem('ciao-theme') || 'dark'
+    activeTheme.value = localStorage.getItem('ciao-theme') || 'system'
     const savedScale = localStorage.getItem('ciao-font-scale')
     if (savedScale) {
       fontScale.value = parseFloat(savedScale) || 1.0
@@ -1857,7 +1857,7 @@ const providerKeysError = ref('')
 const providerKeysSaving = ref(false)
 const providerKeysResult = ref('')
 const providerKeyInputs = ref<Record<string, string>>({})
-const autoUpdateGithubSkills = ref(true)
+const autoUpdateGithubSkills = ref(false)
 const autoUpdateSaving = ref(false)
 const autoUpdateResult = ref('')
 const gwsIntegration = ref<GwsIntegrationSettings | null>(null)

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -5,7 +5,7 @@ import App from './App.vue'
 
 // Restore theme & font scale from localStorage as early as possible
 try {
-  const savedTheme = localStorage.getItem('ciao-theme') || 'dark'
+  const savedTheme = localStorage.getItem('ciao-theme') || 'system'
   if (savedTheme === 'light') {
     document.documentElement.classList.add('theme-light')
   } else if (savedTheme === 'system') {
@@ -19,7 +19,7 @@ try {
   const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
   const listener = (e: { matches: boolean }) => {
     try {
-      const currentTheme = localStorage.getItem('ciao-theme') || 'dark'
+      const currentTheme = localStorage.getItem('ciao-theme') || 'system'
       if (currentTheme === 'system') {
         if (e.matches) {
           document.documentElement.classList.remove('theme-light')


### PR DESCRIPTION
## Summary
Flips two first-run defaults:

- **Skills auto-update disabled by default.** `auto_update_github_skills` now defaults to `False`. Ciaobot no longer checks GitHub for updates to locked-package skills on boot unless the user explicitly enables it in Settings. Applied consistently across the backend config default, the `CIAO_AUTO_UPDATE_GITHUB_SKILLS` env fallback, the `sync_skills` refresh guard, and the provider-config API payload.
- **Theme defaults to "system".** The app theme (color) now defaults to `system` instead of `dark`, so a fresh install follows the OS light/dark preference. Covers the early theme restore + media-query listener in `main.ts` and the active-theme initialization in `SettingsView.vue`.

## Testing
- `pytest tests/test_workspace_settings_routes.py tests/test_sync_skills.py tests/test_upgrade.py` — 27 passed (updated the provider-config default assertion to `False`).
- `cd web && npm run build` — succeeds; verified the built bundle now falls back to `"system"` for `ciao-theme`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)