### PR TITLE
Nest live SubagentPanel inside the Working trace

### DIFF
--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -286,7 +286,7 @@
           <span v-if="liveTraceMeta" class="trace-meta">{{ liveTraceMeta }}</span>
         </div>
         <div
-          v-if="liveTraceOpen && (store.currentTimeline.length || store.currentStreamingText || store.currentStreamingThinking)"
+          v-if="liveTraceOpen && (store.currentTimeline.length || store.currentStreamingText || store.currentStreamingThinking || liveSubagents.length)"
           class="trace-body"
         >
           <template v-for="(entry, j) in store.currentTimeline" :key="j">
@@ -329,6 +329,10 @@
             v-html="renderMarkdown(store.currentStreamingThinking)"
           ></div>
           <div v-if="store.currentStreamingText" class="trace-text trace-streaming" v-html="renderMarkdown(store.currentStreamingText)"></div>
+          <!-- Agents dispatched by the in-flight turn: their full transcripts
+               nest here while streaming; on result they re-anchor into the
+               timeline (renderItems handles the completed-turn placement). -->
+          <SubagentPanel v-if="liveSubagents.length" :subagents="liveSubagents" />
         </div>
         </div>
 
@@ -1731,7 +1735,7 @@ function fileCardIcon(filePath: string): string {
   return '\u{1F4C4}'  // 📄
 }
 
-const renderItems = computed<RenderItem[]>(() => {
+const renderData = computed<{ items: RenderItem[]; liveSubs: SubagentTranscript[] }>(() => {
   const items: RenderItem[] = []
   let buffer: ChatMessage[] = []
 
@@ -1843,6 +1847,13 @@ const renderItems = computed<RenderItem[]>(() => {
     }
   }
   flushTurn(true)
+  // While streaming, the in-flight turn's panels (plus anything unanchored)
+  // nest inside the live "Working..." trace instead of floating as timeline
+  // items; they re-anchor via the completed-turn path once the result lands.
+  if (store.isStreaming) {
+    const liveSubs = [...subsByTurn.values()].flat().concat(unanchoredSubs)
+    return { items, liveSubs }
+  }
   flushSubagents()
   // Anything still unplaced (turn not in history yet, or no turn info):
   // show after the last turn rather than dropping it.
@@ -1850,8 +1861,11 @@ const renderItems = computed<RenderItem[]>(() => {
   if (leftovers.length) {
     items.push({ kind: 'subagents', subs: leftovers })
   }
-  return items
+  return { items, liveSubs: [] }
 })
+
+const renderItems = computed<RenderItem[]>(() => renderData.value.items)
+const liveSubagents = computed<SubagentTranscript[]>(() => renderData.value.liveSubs)
 
 // Watcher: keep highlights in sync with the pending list and message DOM.
 watch(

--- a/web/src/stores/projects.ts
+++ b/web/src/stores/projects.ts
@@ -287,20 +287,21 @@ export const useProjectStore = defineStore('projects', () => {
     backgroundAgents.value[activeChatId.value || ''] || 0
   )
 
-  // Live view while background subagents run: refresh the active chat's
-  // subagent transcripts on a short interval so the panel updates as the
-  // agents work. The CLI appends to the transcript files continuously, so
-  // polling the REST endpoint is enough for a near-live feed. The interval
-  // only exists while the active chat has running agents.
+  // Live view while subagents run: refresh the active chat's subagent
+  // transcripts on a short interval so the panel updates as the agents
+  // work. The CLI appends to the transcript files continuously, so polling
+  // the REST endpoint is enough for a near-live feed. Runs while the active
+  // chat has running background agents OR is streaming a turn (agents
+  // dispatched mid-turn nest live inside the Working trace).
   let subagentPollTimer: ReturnType<typeof setInterval> | null = null
   watch(
-    () => [activeChatId.value, activeBackgroundAgents.value] as const,
-    ([chatId, count]) => {
+    () => [activeChatId.value, activeBackgroundAgents.value, isStreaming.value] as const,
+    ([chatId, count, streamingNow]) => {
       if (subagentPollTimer !== null) {
         clearInterval(subagentPollTimer)
         subagentPollTimer = null
       }
-      if (!chatId || count <= 0) return
+      if (!chatId || (count <= 0 && !streamingNow)) return
       subagentPollTimer = setInterval(() => {
         void loadSubagents(chatId)
       }, 4000)


### PR DESCRIPTION
While a turn is streaming, the subagent activity panel floated *above* the live "Working..." block, because its anchor — the completed turn — doesn't exist yet.

- The in-flight turn's panel (plus anything unanchored) now renders as the last row inside the live trace body, right after the streaming text and the ↳ subagent activity lines. Once the result lands it re-anchors into the timeline via the completed-turn path (PR #42).
- Subagent transcript polling now also runs while the active chat is streaming (previously only when `backgroundAgents > 0`, which is only known after the turn ends), so the nested view updates live as the agent works.

Testing: `npm run build` clean, `npx vitest run` 63 passed.

Note: this PR contains only the two-file frontend change — it was split hunk-by-hunk away from unrelated in-progress work in the shared checkout (live token/elapsed meta), which remains uncommitted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)