### PR TITLE
fix: tie server lifecycle to menu bar; stop baking one-time setup token into app launcher

### DIFF
--- a/ciao/cli.py
+++ b/ciao/cli.py
@@ -199,7 +199,9 @@ def _write_app_shortcut(
     app_dir: Path,
     port: int,
 ) -> Path:
-    token = _ensure_setup_token(workspace)
+    # Create the setup token file if absent so the first launch can log in;
+    # the launcher script below reads its current value live at click time.
+    _ensure_setup_token(workspace)
     _remove_legacy_app_shortcuts(app_dir.expanduser())
     app_root = app_dir.expanduser() / "Ciaobot.app"
     contents = app_root / "Contents"
@@ -234,10 +236,17 @@ def _write_app_shortcut(
         ),
         encoding="utf-8",
     )
-    url = f"http://localhost:{port}/?setup={token}"
+    token_file = _setup_token_path(workspace)
     executable = macos / "Ciaobot"
     # Start the server via launchd when it isn't running, then open the PWA;
     # otherwise clicking the app lands on "site can't be reached".
+    #
+    # Read the setup token live from disk at click time rather than baking it
+    # into this script: the token is one-time-use (redeemed and deleted on
+    # first login), so a frozen "?setup=<token>" URL shows an "invalid setup
+    # token" error page on every launch after the first. Once the token file
+    # is gone we open the plain URL and rely on the session cookie -- matching
+    # how the menu bar builds its "Open Ciaobot" URL (menubar.open_url).
     executable.write_text(
         "#!/bin/sh\n"
         f'if ! curl -s -o /dev/null --max-time 2 "http://localhost:{port}/"; then\n'
@@ -252,7 +261,12 @@ def _write_app_shortcut(
         "fi\n"
         'launchctl kickstart "gui/$(id -u)/com.ciao.menubar" 2>/dev/null \\\n'
         '  || launchctl load -w "$HOME/Library/LaunchAgents/com.ciao.menubar.plist" 2>/dev/null\n'
-        f'open "{url}"\n',
+        f'token=$(tr -d "[:space:]" < "{token_file}" 2>/dev/null)\n'
+        "if [ -n \"$token\" ]; then\n"
+        f'  open "http://localhost:{port}/?setup=$token"\n'
+        "else\n"
+        f'  open "http://localhost:{port}/"\n'
+        "fi\n",
         encoding="utf-8",
     )
     executable.chmod(0o755)

--- a/ciao/menubar.py
+++ b/ciao/menubar.py
@@ -76,6 +76,18 @@ def restart_server_command(uid: int | None = None) -> list[str]:
     return ["launchctl", "kickstart", "-k", f"gui/{resolved}/{SERVER_LAUNCHD_LABEL}"]
 
 
+def stop_server_command(uid: int | None = None) -> list[str]:
+    """Fully stop the server agent when quitting the menu bar.
+
+    The server plist sets KeepAlive=true, so a plain kill would be relaunched
+    immediately; `bootout` removes it from the launchd domain so it stays
+    down. Ciaobot.app reloads it (launchctl load -w) on the next launch.
+    """
+
+    resolved = os.getuid() if uid is None else uid
+    return ["launchctl", "bootout", f"gui/{resolved}/{SERVER_LAUNCHD_LABEL}"]
+
+
 def view_logs_command(workspace: Path) -> list[str]:
     return ["open", str(workspace / ".runtime" / "ciao.stderr.log")]
 
@@ -327,6 +339,23 @@ def run_menubar(workspace: Path, port: int) -> int:
     def on_logs(_sender) -> None:
         subprocess.run(view_logs_command(workspace), check=False)
 
+    def on_quit(_sender) -> None:
+        # The menu bar is the visible presence of a running Ciaobot: quitting
+        # it stops the server too. Confirm first, since that halts scheduled
+        # tasks and any in-flight agent work until Ciaobot is opened again.
+        if not rumps.alert(
+            title="Quit Ciaobot?",
+            message=(
+                "This also stops the Ciaobot server. Scheduled tasks and any "
+                "running agents won't run until you open Ciaobot again."
+            ),
+            ok="Quit",
+            cancel="Cancel",
+        ):
+            return
+        subprocess.run(stop_server_command(), check=False)
+        rumps.quit_application()
+
     def _rebuild_menu(
         status: ServerStatus,
         chats: list[OpenChat],
@@ -372,7 +401,7 @@ def run_menubar(workspace: Path, port: int) -> int:
             rumps.MenuItem("Restart Server", callback=on_restart),
             rumps.MenuItem("View Logs", callback=on_logs),
             None,
-            rumps.MenuItem("Quit", callback=lambda _sender: rumps.quit_application()),
+            rumps.MenuItem("Quit Ciaobot", callback=on_quit),
         ]
 
     def _mute_item():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -274,13 +274,20 @@ def test_setup_scaffolds_workspace_from_stock(tmp_path: Path) -> None:
     assert app_exe.is_file()
     assert app_exe.stat().st_mode & 0o111
     app_text = app_exe.read_text(encoding="utf-8")
-    assert 'open "http://localhost:9443/?setup=' in app_text
+    # The launcher reads the one-time setup token live from disk (it is
+    # deleted after first login), so it must NOT bake a frozen token value
+    # into the URL -- otherwise a second launch shows "invalid setup token".
+    token_file = workspace / ".runtime" / "setup-token"
+    assert f'token=$(tr -d "[:space:]" < "{token_file}"' in app_text
+    assert 'open "http://localhost:9443/?setup=$token"' in app_text
+    assert 'open "http://localhost:9443/"' in app_text
     # The launcher starts the server and menu bar agents when they're down.
     assert 'launchctl kickstart "gui/$(id -u)/com.ciao.server"' in app_text
     assert 'launchctl kickstart "gui/$(id -u)/com.ciao.menubar"' in app_text
-    setup_token = (workspace / ".runtime" / "setup-token").read_text(encoding="utf-8").strip()
+    setup_token = token_file.read_text(encoding="utf-8").strip()
     assert setup_token
-    assert setup_token in app_text
+    # The literal token value must not appear in the script -- it is read live.
+    assert setup_token not in app_text
     icns = apps / "Ciaobot.app" / "Contents" / "Resources" / "Ciaobot.icns"
     assert icns.is_file() and icns.stat().st_size > 0
     info_plist = (apps / "Ciaobot.app" / "Contents" / "Info.plist").read_text(encoding="utf-8")

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -97,6 +97,16 @@ def test_restart_server_command_targets_launchd_label() -> None:
     ]
 
 
+def test_stop_server_command_boots_out_launchd_label() -> None:
+    # bootout (not kill) because the server plist is KeepAlive=true, so a
+    # plain kill would be relaunched; bootout takes it out of the domain.
+    assert menubar.stop_server_command(uid=501) == [
+        "launchctl",
+        "bootout",
+        "gui/501/com.ciao.server",
+    ]
+
+
 def test_view_logs_command_opens_stderr_log(tmp_path: Path) -> None:
     assert menubar.view_logs_command(tmp_path) == [
         "open",


### PR DESCRIPTION
## Summary

Two related menu-bar / lifecycle fixes, both from the same user report ("when I close the menu bar the server keeps running" + "clicking the app gives `{"error":"invalid setup token"}`").

### 1. Quitting the menu bar now stops the server
The menu bar is the visible presence of a running Ciaobot: tray present ⟺ Ciaobot running. Previously "Quit" only killed the tray (`rumps.quit_application()`), leaving the `com.ciao.server` launchd agent (which is `KeepAlive=true`) running forever.

- New `stop_server_command()` helper runs `launchctl bootout gui/<uid>/com.ciao.server`. It uses **bootout, not kill**, because `KeepAlive=true` would relaunch a plain kill. `Ciaobot.app` already reloads the agent (`launchctl load -w`) on the next launch, so start-up is unaffected.
- The renamed **"Quit Ciaobot"** item shows a confirmation dialog first, since stopping the server halts scheduled tasks and in-flight agent work.

### 2. `Ciaobot.app` launcher no longer bakes the one-time setup token into its URL
The setup token is **one-time-use** — redeemed and then deleted on first login (`auth.py` `_redeem_setup_token`). The launcher hard-coded `?setup=<token>` into the URL, so the **second** time you ever clicked the app icon you'd hit an "invalid setup token" error page instead of the app.

The launcher now reads the token live from `.runtime/setup-token` at click time and falls back to the plain URL (relying on the session cookie) once the file is gone — exactly mirroring how the menu bar builds its "Open Ciaobot" URL (`menubar.open_url`).

## Testing
- `pytest tests/` — 900 passed.
- Generated the launcher script into a temp workspace, confirmed `sh -n` passes, that it emits `?setup=$token` while the token file exists, and the plain URL after the file is removed (simulating redemption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)