### PR TITLE
Release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.4.4 - 2026-07-07
+
+### Added
+- feat: add `ciao setup-url` and print login URL + PATH hint after setup (`500ab24`)
+- feat: menu bar Notifications submenu lists unread chats, matching the PWA bell (`de20c4b`)
+- feat: tidy routine model settings for tier-less providers (`b87c602`)
+
+### Changed
+- refactor: drop Telegram-specific labels from archived transcripts (`a7bbe06`)
+
 ## v0.4.3 - 2026-07-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,7 +46,15 @@ python3.13 -m venv ~/.ciaobot-venv
 
 Then open `http://localhost:8443`: with no configured workspace the server starts in bootstrap mode and the setup wizard walks you through choosing the workspace folder (default `~/ciaobot`) — one root folder that holds your second brain (`memory-vault/`) alongside app data (config, `.env`, runtime state, chat metadata) — plus provider choice, before anything is created. Starting from scratch scaffolds the vault inside that folder; you can also point Ciaobot at an existing notes folder elsewhere and it adapts it into the vault structure. When you finish, it writes the config, scaffolds the vault, and (on macOS) renders the LaunchAgents and `Ciaobot.app`. Setup makes sure the workspace folder is one git repository (running `git init` with a `.gitignore` that keeps `.env` and runtime state out of commits) so snapshots and sync work from the start; an existing notes folder outside the workspace gets its own repo with a minimal `.gitignore` for OS/editor litter.
 
-For scripted or headless setups, `ciao setup --workspace <dir>` pre-creates a workspace with defaults and skips the wizard.
+For scripted or headless setups, `ciao setup --workspace <dir>` pre-creates a workspace with defaults and skips the wizard. It prints the resolved workspace, the localhost login URL to open, and — since the CLI lives in a venv that is not on your `PATH` — an `export PATH=…` hint if you want to type `ciao` instead of the full `~/.ciaobot-venv/bin/ciao` path.
+
+If the app or menu bar ever opens an `?setup=…` URL that returns `invalid setup token` (the token is one-time-use and deleted on first login), mint a fresh one and print the URL to open:
+
+```bash
+~/.ciaobot-venv/bin/ciao setup-url --workspace <dir>
+```
+
+Pass `--no-rotate` to print the existing token's URL instead of minting a new one. The `Workspace:` line it prints is the workspace whose token the running server validates against — if it does not match the folder holding your data, the server is serving a different workspace.
 
 ## Quickstart (from source)
 

--- a/ciao/__init__.py
+++ b/ciao/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"

--- a/ciao/cli.py
+++ b/ciao/cli.py
@@ -151,10 +151,87 @@ def _ensure_setup_token(workspace: Path) -> str:
         token = path.read_text(encoding="utf-8").strip()
         if token:
             return token
+    return _rotate_setup_token(workspace)
+
+
+def _rotate_setup_token(workspace: Path) -> str:
+    """Write a fresh one-time setup token, replacing any existing one.
+
+    Unlike ``_ensure_setup_token`` this always mints a new value: use it when
+    the caller wants a guaranteed-valid login URL (the token is redeemed and
+    deleted on first login, so a stale file otherwise yields "invalid setup
+    token"). The app launcher and menu bar read the token live from disk, so
+    they pick up the rotated value on the next open.
+    """
+
+    path = _setup_token_path(workspace)
     token = secrets.token_urlsafe(24)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(token + "\n", encoding="utf-8")
     return token
+
+
+def _pwa_port_from_env(workspace: Path, fallback: int) -> int:
+    """Port the server actually listens on, read from the workspace ``.env``.
+
+    Falls back to ``fallback`` when ``.env`` is absent or has no ``PWA_PORT``,
+    so ``setup-url`` reports a URL that matches a configured install rather
+    than a hard-coded default.
+    """
+
+    env_path = workspace / ".env"
+    if not env_path.exists():
+        return fallback
+    try:
+        from dotenv import dotenv_values
+
+        raw = (dotenv_values(env_path).get("PWA_PORT") or "").strip()
+        return int(raw) if raw else fallback
+    except (OSError, ValueError):
+        return fallback
+
+
+def _path_export_hint() -> str | None:
+    """An ``export PATH=...`` line for the running interpreter's bin dir, or
+    ``None`` when it is already on PATH.
+
+    Ciaobot installs into a standalone venv (``~/.ciaobot-venv``) that is not
+    added to PATH, so ``ciao`` is normally invoked by absolute path. Shell
+    users who want to type ``ciao`` need this hint.
+    """
+
+    # Not .resolve(): a venv's bin/python is a symlink to the base interpreter,
+    # and resolving it would report the base (e.g. Homebrew) bin dir instead of
+    # the venv's own bin/ where the `ciao` entry point actually lives.
+    bin_dir = Path(sys.executable).parent
+    entries = {
+        str(Path(p).expanduser())
+        for p in os.environ.get("PATH", "").split(os.pathsep)
+        if p
+    }
+    if str(bin_dir) in entries:
+        return None
+    return f'export PATH="{bin_dir}:$PATH"'
+
+
+def _print_setup_summary(workspace: Path, port: int) -> None:
+    """Print the resolved workspace, the login URL, and a PATH hint.
+
+    Surfaces the two things setup previously left implicit: which workspace was
+    configured (a mismatch with the running server produces "invalid setup
+    token"), and the URL to open when the generated app is unavailable.
+    """
+
+    token = _setup_token_path(workspace).read_text(encoding="utf-8").strip()
+    base = f"http://localhost:{port}/"
+    url = f"{base}?setup={token}" if token else base
+    print()
+    print(f"Workspace: {workspace}")
+    print(f"Open Ciaobot: {url}")
+    hint = _path_export_hint()
+    if hint is not None:
+        print("To run `ciao` from a shell, add its venv to PATH:")
+        print(f"  {hint}")
 
 
 def _default_app_dir() -> Path:
@@ -546,6 +623,7 @@ def _setup_command(args: argparse.Namespace) -> int:
         Path(args.launch_agents_dir).expanduser() / name
         for name in ("com.ciao.server.plist", "com.ciao.menubar.plist")
     ]
+    root = Path(args.workspace).expanduser().resolve()
     if args.load_launchd:
         rc = 0
         for plist in plists:
@@ -553,9 +631,26 @@ def _setup_command(args: argparse.Namespace) -> int:
             rc = subprocess.run(
                 ["launchctl", "load", "-w", str(plist)], check=False
             ).returncode or rc
+        _print_setup_summary(root, args.port)
         return rc
     for plist in plists:
         print(f"LaunchAgent not loaded. To load it: launchctl load -w {plist}")
+    _print_setup_summary(root, args.port)
+    return 0
+
+
+def _setup_url_command(args: argparse.Namespace) -> int:
+    """Print the localhost login URL for a workspace, minting a fresh one-time
+    setup token by default (``--no-rotate`` reuses the existing token)."""
+
+    root = Path(args.workspace).expanduser().resolve()
+    port = _pwa_port_from_env(root, args.port)
+    if args.rotate:
+        token = _rotate_setup_token(root)
+    else:
+        token = _ensure_setup_token(root)
+    print(f"Workspace: {root}")
+    print(f"http://localhost:{port}/?setup={token}")
     return 0
 
 
@@ -1042,6 +1137,30 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run launchctl unload/load after writing the LaunchAgent.",
     )
     setup_parser.set_defaults(func=_setup_command)
+
+    setup_url_parser = subparsers.add_parser(
+        "setup-url",
+        help="Print the localhost login URL, minting a fresh setup token.",
+    )
+    setup_url_parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path(os.environ.get("CIAO_WORKSPACE", ".")),
+        help="Workspace directory (defaults to $CIAO_WORKSPACE or cwd).",
+    )
+    setup_url_parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("CIAO_PORT", "8443")),
+        help="Fallback port when the workspace .env has no PWA_PORT.",
+    )
+    setup_url_parser.add_argument(
+        "--rotate",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Mint a fresh token (default); --no-rotate reuses the existing one.",
+    )
+    setup_url_parser.set_defaults(func=_setup_url_command)
 
     auth_parser = subparsers.add_parser(
         "auth",

--- a/ciao/menubar.py
+++ b/ciao/menubar.py
@@ -160,38 +160,64 @@ def notify_command(title: str, body: str) -> list[str]:
 class OpenChat:
     chat_id: str
     title: str
-    last_activity_at: float
+    last_activity_at: str
+
+
+def _load_chats(workspace: Path) -> dict[str, dict]:
+    """Chats from the server's persisted PWA state (``.runtime/web_projects.json``)."""
+
+    state_path = workspace / ".runtime" / "web_projects.json"
+    try:
+        data = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    chats = data.get("chats") if isinstance(data, dict) else None
+    if not isinstance(chats, dict):
+        return {}
+    return {str(chat_id): chat for chat_id, chat in chats.items() if isinstance(chat, dict)}
+
+
+def chat_is_unread(chat: dict) -> bool:
+    """Match the PWA bell: unread when ``last_activity_at > last_read_at``."""
+
+    if chat.get("archived"):
+        return False
+    activity = str(chat.get("last_activity_at") or "")
+    read = str(chat.get("last_read_at") or "")
+    return bool(activity) and activity > read
+
+
+def _open_chat_from_state(chat_id: str, chat: dict) -> OpenChat:
+    return OpenChat(
+        chat_id=chat_id,
+        title=str(chat.get("title") or "Untitled chat"),
+        last_activity_at=str(chat.get("last_activity_at") or ""),
+    )
 
 
 def read_open_chats(workspace: Path, *, limit: int = 10) -> list[OpenChat]:
     """Return non-archived chats from the server's persisted PWA state,
     most recently active first."""
 
-    state_path = workspace / ".runtime" / "web_projects.json"
-    try:
-        data = json.loads(state_path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return []
-    chats = data.get("chats") if isinstance(data, dict) else None
-    if not isinstance(chats, dict):
-        return []
     open_chats: list[OpenChat] = []
-    for chat_id, chat in chats.items():
-        if not isinstance(chat, dict) or chat.get("archived"):
+    for chat_id, chat in _load_chats(workspace).items():
+        if chat.get("archived"):
             continue
-        try:
-            last_activity = float(chat.get("last_activity_at") or 0.0)
-        except (TypeError, ValueError):
-            last_activity = 0.0
-        open_chats.append(
-            OpenChat(
-                chat_id=str(chat_id),
-                title=str(chat.get("title") or "Untitled chat"),
-                last_activity_at=last_activity,
-            )
-        )
+        open_chats.append(_open_chat_from_state(chat_id, chat))
     open_chats.sort(key=lambda chat: chat.last_activity_at, reverse=True)
     return open_chats[:limit]
+
+
+def read_unread_chats(workspace: Path, *, limit: int = 10) -> list[OpenChat]:
+    """Unread non-archived chats, most recently active first — mirrors the PWA bell."""
+
+    unread: list[OpenChat] = []
+    for chat_id, chat in _load_chats(workspace).items():
+        if not chat_is_unread(chat):
+            continue
+        unread.append(_open_chat_from_state(chat_id, chat))
+    unread.sort(key=lambda chat: chat.last_activity_at, reverse=True)
+    return unread[:limit]
 
 
 _INET_RE = re.compile(r"^\s*inet (\d+\.\d+\.\d+\.\d+)", re.MULTILINE)
@@ -351,6 +377,7 @@ def run_menubar(workspace: Path, port: int) -> int:
             ),
             ok="Quit",
             cancel="Cancel",
+            icon_path=icon_path("Ciaobot.icns"),
         ):
             return
         subprocess.run(stop_server_command(), check=False)
@@ -359,18 +386,16 @@ def run_menubar(workspace: Path, port: int) -> int:
     def _rebuild_menu(
         status: ServerStatus,
         chats: list[OpenChat],
-        entries: list[Notification],
+        unread_chats: list[OpenChat],
         addresses: list[str],
     ) -> None:
         notifications_menu = rumps.MenuItem("Notifications")
-        if not entries:
-            notifications_menu.add(_disabled_item(rumps, "No notifications yet"))
-        for entry in entries:
+        if not unread_chats:
+            notifications_menu.add(_disabled_item(rumps, "No unread chats"))
+        for chat in unread_chats:
+            title = chat.title if len(chat.title) <= 60 else chat.title[:59] + "…"
             notifications_menu.add(
-                rumps.MenuItem(
-                    notification_menu_title(entry),
-                    callback=_open_chat_callback(entry.chat_id),
-                )
+                rumps.MenuItem(title, callback=_open_chat_callback(chat.chat_id))
             )
 
         addresses_menu = rumps.MenuItem("Addresses (click to copy)")
@@ -413,26 +438,36 @@ def run_menubar(workspace: Path, port: int) -> int:
         status = fetch_server_status(port)
         app.icon = face if status.reachable else face_scared
 
-        entries = read_notifications(workspace)
+        log_entries = read_notifications(workspace)
         chats = read_open_chats(workspace)
+        unread_chats = read_unread_chats(workspace)
+        chats_by_id = _load_chats(workspace)
         addresses = server_addresses(port)
 
         # Rebuild only when content changed so an open menu doesn't flicker.
         fingerprint = (
             status,
             tuple((c.chat_id, c.title) for c in chats),
-            tuple((e.ts, e.title, e.body) for e in entries),
+            tuple((c.chat_id, c.title) for c in unread_chats),
             tuple(addresses),
         )
         if fingerprint != state["fingerprint"]:
             state["fingerprint"] = fingerprint
-            _rebuild_menu(status, chats, entries, addresses)
+            _rebuild_menu(status, chats, unread_chats, addresses)
 
-        fresh = [e for e in entries if e.ts > state["last_seen_ts"]]
+        # Banner only for new log lines whose chat is still unread (same rule
+        # as the PWA bell). Reading a chat in the webapp clears it here too.
+        fresh = [
+            entry
+            for entry in log_entries
+            if entry.ts > state["last_seen_ts"]
+            and entry.chat_id
+            and chat_is_unread(chats_by_id.get(entry.chat_id, {}))
+        ]
         if fresh:
             # Advance the cursor even when muted so unmuting doesn't replay
-            # the backlog; the submenu still lists everything.
-            state["last_seen_ts"] = max(e.ts for e in fresh)
+            # the backlog; the submenu still lists unread chats only.
+            state["last_seen_ts"] = max(entry.ts for entry in fresh)
             if not state["banners_muted"]:
                 for entry in fresh[:3]:
                     subprocess.run(notify_command(entry.title, entry.body), check=False)

--- a/ciao/transcripts.py
+++ b/ciao/transcripts.py
@@ -255,7 +255,6 @@ class TranscriptStore:
         context_label = transcript.get("context_label", "")
         context_key = transcript.get("context_key", "")
         frontmatter = {
-            "type": "telegram-transcript",
             "provider": transcript.get("provider", ""),
             "context": context_label or context_key or "",
             "selected_model": transcript.get("selected_model", ""),
@@ -265,7 +264,7 @@ class TranscriptStore:
             "started": transcript.get("started_at", ""),
             "ended": transcript.get("ended_at", ""),
             "turn_count": len(turns),
-            "tags": ["telegram", "transcript", str(transcript.get("provider", ""))],
+            "tags": ["transcript", str(transcript.get("provider", ""))],
             "usage_totals": usage_totals,
         }
         lines = ["---"]
@@ -275,7 +274,7 @@ class TranscriptStore:
             [
                 "---",
                 "",
-                f"# Telegram Transcript ({transcript.get('provider', '')})",
+                f"# Chat Transcript ({transcript.get('provider', '')})",
                 "",
                 f"- Started: {transcript.get('started_at', '-')}",
                 f"- Ended: {transcript.get('ended_at', '-')}",

--- a/ciao/web/static/index.html
+++ b/ciao/web/static/index.html
@@ -13,7 +13,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-180.png" />
     <title>Ciaobot</title>
-    <script type="module" crossorigin src="/assets/index-Ba_ydC0q.js"></script>
+    <script type="module" crossorigin src="/assets/index-DdFI8kho.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-Dv6rjITN.css">
   </head>
   <body>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciaobot"
-version = "0.4.3"
+version = "0.4.4"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_chat_continue_route.py
+++ b/tests/test_chat_continue_route.py
@@ -58,7 +58,6 @@ def test_route_chat_continue(tmp_path: Path) -> None:
     chat_md = chat_provider_dir / "2026-06-10T12-00-00Z-sess.md"
     chat_content = (
         "---\n"
-        "type: telegram-transcript\n"
         "provider: claude\n"
         "context: Chat to Continue\n"
         "active_model: sonnet\n"

--- a/tests/test_chat_messages_archived.py
+++ b/tests/test_chat_messages_archived.py
@@ -16,7 +16,6 @@ from ciao.web.routes_api import chat_messages
 
 
 _TRANSCRIPT = """---
-type: telegram-transcript
 provider: claude
 context: archived fallback test
 selected_model: opus
@@ -28,7 +27,7 @@ ended: 2026-06-19T10:05:00Z
 turn_count: 2
 ---
 
-# Telegram Transcript (claude)
+# Chat Transcript (claude)
 
 ## Turn 1
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -393,6 +393,72 @@ def test_setup_is_idempotent_and_does_not_overwrite_env(tmp_path: Path) -> None:
     assert (workspace / ".env").read_text(encoding="utf-8") == "PWA_AUTH_TOKEN=existing\n"
 
 
+def test_setup_prints_workspace_and_login_url(tmp_path: Path, capsys) -> None:
+    workspace = tmp_path / "workspace"
+
+    assert cli.main([
+        "setup",
+        "--workspace",
+        str(workspace),
+        "--launch-agents-dir",
+        str(tmp_path / "LaunchAgents"),
+        "--app-dir",
+        str(tmp_path / "Applications"),
+        "--port",
+        "9443",
+    ]) == 0
+
+    out = capsys.readouterr().out
+    token = (workspace / ".runtime" / "setup-token").read_text(encoding="utf-8").strip()
+    assert f"Workspace: {workspace.resolve()}" in out
+    assert f"Open Ciaobot: http://localhost:9443/?setup={token}" in out
+
+
+def test_path_export_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    bin_dir = Path(cli.sys.executable).parent
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    assert cli._path_export_hint() == f'export PATH="{bin_dir}:$PATH"'
+    monkeypatch.setenv("PATH", f"/usr/bin:{bin_dir}")
+    assert cli._path_export_hint() is None
+
+
+def test_setup_url_rotates_token_by_default(tmp_path: Path, capsys) -> None:
+    workspace = tmp_path / "workspace"
+    token_path = workspace / ".runtime" / "setup-token"
+    token_path.parent.mkdir(parents=True)
+    token_path.write_text("stale-token\n", encoding="utf-8")
+
+    assert cli.main(["setup-url", "--workspace", str(workspace)]) == 0
+
+    new_token = token_path.read_text(encoding="utf-8").strip()
+    assert new_token and new_token != "stale-token"
+    out = capsys.readouterr().out
+    assert f"Workspace: {workspace.resolve()}" in out
+    assert f"http://localhost:8443/?setup={new_token}" in out
+
+
+def test_setup_url_no_rotate_reuses_existing_token(tmp_path: Path, capsys) -> None:
+    workspace = tmp_path / "workspace"
+    token_path = workspace / ".runtime" / "setup-token"
+    token_path.parent.mkdir(parents=True)
+    token_path.write_text("keep-me\n", encoding="utf-8")
+
+    assert cli.main(["setup-url", "--workspace", str(workspace), "--no-rotate"]) == 0
+
+    assert token_path.read_text(encoding="utf-8").strip() == "keep-me"
+    assert "http://localhost:8443/?setup=keep-me" in capsys.readouterr().out
+
+
+def test_setup_url_reads_port_from_env(tmp_path: Path, capsys) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / ".env").write_text("PWA_PORT=9999\n", encoding="utf-8")
+
+    assert cli.main(["setup-url", "--workspace", str(workspace)]) == 0
+
+    assert "http://localhost:9999/?setup=" in capsys.readouterr().out
+
+
 def test_auth_print_only_outputs_terminal_command(capsys) -> None:
     assert cli.main(["auth", "ollama", "--print-only"]) == 0
 

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -119,6 +119,7 @@ def test_icon_paths_resolve_to_packaged_faces() -> None:
     # ciao.stock/deploy (never in web/static, which the PWA build empties).
     assert Path(menubar.icon_path("face_template.png")).is_file()
     assert Path(menubar.icon_path("face_scared_template.png")).is_file()
+    assert Path(menubar.icon_path("Ciaobot.icns")).is_file()
 
 
 def test_menubar_template_icons_are_packaged() -> None:
@@ -197,9 +198,21 @@ def test_read_open_chats_filters_archived_and_sorts_by_activity(tmp_path: Path) 
         json.dumps(
             {
                 "chats": {
-                    "old": {"title": "Old", "archived": False, "last_activity_at": 1.0},
-                    "new": {"title": "New", "archived": False, "last_activity_at": 9.0},
-                    "gone": {"title": "Gone", "archived": True, "last_activity_at": 99.0},
+                    "old": {
+                        "title": "Old",
+                        "archived": False,
+                        "last_activity_at": "2026-01-01T10:00:00",
+                    },
+                    "new": {
+                        "title": "New",
+                        "archived": False,
+                        "last_activity_at": "2026-01-02T10:00:00",
+                    },
+                    "gone": {
+                        "title": "Gone",
+                        "archived": True,
+                        "last_activity_at": "2026-12-31T10:00:00",
+                    },
                 }
             }
         ),
@@ -210,6 +223,62 @@ def test_read_open_chats_filters_archived_and_sorts_by_activity(tmp_path: Path) 
 
     assert [chat.chat_id for chat in chats] == ["new", "old"]
     assert chats[0].title == "New"
+
+
+def test_chat_is_unread_matches_pwa_logic() -> None:
+    assert menubar.chat_is_unread(
+        {"last_activity_at": "2026-01-02T10:00:00", "last_read_at": "2026-01-01T10:00:00"}
+    )
+    assert not menubar.chat_is_unread(
+        {"last_activity_at": "2026-01-01T10:00:00", "last_read_at": "2026-01-02T10:00:00"}
+    )
+    assert not menubar.chat_is_unread(
+        {
+            "archived": True,
+            "last_activity_at": "2026-01-02T10:00:00",
+            "last_read_at": "",
+        }
+    )
+
+
+def test_read_unread_chats_filters_read_and_sorts_by_activity(tmp_path: Path) -> None:
+    state = tmp_path / ".runtime" / "web_projects.json"
+    state.parent.mkdir(parents=True)
+    state.write_text(
+        json.dumps(
+            {
+                "chats": {
+                    "read": {
+                        "title": "Read",
+                        "last_activity_at": "2026-01-03T10:00:00",
+                        "last_read_at": "2026-01-03T11:00:00",
+                    },
+                    "unread-old": {
+                        "title": "Unread old",
+                        "last_activity_at": "2026-01-01T10:00:00",
+                        "last_read_at": "2026-01-01T09:00:00",
+                    },
+                    "unread-new": {
+                        "title": "Unread new",
+                        "last_activity_at": "2026-01-02T10:00:00",
+                        "last_read_at": "",
+                    },
+                    "archived": {
+                        "title": "Archived",
+                        "archived": True,
+                        "last_activity_at": "2026-12-31T10:00:00",
+                        "last_read_at": "",
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    unread = menubar.read_unread_chats(tmp_path)
+
+    assert [chat.chat_id for chat in unread] == ["unread-new", "unread-old"]
+    assert [chat.title for chat in unread] == ["Unread new", "Unread old"]
 
 
 def test_read_open_chats_missing_state_returns_empty(tmp_path: Path) -> None:

--- a/tests/test_transcript_discovery.py
+++ b/tests/test_transcript_discovery.py
@@ -50,7 +50,6 @@ def test_discover_archived_chats_happy_path(tmp_path: Path) -> None:
     chat1_md = chat1_provider_dir / "2026-06-10T12-00-00Z-sess1.md"
     chat1_content = (
         "---\n"
-        "type: telegram-transcript\n"
         "provider: claude\n"
         "context: Work Chat Title\n"
         "active_model: sonnet\n"
@@ -78,7 +77,6 @@ def test_discover_archived_chats_happy_path(tmp_path: Path) -> None:
     chat2_md = chat2_provider_dir / "2026-06-10T14-00-00Z-sess2.md"
     chat2_content = (
         "---\n"
-        "type: telegram-transcript\n"
         "provider: pi\n"
         "context: Personal Chat Title\n"
         "selected_model: qwen3\n"
@@ -105,7 +103,6 @@ def test_discover_archived_chats_happy_path(tmp_path: Path) -> None:
     chat3_md = chat3_provider_dir / "2026-06-10T16-00-00Z-sess3.md"
     chat3_content = (
         "---\n"
-        "type: telegram-transcript\n"
         "provider: claude\n"
         "context: Work General Chat Title\n"
         "active_model: opus\n"
@@ -222,7 +219,6 @@ def test_continue_archived_chat(tmp_path: Path) -> None:
     chat_md = chat_provider_dir / "2026-06-10T12-00-00Z-sess.md"
     chat_content = (
         "---\n"
-        "type: telegram-transcript\n"
         "provider: claude\n"
         "context: Chat to Continue\n"
         "active_model: sonnet\n"

--- a/tests/test_transcripts.py
+++ b/tests/test_transcripts.py
@@ -52,7 +52,7 @@ def test_transcript_store_archives_markdown_with_usage_totals(tmp_path: Path) ->
 
     assert archived is not None
     content = archived.read_text(encoding="utf-8")
-    assert "type: telegram-transcript" in content
+    assert "type:" not in content
     assert "turn_count: 2" in content
     assert "input_tokens: 14" in content
     assert "output_tokens: 8" in content

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-pwa",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-pwa",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
         "dompurify": "^3.4.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-pwa",
   "private": true,
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -265,7 +265,10 @@
                   </span>
                 </div>
               </div>
-              <div class="routine-model-controls">
+              <div
+                class="routine-model-controls"
+                :class="{ 'routine-model-controls--single': routineProviderValue('title_model') === 'apple' }"
+              >
                 <select
                   class="routine-select routine-select--provider"
                   :value="routineProviderValue('title_model')"
@@ -280,16 +283,22 @@
                   <option v-if="routineProviderValue('title_model') === 'custom'" value="custom">Custom model</option>
                 </select>
                 <select
+                  v-if="routineTierSelectable('title_model')"
                   class="routine-select routine-select--tier"
                   :value="routineTierValue('title_model')"
-                  :disabled="routinesSaving || !routineTierSelectable('title_model')"
+                  :disabled="routinesSaving"
                   @change="saveRoutineTier('title_model', ($event.target as HTMLSelectElement).value)"
                 >
                   <option v-for="tier in modelTiers" :key="`title-${tier.key}`" :value="tier.key">
                     {{ tier.label }}
                   </option>
                 </select>
-                <span class="routine-model-hint">{{ routineModelSummary('title_model') }}</span>
+                <span class="routine-model-hint">
+                  <template v-if="routineProviderValue('title_model') === 'apple'">
+                    Uses <a :href="APFEL_REPO_URL" target="_blank" rel="noopener">apfel</a> (Apple Intelligence CLI).
+                  </template>
+                  <template v-else>{{ routineModelSummary('title_model') }}</template>
+                </span>
               </div>
             </div>
 
@@ -391,7 +400,18 @@
             <div class="routine-row routine-row--flush">
               <div class="routine-info">
                 <span class="routine-name">Engine</span>
-                <span class="routine-detail">
+              </div>
+              <div class="routine-model-controls routine-model-controls--single">
+                <select
+                  class="routine-select"
+                  :value="routines.transcription.engine"
+                  :disabled="routinesSaving"
+                  @change="saveRoutines({ transcription_engine: ($event.target as HTMLSelectElement).value })"
+                >
+                  <option value="local">Local (free)</option>
+                  <option value="cloud" :disabled="!routines.transcription.cloud_available">Cloud (OpenAI)</option>
+                </select>
+                <span class="routine-model-hint">
                   <template v-if="routines.transcription.engine === 'local'">
                     Dictation runs on-device via mlx-whisper (<code>{{ routines.transcription.local_model }}</code>).
                     The first transcription downloads the model.
@@ -401,15 +421,6 @@
                   </template>
                 </span>
               </div>
-              <select
-                class="routine-select"
-                :value="routines.transcription.engine"
-                :disabled="routinesSaving"
-                @change="saveRoutines({ transcription_engine: ($event.target as HTMLSelectElement).value })"
-              >
-                <option value="local">Local (free)</option>
-                <option value="cloud" :disabled="!routines.transcription.cloud_available">Cloud (OpenAI)</option>
-              </select>
             </div>
             <p v-if="!routines.transcription.local_available" class="hint hint--warn voice-warning">
               <span v-if="routines.transcription.engine === 'local'">
@@ -1522,6 +1533,8 @@ type TierProviderKey = Exclude<AliasProviderKey, 'claude'>
 type TierKey = 'haiku' | 'sonnet' | 'opus'
 type RoutineModelKey = 'title_model' | 'insights_model'
 type RoutineProviderValue = 'automatic' | 'apple' | 'custom' | AliasProviderKey
+
+const APFEL_REPO_URL = 'https://github.com/Arthur-Ficial/apfel'
 type AliasProviderSection = {
   key: AliasProviderKey
   label: string
@@ -3562,6 +3575,9 @@ async function doPackageUpdate() {
   gap: 8px;
   align-items: start;
 }
+.routine-model-controls--single {
+  grid-template-columns: 1fr;
+}
 .routine-model-controls .routine-select {
   max-width: none;
   min-width: 0;
@@ -3574,6 +3590,20 @@ async function doPackageUpdate() {
   font-size: var(--text-xs);
   line-height: 1.35;
   overflow-wrap: anywhere;
+}
+.routine-model-hint code {
+  font-size: var(--text-xs);
+  padding: 1px 4px;
+  border-radius: 3px;
+  background: var(--bg);
+  color: var(--fg);
+}
+.routine-model-hint a {
+  color: var(--accent);
+  text-decoration: underline;
+}
+.routine-model-hint a:hover {
+  color: var(--accent2);
 }
 .setting-row,
 .credential-row {

--- a/web/src/components/__tests__/mountSmoke.test.ts
+++ b/web/src/components/__tests__/mountSmoke.test.ts
@@ -475,10 +475,13 @@ describe('component mount smoke', () => {
     await flushPromises()
     await nextTick()
 
+    // title_model (0) and insights_model (1) each carry a provider select;
+    // the title tier select is hidden for tier-less providers (apple/automatic),
+    // so scope the tier lookup to the insights block rather than a fixed index.
+    const controls = wrapper.findAll('.routine-model-controls')
     const providerSelects = wrapper.findAll('.routine-model-controls .routine-select--provider')
-    const tierSelects = wrapper.findAll('.routine-model-controls .routine-select--tier')
     expect(providerSelects.length).toBeGreaterThanOrEqual(2)
-    expect(tierSelects.length).toBeGreaterThanOrEqual(2)
+    const insightsControls = controls[1]
 
     await providerSelects[1].setValue('openrouter')
     await flushPromises()
@@ -486,7 +489,9 @@ describe('component mount smoke', () => {
       insights_model: 'anthropic/claude-haiku-4.5',
     })
 
-    await tierSelects[1].setValue('opus')
+    const insightsTier = insightsControls.find('.routine-select--tier')
+    expect(insightsTier.exists()).toBe(true)
+    await insightsTier.setValue('opus')
     await flushPromises()
     expect(api.patch).toHaveBeenLastCalledWith('/api/settings/routines', {
       insights_model: 'anthropic/claude-opus-4.8',


### PR DESCRIPTION
## Summary
- Prepare Ciaobot v0.4.4
- Update package, PWA, and package-lock versions
- Add changelog notes for the release range

## Release notes
## v0.4.4 - 2026-07-07

### Added
- feat: add `ciao setup-url` and print login URL + PATH hint after setup (`500ab24`)
- feat: menu bar Notifications submenu lists unread chats, matching the PWA bell (`de20c4b`)
- feat: tidy routine model settings for tier-less providers (`b87c602`)

### Changed
- refactor: drop Telegram-specific labels from archived transcripts (`a7bbe06`)

## Testing
- pytest tests/
- cd web && npm run test
- cd web && npm run build
- ciao package-smoke --skip-frontend

## After approval
- Merge this PR
- Create and push tag `v0.4.4`
- Publish the package artifact from the tagged commit
