### PR TITLE
Release v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.4.5 - 2026-07-08
+
+### Added
+- feat: menubar update/notifications and shared pane title styling (`4dd52bc`)
+- feat: menubar unread dots on chats and icon badge count (`1e06395`)
+
+### Changed
+- Remove dispatch_schedules gate and improve schedule run-now UX. (`15f18e5`)
+- Show workspace tags on menubar open-chat entries. (`f0b3c9e`)
+- Ship gws skills as stock and document Google Workspace setup in the PWA. (`c3832e9`)
+- Make background subagent work visible in the PWA. (`0017f94`)
+- Merge pull request #40 from raffaelefarinaro/remove-dispatch-schedules-flag (`29e0a61`)
+
+### Fixed
+- Fix schedule running state and finish dispatch_schedules cleanup. (`d3f790b`)
+
 ## v0.4.4 - 2026-07-07
 
 ### Added

--- a/ciao/__init__.py
+++ b/ciao/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.4"
+__version__ = "0.4.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciaobot"
-version = "0.4.4"
+version = "0.4.5"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-pwa",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-pwa",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
         "dompurify": "^3.4.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-pwa",
   "private": true,
-  "version": "0.4.4",
+  "version": "0.4.5",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Prepare Ciaobot v0.4.5
- Update package, PWA, and package-lock versions
- Add changelog notes for the release range

## Release notes
## v0.4.5 - 2026-07-08

### Added
- feat: menubar update/notifications and shared pane title styling (`4dd52bc`)
- feat: menubar unread dots on chats and icon badge count (`1e06395`)

### Changed
- Remove dispatch_schedules gate and improve schedule run-now UX. (`15f18e5`)
- Show workspace tags on menubar open-chat entries. (`f0b3c9e`)
- Ship gws skills as stock and document Google Workspace setup in the PWA. (`c3832e9`)
- Make background subagent work visible in the PWA. (`0017f94`)
- Merge pull request #40 from raffaelefarinaro/remove-dispatch-schedules-flag (`29e0a61`)

### Fixed
- Fix schedule running state and finish dispatch_schedules cleanup. (`d3f790b`)

## Testing
- pytest tests/
- cd web && npm run test
- cd web && npm run build
- ciao package-smoke --skip-frontend

## After approval
- Merge this PR
- Create and push tag `v0.4.5`
- Publish the package artifact from the tagged commit
