### PR TITLE
Anchor SubagentPanel before the completion notice

### DIFF
--- a/ciao/web/static/index.html
+++ b/ciao/web/static/index.html
@@ -13,7 +13,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-180.png" />
     <title>Ciaobot</title>
-    <script type="module" crossorigin src="/assets/index-wGBlmZM3.js"></script>
+    <script type="module" crossorigin src="/assets/index-DKGaqapE.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-Dv6rjITN.css">
   </head>
   <body>

--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -1613,6 +1613,14 @@ async function copyMessageText(text: string, key: string): Promise<void> {
   }
 }
 
+// System bubbles produced by _summarize_task_notification (routes_api.py)
+// announce a subagent completion ("🤖 Subagent completed: ..." / "🤖 Agent
+// \"X\" completed"). renderItems uses them as the chronological anchor for
+// the dispatching turn's SubagentPanel.
+function isSubagentCompletionNotice(content: string): boolean {
+  return /^\u{1F916} (Subagent|Agent\b)/u.test(content.trim())
+}
+
 // Subagent activity lines are tagged with the leading turnstile arrow by the
 // store's tool_use handler when an event arrives with parent_tool_use_id set.
 // Used to indent and de-emphasize them so the trace reads "parent → subagent
@@ -1821,6 +1829,12 @@ const renderItems = computed<RenderItem[]>(() => {
       && msg.tool_name !== '_filecard'
     ) {
       flushTurn()
+      // A subagent-completion notice marks where the background work ended:
+      // flush the dispatching turn's activity panel just before it so the
+      // chat reads chronologically (dispatch reply → subagent activity →
+      // completion notice → report) instead of dumping the panel after the
+      // report at the end of the turn.
+      if (isSubagentCompletionNotice(msg.content)) flushSubagents()
       items.push({ kind: 'system', msg })
     } else {
       // assistant text, _activity tool block, _thinking note, or _filecard:


### PR DESCRIPTION
The subagent activity panel is grouped by dispatching turn, so in a single-turn chat it rendered at the very bottom — below the "🤖 Subagent completed" notice and the final report that chronologically follow the subagent's work.

`renderItems` now flushes the dispatching turn's panel just before the task-notification system bubble (produced by `_summarize_task_notification`), so the chat reads top-to-bottom in the order things actually happened:

dispatch reply → **subagent activity** → completion notice → report

Panels for still-running agents keep the previous behavior (end of the dispatching turn, near the composer, where the live feed belongs).

Testing: `npm run build` clean, `npx vitest run` 63 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)