### PR TITLE
fix: return 409 instead of 500 when running a schedule while paused

### DIFF
--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -2695,6 +2695,11 @@ async def run_schedule_now(request: Request) -> JSONResponse:
         result = await sm.dispatch_now(schedule_id)
     except ValueError:
         return JSONResponse({"error": "not found"}, status_code=404)
+    except RuntimeError as exc:
+        # dispatch_now raises RuntimeError when the instance is paused. That's
+        # a client-visible conflict, not a server fault, so return 409 with the
+        # message instead of leaking an unhandled 500 ("Internal Server Error").
+        return JSONResponse({"error": str(exc)}, status_code=409)
     return JSONResponse(result, status_code=201)
 
 

--- a/tests/test_schedule_api_delivery_modes.py
+++ b/tests/test_schedule_api_delivery_modes.py
@@ -8,7 +8,7 @@ from starlette.testclient import TestClient
 
 from ciao.schedules import ScheduleManager, ScheduleStore
 from ciao.sessions import StateStore
-from ciao.web.routes_api import create_schedule, schedule_detail
+from ciao.web.routes_api import create_schedule, run_schedule_now, schedule_detail
 
 
 class _Config:
@@ -51,6 +51,47 @@ def _make_client(
     app.state.state_store = state
     app.state.project_chat_manager = _ProjectChats(workspaces)
     return TestClient(app)
+
+
+def _make_run_now_client(
+    tmp_path: Path, *, paused: bool
+) -> tuple[TestClient, str]:
+    runtime = tmp_path / ".runtime"
+    runtime.mkdir()
+    store = ScheduleStore(runtime)
+    manager = ScheduleManager(store=store, is_paused=lambda: paused)
+    entry = manager.create(
+        daily_time_utc="01:00",
+        prompt="curate",
+        model="sonnet",
+        mode="print",
+        chat_id=0,
+        frequency="manual",
+    )
+    app = Starlette(
+        routes=[
+            Route(
+                "/api/schedule-run/{schedule_id}",
+                run_schedule_now,
+                methods=["POST"],
+            ),
+        ]
+    )
+    app.state.schedule_manager = manager
+    return TestClient(app), entry.schedule_id
+
+
+def test_run_schedule_now_while_paused_returns_409(tmp_path: Path) -> None:
+    client, schedule_id = _make_run_now_client(tmp_path, paused=True)
+    response = client.post(f"/api/schedule-run/{schedule_id}")
+    assert response.status_code == 409, response.text
+    assert "paused" in response.json()["error"].lower()
+
+
+def test_run_schedule_now_missing_schedule_returns_404(tmp_path: Path) -> None:
+    client, _ = _make_run_now_client(tmp_path, paused=False)
+    response = client.post("/api/schedule-run/does-not-exist")
+    assert response.status_code == 404, response.text
 
 
 def test_create_schedule_rejects_unknown_archive_policy(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

Clicking **Run now** on a schedule while the instance is paused returned an HTTP 500 that the PWA surfaced as `Internal Server Error`. Observed on the `system-skill-evolution` system schedule:

```
:8443/api/schedule-run/system-skill-evolution → 500 (Internal Server Error)
```

## Root cause

`ScheduleManager.dispatch_now` raises `RuntimeError("Instance is paused; cannot run schedule now.")` as its first check when the instance is paused. The `run_schedule_now` route handler (`ciao/web/routes_api.py`) only translated `ValueError` → 404, so the `RuntimeError` escaped as an unhandled 500. Server traceback confirmed this exact path.

## Fix

Catch `RuntimeError` in `run_schedule_now` and return **409 Conflict** with the error message. The PWA's API client already renders `err.error`, so the user now sees "Instance is paused; cannot run schedule now." instead of "Internal Server Error". 409 matches the pattern used by other conflict-style responses in this module.

## Tests

Added route-level tests in `tests/test_schedule_api_delivery_modes.py`:
- `test_run_schedule_now_while_paused_returns_409`
- `test_run_schedule_now_missing_schedule_returns_404` (guards the existing 404 path)

`tests/test_schedule_api_delivery_modes.py` (6) and `tests/test_schedules.py` (38) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)