### PR TITLE
Release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## v0.4.3 - 2026-07-07
+
+### Added
+- feat: detect gws via login-shell PATH; add Install gws button (#36) (`d4ed632`)
+- feat: collapse live thinking trace by default in chat (`ebefeb1`)
+
+### Changed
+- Merge branch 'main' of https://github.com/raffaelefarinaro/ciaobot (`6dea3c9`)
+
+### Fixed
+- fix: setup_workspace honors existing .env vault root on re-run (#29) (`c08bba9`)
+- fix: evaluate provider-alias tier placeholder instead of showing raw template (#30) (`0005864`)
+- fix: move menu bar template icons out of the PWA build output dir (#31) (`62f024c`)
+- fix: default skills auto-update off and theme to system (#32) (`6ffca13`)
+- fix: reliable chat updates during subagent/background work (#34) (`7e7b16a`)
+- fix: return 409 instead of 500 when running a schedule while paused (#35) (`dd6f357`)
+- fix: update check no longer fails on GitHub rate limits (use public redirect) (#33) (`666239e`)
+- fix: tie server lifecycle to menu bar and stop baking one-time token into app launcher (#37) (`cd8acd4`)
+
+### Maintenance
+- chore(deps): bump claude-agent-sdk to 0.2.111 (`e0eb1e1`)
+
 ## v0.4.2 - 2026-07-07
 
 ### Fixed

--- a/ciao/__init__.py
+++ b/ciao/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciaobot"
-version = "0.4.2"
+version = "0.4.3"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 license = "Apache-2.0"
 dependencies = [
-  "claude-agent-sdk==0.2.110",
+  "claude-agent-sdk==0.2.111",
   "openai==2.44.0",
   "starlette==0.52.1",
   "uvicorn[standard]==0.50.2",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-pwa",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-pwa",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
         "dompurify": "^3.4.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-pwa",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Prepare Ciaobot v0.4.3
- Update package, PWA, and package-lock versions
- Add changelog notes for the release range

## Release notes
## v0.4.3 - 2026-07-07

### Added
- feat: detect gws via login-shell PATH; add Install gws button (#36) (`d4ed632`)
- feat: collapse live thinking trace by default in chat (`ebefeb1`)

### Changed
- Merge branch 'main' of https://github.com/raffaelefarinaro/ciaobot (`6dea3c9`)

### Fixed
- fix: setup_workspace honors existing .env vault root on re-run (#29) (`c08bba9`)
- fix: evaluate provider-alias tier placeholder instead of showing raw template (#30) (`0005864`)
- fix: move menu bar template icons out of the PWA build output dir (#31) (`62f024c`)
- fix: default skills auto-update off and theme to system (#32) (`6ffca13`)
- fix: reliable chat updates during subagent/background work (#34) (`7e7b16a`)
- fix: return 409 instead of 500 when running a schedule while paused (#35) (`dd6f357`)
- fix: update check no longer fails on GitHub rate limits (use public redirect) (#33) (`666239e`)
- fix: tie server lifecycle to menu bar and stop baking one-time token into app launcher (#37) (`cd8acd4`)

### Maintenance
- chore(deps): bump claude-agent-sdk to 0.2.111 (`e0eb1e1`)

## Testing
- pytest tests/
- cd web && npm run test
- cd web && npm run build
- ciao package-smoke --skip-frontend

## After approval
- Merge this PR
- Create and push tag `v0.4.3`
- Publish the package artifact from the tagged commit
