### PR TITLE
Release v0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - feat(web): first-run product tour overlay (`f257f41`)
 - feat(voice): read messages aloud with cloud (OpenAI) or local (Kokoro) TTS (`44e26b7`)
 - feat(settings): add open-source card linking to the GitHub repo (`6b12104`)
+- feat(web): product tour missing-state hints and toast UX polish (`245ad2d`)
 
 ### Changed
 - Anchor the SubagentPanel before the completion notice, not after the report. (`18bb2ef`)
@@ -23,6 +24,7 @@
 - polish(settings): tidy routine-context layout, drop redundant hint (`455ac28`)
 - polish(settings): explain how to change the main workspace path (`18359e4`)
 - refactor(prompt): move Ciaobot system instructions into system_prompt.md (`828ea3d`)
+- polish(settings): label local title engine, fix select chevron spacing (`6b200b3`)
 
 ### Fixed
 - fix(dag,skillevo): record non-OK node status + write stubs for under-cap no-proposal skills (`bc01710`)
@@ -36,6 +38,7 @@
 - docs(readme): illustrate chat annotations and pinned files with screenshots (`863990b`)
 - test(models): align model-bucket expectation with -latest alias defaults (`72094d7`)
 - chore(web): refresh bundled index.html from the latest PWA build (`e5eb2cf`)
+- docs(readme): condense the install/setup-wizard walkthrough (`3b42be5`)
 
 ## v0.4.5 - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## v0.4.6 - 2026-07-08
+
+### Added
+- feat(skills): add GWS workflow, persona, and recipe skill library (`1eef488`)
+- feat(deps): surface available dependency updates from PyPI and npm (`c4e6062`)
+- feat(release): update the Homebrew tap formula on publish (`1d1b7b9`)
+- feat(chat): live token count and elapsed time in the Working trace (`4e09d5b`)
+- feat(web): first-run product tour overlay (`f257f41`)
+- feat(voice): read messages aloud with cloud (OpenAI) or local (Kokoro) TTS (`44e26b7`)
+- feat(settings): add open-source card linking to the GitHub repo (`6b12104`)
+
+### Changed
+- Anchor the SubagentPanel before the completion notice, not after the report. (`18bb2ef`)
+- Merge pull request #42 from raffaelefarinaro/subagent-panel-placement (`fe99de0`)
+- Emit localhost chat links so live updates work. (`563f3e1`)
+- Nest the live SubagentPanel inside the Working trace while streaming. (`4cfce88`)
+- Nest the live SubagentPanel inside the Working trace while streaming. (`9e4c3b6`)
+- Merge pull request #43 from raffaelefarinaro/subagent-live-nesting (`de8d699`)
+- Merge remote-tracking branch 'origin/main' into subagent-panel-live-nesting (`fd8bb91`)
+- release: regenerate gws-* stock skills from the gws CLI (`1fa2fef`)
+- polish(settings): tidy routine-context layout, drop redundant hint (`455ac28`)
+- polish(settings): explain how to change the main workspace path (`18359e4`)
+- refactor(prompt): move Ciaobot system instructions into system_prompt.md (`828ea3d`)
+
+### Fixed
+- fix(dag,skillevo): record non-OK node status + write stubs for under-cap no-proposal skills (`bc01710`)
+- fix(schedules): wait for background subagents before auto-archive + robust classifier routing (`ec86289`)
+- fix(settings): keep instruction expand chevron off the left edge (`c394a42`)
+
+### Maintenance
+- docs(readme): position Ciaobot for knowledge work and credit upstream tools (`d02bff7`)
+- chore(models): default OpenRouter tiers to anthropic -latest aliases (`2bb4b38`)
+- chore(models): move remaining OpenRouter defaults to -latest aliases (`c01b3cd`)
+- docs(readme): illustrate chat annotations and pinned files with screenshots (`863990b`)
+- test(models): align model-bucket expectation with -latest alias defaults (`72094d7`)
+- chore(web): refresh bundled index.html from the latest PWA build (`e5eb2cf`)
+
 ## v0.4.5 - 2026-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -82,17 +82,14 @@ python3.13 -m venv ~/.ciaobot-venv
 ~/.ciaobot-venv/bin/ciao run
 ```
 
-Then open `http://localhost:8443`: with no configured workspace the server starts in bootstrap mode and the setup wizard walks you through choosing the workspace folder (default `~/ciaobot`) — one root folder that holds your second brain (`memory-vault/`) alongside app data (config, `.env`, runtime state, chat metadata) — plus provider choice, before anything is created. Starting from scratch scaffolds the vault inside that folder; you can also point Ciaobot at an existing notes folder elsewhere and it adapts it into the vault structure. When you finish, it writes the config, scaffolds the vault, and (on macOS) renders the LaunchAgents and `Ciaobot.app`. Setup makes sure the workspace folder is one git repository (running `git init` with a `.gitignore` that keeps `.env` and runtime state out of commits) so snapshots and sync work from the start; an existing notes folder outside the workspace gets its own repo with a minimal `.gitignore` for OS/editor litter.
+Then open `http://localhost:8443` and follow the setup wizard. It asks for two things before creating anything:
 
-For scripted or headless setups, `ciao setup --workspace <dir>` pre-creates a workspace with defaults and skips the wizard. It prints the resolved workspace, the localhost login URL to open, and — since the CLI lives in a venv that is not on your `PATH` — an `export PATH=…` hint if you want to type `ciao` instead of the full `~/.ciaobot-venv/bin/ciao` path.
+- **Workspace folder** (default `~/ciaobot`) — one root folder holding your second brain (`memory-vault/`) plus app config and runtime state. Start from scratch and it scaffolds the vault, or point it at an existing notes folder and it adapts it.
+- **Model provider** — which of the supported providers to use.
 
-If the app or menu bar ever opens an `?setup=…` URL that returns `invalid setup token` (the token is one-time-use and deleted on first login), mint a fresh one and print the URL to open:
+The wizard then writes the config, initializes the workspace as a git repository (with a `.gitignore` that keeps `.env` and runtime state out of commits, so snapshots and sync work from day one), and on macOS installs the LaunchAgents and `Ciaobot.app`.
 
-```bash
-~/.ciaobot-venv/bin/ciao setup-url --workspace <dir>
-```
-
-Pass `--no-rotate` to print the existing token's URL instead of minting a new one. The `Workspace:` line it prints is the workspace whose token the running server validates against — if it does not match the folder holding your data, the server is serving a different workspace.
+For scripted or headless setups, `ciao setup --workspace <dir>` skips the wizard and prints the login URL to open. If a setup link ever returns `invalid setup token` (tokens are one-time-use), print a fresh one with `~/.ciaobot-venv/bin/ciao setup-url --workspace <dir>`.
 
 ## Quickstart (from source)
 

--- a/ciao/__init__.py
+++ b/ciao/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"

--- a/ciao/web/static/index.html
+++ b/ciao/web/static/index.html
@@ -13,8 +13,8 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-180.png" />
     <title>Ciaobot</title>
-    <script type="module" crossorigin src="/assets/index-_TjNBvIb.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-Dv6rjITN.css">
+    <script type="module" crossorigin src="/assets/index-DyaKqyJh.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-DDpVIVK5.css">
   </head>
   <body>
     <div id="app"></div>

--- a/ciao/web/static/index.html
+++ b/ciao/web/static/index.html
@@ -13,7 +13,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-180.png" />
     <title>Ciaobot</title>
-    <script type="module" crossorigin src="/assets/index-BMsA4Uu-.js"></script>
+    <script type="module" crossorigin src="/assets/index-_TjNBvIb.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-Dv6rjITN.css">
   </head>
   <body>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciaobot"
-version = "0.4.5"
+version = "0.4.6"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
 requires-python = ">=3.12"
 license = "Apache-2.0"
 dependencies = [
-  "claude-agent-sdk==0.2.111",
+  "claude-agent-sdk==0.2.113",
   "openai==2.44.0",
   "starlette==0.52.1",
   "uvicorn[standard]==0.50.2",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-pwa",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-pwa",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
         "dompurify": "^3.4.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-pwa",
   "private": true,
-  "version": "0.4.5",
+  "version": "0.4.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/components/InAppToast.vue
+++ b/web/src/components/InAppToast.vue
@@ -4,9 +4,14 @@
       v-for="t in store.toasts"
       :key="t.id"
       class="toast"
-      :class="{ 'toast-error': t.variant === 'error' }"
+      :class="{ 'toast-error': t.variant === 'error', 'toast-swiping': swipeId === t.id }"
+      :style="swipeId === t.id ? swipeStyle : undefined"
       role="status"
       @click="onClick(t)"
+      @pointerdown="onPointerDown(t, $event)"
+      @pointermove="onPointerMove($event)"
+      @pointerup="onPointerUp(t)"
+      @pointercancel="onPointerUp(t)"
     >
       <div class="toast-title">{{ t.title }}</div>
       <div class="toast-body">{{ t.body }}</div>
@@ -25,12 +30,56 @@
 </template>
 
 <script setup lang="ts">
+import { computed, ref } from 'vue'
 import { useProjectStore } from '../stores/projects'
 import type { InAppToast } from '../lib/types'
 
 const store = useProjectStore()
 
+// ── Swipe-to-dismiss ────────────────────────────────────────────────────────
+// Horizontal drag past a threshold dismisses the toast. Tracked per-toast so
+// only the one under the finger moves. A movement threshold before we treat a
+// gesture as a swipe keeps plain taps (which open the linked chat) working.
+const SWIPE_DISMISS_PX = 80
+const swipeId = ref<number | null>(null)
+const swipeStartX = ref(0)
+const swipeDX = ref(0)
+const swiping = ref(false)
+
+const swipeStyle = computed(() => ({
+  transform: `translateX(${swipeDX.value}px)`,
+  opacity: String(Math.max(0, 1 - Math.abs(swipeDX.value) / (SWIPE_DISMISS_PX * 2))),
+}))
+
+function onPointerDown(toast: InAppToast, e: PointerEvent) {
+  if (e.pointerType === 'mouse' && e.button !== 0) return
+  swipeId.value = toast.id
+  swipeStartX.value = e.clientX
+  swipeDX.value = 0
+  swiping.value = false
+  ;(e.currentTarget as HTMLElement).setPointerCapture?.(e.pointerId)
+}
+
+function onPointerMove(e: PointerEvent) {
+  if (swipeId.value === null) return
+  swipeDX.value = e.clientX - swipeStartX.value
+  if (Math.abs(swipeDX.value) > 6) swiping.value = true
+}
+
+function onPointerUp(toast: InAppToast) {
+  if (swipeId.value === null) return
+  const dismissed = Math.abs(swipeDX.value) >= SWIPE_DISMISS_PX
+  swipeId.value = null
+  swipeDX.value = 0
+  if (dismissed) store.dismissToast(toast.id)
+}
+
 async function onClick(toast: InAppToast) {
+  // Ignore the click that fires at the end of a swipe gesture.
+  if (swiping.value) {
+    swiping.value = false
+    return
+  }
   // Global error toasts aren't tied to a chat — clicking the body is a no-op
   // (use the Fix / dismiss buttons instead).
   if (!toast.chat_id) return
@@ -74,6 +123,16 @@ async function onFix(toast: InAppToast) {
   position: relative;
   pointer-events: auto;
   animation: toast-in 180ms var(--ease);
+  /* Horizontal swipe-to-dismiss; keep vertical scroll gestures to the page. */
+  touch-action: pan-y;
+  transition: transform 200ms var(--ease), opacity 200ms var(--ease);
+}
+
+/* While the finger is down the transform tracks the pointer directly. */
+.toast-swiping {
+  transition: none;
+  cursor: grabbing;
+  user-select: none;
 }
 
 .toast:hover { background: var(--bg3); }

--- a/web/src/components/ProductTour.vue
+++ b/web/src/components/ProductTour.vue
@@ -25,6 +25,7 @@
         <div class="product-tour-progress">{{ tour.progressLabel }}</div>
         <h2 class="product-tour-title">{{ tour.currentStep.title }}</h2>
         <p class="product-tour-body">{{ tour.currentStep.body }}</p>
+        <p v-if="showMissingHint" class="product-tour-missing">{{ tour.currentStep.missingHint }}</p>
         <div class="product-tour-actions">
           <button type="button" class="product-tour-skip" @click="tour.skip()">Skip tour</button>
           <div class="product-tour-nav">
@@ -50,11 +51,32 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useProductTourStore } from '../stores/productTour'
-import { tourTargetSelector } from '../lib/productTour'
+import { useProjectStore } from '../stores/projects'
+import { shouldShowMissingHint, tourTargetSelector } from '../lib/productTour'
 
 const tour = useProductTourStore()
+const projectStore = useProjectStore()
 
 const targetRect = ref<DOMRect | null>(null)
+
+const targetFound = computed(() => {
+  const step = tour.currentStep
+  if (!step?.target || step.placement === 'center') return true
+  return targetRect.value !== null
+})
+
+const showMissingHint = computed(() => {
+  const step = tour.currentStep
+  if (!step) return false
+  return shouldShowMissingHint(
+    step,
+    {
+      hasActiveChat: !!projectStore.activeChat,
+      projectCount: projectStore.workspaceProjects.length,
+    },
+    targetFound.value,
+  )
+})
 
 const isCentered = computed(() => {
   const step = tour.currentStep
@@ -228,6 +250,18 @@ onBeforeUnmount(() => {
   font-size: var(--text-sm);
   color: var(--fg2);
   line-height: 1.45;
+}
+
+.product-tour-missing {
+  margin: -6px 0 14px;
+  padding: 8px 10px;
+  font-size: var(--text-sm);
+  color: var(--fg2);
+  line-height: 1.45;
+  background: color-mix(in srgb, var(--accent2) 8%, var(--bg-elev));
+  border: 1px solid var(--border-strong);
+  border-left: 3px solid var(--accent2);
+  border-radius: var(--radius-sm);
 }
 
 .product-tour-actions {

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -310,7 +310,7 @@
                   @change="saveRoutineProvider('title_model', ($event.target as HTMLSelectElement).value)"
                 >
                   <option value="automatic">Automatic</option>
-                  <option value="apple">Apple Intelligence</option>
+                  <option value="apple">Local (free)</option>
                   <option v-for="provider in aliasProviderSections" :key="provider.key" :value="provider.key">
                     {{ provider.label }}
                   </option>
@@ -329,7 +329,7 @@
                 </select>
                 <span class="routine-model-hint">
                   <template v-if="routineProviderValue('title_model') === 'apple'">
-                    Uses <a :href="APFEL_REPO_URL" target="_blank" rel="noopener">apfel</a> (Apple Intelligence CLI).
+                    Runs on-device for free via <a :href="APFEL_REPO_URL" target="_blank" rel="noopener">apfel</a> (Apple Intelligence CLI).
                   </template>
                   <template v-else>{{ routineModelSummary('title_model') }}</template>
                 </span>
@@ -1619,7 +1619,8 @@ const hasDeployError = computed(() => {
     'complete',
     'waiting',
     'reloading',
-    'cancelled by user'
+    'cancelled by user',
+    'synced with remote'
   ]
   const val = actionResult.value.toLowerCase()
   return !successOrPending.some(str => val.includes(str))
@@ -1711,8 +1712,7 @@ async function saveRoutines(patch: Record<string, string>) {
   routinesResult.value = ''
   try {
     routines.value = await api.patch<RoutineSettings>('/api/settings/routines', patch)
-    routinesResult.value = 'Saved.'
-    setTimeout(() => { routinesResult.value = '' }, 2000)
+    notifySaved('Model settings saved.')
   } catch (e: any) {
     routinesResult.value = `Error: ${e?.message || e}`
   } finally {
@@ -1982,7 +1982,7 @@ function routineModelSummary(key: RoutineModelKey): string {
   if (provider === 'automatic') {
     return `Automatic: ${routineEffectiveModel(key) || 'default'}`
   }
-  if (provider === 'apple') return 'Apple Intelligence'
+  if (provider === 'apple') return 'Local (free)'
   if (provider === 'custom') return `Custom: ${routineCustomModel(key)}`
   const tier = routineTierValue(key)
   const model = tierModelForProvider(provider, tier)
@@ -2171,8 +2171,7 @@ async function saveAutoUpdateGithubSkills() {
     if (providerKeys.value) {
       providerKeys.value = res
     }
-    autoUpdateResult.value = 'Saved.'
-    setTimeout(() => { autoUpdateResult.value = '' }, 2000)
+    notifySaved('Saved.')
   } catch (e: any) {
     autoUpdateResult.value = `Error: ${e?.message || e}`
     autoUpdateGithubSkills.value = !autoUpdateGithubSkills.value
@@ -2497,7 +2496,8 @@ async function saveSubagent(agent: SubagentAsset) {
       description: editSubagentDescription.value.trim(),
       content: editSubagentContent.value.trim(),
     })
-    assetLifecycleResult.value = `Saved ${agent.name}. Restart or sync Claude Code sessions to pick it up.`
+    assetLifecycleResult.value = ''
+    notifySaved(`Saved ${agent.name}. Restart or sync Claude Code sessions to pick it up.`, 'Subagent')
     cancelEditSubagent()
     await fetchAgentAssets()
   } catch (e: any) {
@@ -2516,7 +2516,8 @@ async function deleteSubagent(agent: SubagentAsset) {
   assetLifecycleError.value = false
   try {
     await api.del(`/api/agent-assets/subagents/${encodeURIComponent(agent.name)}`)
-    assetLifecycleResult.value = `Deleted ${agent.name}. Restart or sync Claude Code sessions to pick it up.`
+    assetLifecycleResult.value = ''
+    notifySaved(`Deleted ${agent.name}. Restart or sync Claude Code sessions to pick it up.`, 'Subagent')
     if (editingSubagent.value === agent.name) cancelEditSubagent()
     await fetchAgentAssets()
   } catch (e: any) {
@@ -2555,7 +2556,8 @@ async function saveCommand(command: CommandAsset) {
       argument_hint: editCommandArgumentHint.value.trim(),
       content: editCommandContent.value.trim(),
     })
-    assetLifecycleResult.value = `Saved /${command.name}. Restart or sync Claude Code sessions to pick it up.`
+    assetLifecycleResult.value = ''
+    notifySaved(`Saved /${command.name}. Restart or sync Claude Code sessions to pick it up.`, 'Command')
     cancelEditCommand()
     await Promise.all([fetchAgentAssets(), fetchCommands()])
   } catch (e: any) {
@@ -2574,7 +2576,8 @@ async function deleteCommand(command: CommandAsset) {
   assetLifecycleError.value = false
   try {
     await api.del(`/api/agent-assets/commands/${encodeURIComponent(command.name)}`)
-    assetLifecycleResult.value = `Deleted /${command.name}. Restart or sync Claude Code sessions to pick it up.`
+    assetLifecycleResult.value = ''
+    notifySaved(`Deleted /${command.name}. Restart or sync Claude Code sessions to pick it up.`, 'Command')
     if (editingCommand.value === command.name) cancelEditCommand()
     await Promise.all([fetchAgentAssets(), fetchCommands()])
   } catch (e: any) {
@@ -2734,6 +2737,13 @@ function isStandalone(): boolean {
 
 // ── Workspaces settings (Workspaces tab) ───────────────────────────────────
 const projectStore = useProjectStore()
+
+// Transient success feedback. Routes through the app-wide in-app toast (the
+// same auto-dismissing popup used for routine/chat notifications) instead of
+// leaving persistent inline text under the form.
+function notifySaved(body: string, title = 'Settings') {
+  projectStore.pushToast({ chat_id: '', title, body })
+}
 const workspacesLoaded = ref(false)
 const workspacesError = ref('')
 const workspacesSaving = ref<string | null>(null)
@@ -2900,13 +2910,12 @@ async function saveWorkspace(name: string) {
       disallowed_tools: disallowedToolsPayload(form.disallowed_tools),
       claude_ai_mcps: claudeAiMcpsPayload(form.claude_ai_mcps),
     })
-    workspacesResult.value = `Workspace "${name}" saved.`
+    notifySaved(`Workspace "${name}" saved.`, 'Workspaces')
     await fetchWorkspacesList()
   } catch (e: any) {
     workspacesResult.value = `Error: ${e?.message || e}`
   } finally {
     workspacesSaving.value = null
-    setTimeout(() => { if (workspacesResult.value.startsWith('Workspace')) workspacesResult.value = '' }, 3000)
   }
 }
 
@@ -2929,7 +2938,7 @@ async function createNewWorkspace() {
       disallowed_tools: disallowedToolsPayload(form.disallowed_tools),
       claude_ai_mcps: claudeAiMcpsPayload(form.claude_ai_mcps),
     })
-    workspacesResult.value = `Workspace "${form.name.trim()}" created.`
+    notifySaved(`Workspace "${form.name.trim()}" created.`, 'Workspaces')
     showNewWorkspace.value = false
     newWorkspaceForm.value = blankWorkspaceForm()
     await fetchWorkspacesList()
@@ -2937,7 +2946,6 @@ async function createNewWorkspace() {
     workspacesResult.value = `Error: ${e?.message || e}`
   } finally {
     workspacesSaving.value = null
-    setTimeout(() => { if (workspacesResult.value.startsWith('Workspace')) workspacesResult.value = '' }, 3000)
   }
 }
 
@@ -3679,6 +3687,19 @@ async function doPackageUpdate() {
 }
 .routine-input::placeholder {
   color: var(--fg3);
+}
+.routine-select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  padding-right: 30px;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'><path d='M2.5 4.5L6 8l3.5-3.5' fill='none' stroke='%23888' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  background-size: 12px 12px;
+}
+.routine-select::-ms-expand {
+  display: none;
 }
 .routine-context {
   display: flex;

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -2429,13 +2429,11 @@ async function addSubagent() {
       description: newSubagentDescription.value.trim(),
       prompt: newSubagentPrompt.value.trim(),
     })
-    addSubagentResult.value = `Created ${res.path}`
+    addSubagentResult.value = ''
+    notifySaved(`Created ${res.path}`, 'Subagent')
     resetSubagentForm(false)
+    showAddSubagent.value = false
     await fetchAgentAssets()
-    setTimeout(() => {
-      showAddSubagent.value = false
-      addSubagentResult.value = ''
-    }, 2000)
   } catch (e: any) {
     addSubagentError.value = true
     addSubagentResult.value = `Error: ${e?.message || e}`
@@ -2456,13 +2454,11 @@ async function addCommand() {
       argument_hint: newCommandArgumentHint.value.trim(),
       prompt: newCommandPrompt.value.trim(),
     })
-    addCommandResult.value = `Created ${res.path}`
+    addCommandResult.value = ''
+    notifySaved(`Created ${res.path}`, 'Command')
     resetCommandForm(false)
+    showAddCommand.value = false
     await Promise.all([fetchAgentAssets(), fetchCommands()])
-    setTimeout(() => {
-      showAddCommand.value = false
-      addCommandResult.value = ''
-    }, 2000)
   } catch (e: any) {
     addCommandError.value = true
     addCommandResult.value = `Error: ${e?.message || e}`
@@ -2614,14 +2610,12 @@ async function addGithubSkill() {
       skill: githubSkillName.value.trim() || undefined,
     })
     if (res.ok) {
-      addGithubSkillResult.value = res.message || 'Skill added successfully.'
+      addGithubSkillResult.value = ''
+      notifySaved(res.message || 'Skill added successfully.', 'Skills')
       githubSource.value = ''
       githubSkillName.value = ''
+      showAddGithubSkill.value = false
       await fetchSkills()
-      setTimeout(() => {
-        showAddGithubSkill.value = false
-        addGithubSkillResult.value = ''
-      }, 2000)
     } else {
       addGithubSkillError.value = true
       addGithubSkillResult.value = res.error || 'Failed to add skill.'
@@ -2955,13 +2949,12 @@ async function removeWorkspace(name: string) {
   workspacesResult.value = ''
   try {
     await projectStore.deleteWorkspace(name)
-    workspacesResult.value = `Workspace "${name}" deleted.`
+    notifySaved(`Workspace "${name}" deleted.`, 'Workspaces')
     await fetchWorkspacesList()
   } catch (e: any) {
     workspacesResult.value = `Error: ${e?.message || e}`
   } finally {
     workspacesSaving.value = null
-    setTimeout(() => { if (workspacesResult.value.startsWith('Workspace')) workspacesResult.value = '' }, 3000)
   }
 }
 

--- a/web/src/lib/productTour.test.ts
+++ b/web/src/lib/productTour.test.ts
@@ -7,6 +7,7 @@ import {
   clearTourCompleted,
   isTourCompleted,
   markTourCompleted,
+  shouldShowMissingHint,
   tourTargetSelector,
 } from './productTour'
 
@@ -35,5 +36,18 @@ describe('productTour', () => {
 
   it('builds data-tour selectors', () => {
     expect(tourTargetSelector('chat-input')).toBe('[data-tour="chat-input"]')
+  })
+
+  it('shows missing hints when chat UI or projects are unavailable', () => {
+    const modelStep = PRODUCT_TOUR_STEPS.find(s => s.id === 'model')!
+    const fileStep = PRODUCT_TOUR_STEPS.find(s => s.id === 'file-cards')!
+    const projectsStep = PRODUCT_TOUR_STEPS.find(s => s.id === 'projects')!
+
+    expect(shouldShowMissingHint(modelStep, { hasActiveChat: false, projectCount: 1 }, false)).toBe(true)
+    expect(shouldShowMissingHint(modelStep, { hasActiveChat: true, projectCount: 1 }, true)).toBe(false)
+    expect(shouldShowMissingHint(fileStep, { hasActiveChat: false, projectCount: 1 }, true)).toBe(true)
+    expect(shouldShowMissingHint(fileStep, { hasActiveChat: true, projectCount: 1 }, true)).toBe(false)
+    expect(shouldShowMissingHint(projectsStep, { hasActiveChat: true, projectCount: 0 }, true)).toBe(true)
+    expect(shouldShowMissingHint(projectsStep, { hasActiveChat: true, projectCount: 2 }, true)).toBe(false)
   })
 })

--- a/web/src/lib/productTour.ts
+++ b/web/src/lib/productTour.ts
@@ -8,10 +8,32 @@ export interface ProductTourStep {
   id: string
   title: string
   body: string
+  /** Shown when the UI for this step is not available yet (no chat open, empty list, etc.). */
+  missingHint?: string
   /** Matches a `data-tour` attribute on a visible element. Omit for centered cards. */
   target?: string
   placement?: TourPlacement
   beforeEnter?: TourBeforeEnter[]
+}
+
+export type TourAvailabilityContext = {
+  hasActiveChat: boolean
+  projectCount: number
+}
+
+export function shouldShowMissingHint(
+  step: ProductTourStep,
+  ctx: TourAvailabilityContext,
+  targetFound: boolean,
+): boolean {
+  if (!step.missingHint) return false
+  if (step.target) {
+    if (!targetFound) return true
+    if (step.id === 'projects' && ctx.projectCount === 0) return true
+    return false
+  }
+  if (step.beforeEnter?.includes('welcomeChat') && !ctx.hasActiveChat) return true
+  return false
 }
 
 export const PRODUCT_TOUR_STEPS: ProductTourStep[] = [
@@ -30,6 +52,8 @@ export const PRODUCT_TOUR_STEPS: ProductTourStep[] = [
     target: 'sidebar-workspaces',
     placement: 'right',
     beforeEnter: ['openSidebar', 'chatRoute'],
+    missingHint:
+      'You will see workspace tabs in the sidebar once the main view is open. A default personal/work split is created on first launch.',
   },
   {
     id: 'projects',
@@ -39,6 +63,8 @@ export const PRODUCT_TOUR_STEPS: ProductTourStep[] = [
     target: 'sidebar-projects',
     placement: 'right',
     beforeEnter: ['openSidebar', 'chatRoute'],
+    missingHint:
+      'You will see projects listed here after setup — a General project is created automatically for each workspace.',
   },
   {
     id: 'schedules',
@@ -48,6 +74,7 @@ export const PRODUCT_TOUR_STEPS: ProductTourStep[] = [
     target: 'nav-schedules',
     placement: 'bottom',
     beforeEnter: ['openSidebar', 'chatRoute'],
+    missingHint: 'You will find the Schedules shortcut in the sidebar header once the sidebar is open.',
   },
   {
     id: 'model',
@@ -57,6 +84,7 @@ export const PRODUCT_TOUR_STEPS: ProductTourStep[] = [
     target: 'model-picker',
     placement: 'bottom',
     beforeEnter: ['welcomeChat', 'chatRoute'],
+    missingHint: 'Open a chat from the sidebar — the model picker appears in the chat header.',
   },
   {
     id: 'chat-comments',
@@ -66,6 +94,7 @@ export const PRODUCT_TOUR_STEPS: ProductTourStep[] = [
     target: 'chat-messages',
     placement: 'top',
     beforeEnter: ['welcomeChat', 'chatRoute'],
+    missingHint: 'Open a chat to see messages here, then select text to add a comment.',
   },
   {
     id: 'chat-input',
@@ -75,6 +104,7 @@ export const PRODUCT_TOUR_STEPS: ProductTourStep[] = [
     target: 'chat-input',
     placement: 'top',
     beforeEnter: ['welcomeChat', 'chatRoute'],
+    missingHint: 'Open a chat from the sidebar — the message box sits at the bottom of the chat view.',
   },
   {
     id: 'file-cards',
@@ -83,6 +113,8 @@ export const PRODUCT_TOUR_STEPS: ProductTourStep[] = [
       'When the agent reads or edits a file, an inline card appears in the thread. Click it to open a preview with history, diff, and restore.',
     placement: 'center',
     beforeEnter: ['welcomeChat', 'chatRoute'],
+    missingHint:
+      'You will see inline file cards in the chat thread once the agent reads or edits a file.',
   },
   {
     id: 'pin-preview',
@@ -91,6 +123,8 @@ export const PRODUCT_TOUR_STEPS: ProductTourStep[] = [
       'From the file viewer, pin a document to keep it open beside the chat. Select text in the preview to add line-level comments — they are attached to your next message, same as chat comments.',
     placement: 'center',
     beforeEnter: ['welcomeChat', 'chatRoute'],
+    missingHint:
+      'Open a file from a chat card, then use Pin in the viewer to keep it open beside the conversation.',
   },
   {
     id: 'rich-preview',
@@ -99,6 +133,8 @@ export const PRODUCT_TOUR_STEPS: ProductTourStep[] = [
       'Images render inline in chat and in the viewer. PDFs open in a built-in preview. PowerPoint (.pptx) files are converted to PDF for viewing (requires LibreOffice on the server).',
     placement: 'center',
     beforeEnter: ['welcomeChat', 'chatRoute'],
+    missingHint:
+      'You will see image and PDF previews once files show up in a chat or the file viewer.',
   },
   {
     id: 'done',


### PR DESCRIPTION
## Summary
- Prepare Ciaobot v0.4.6
- Update package, PWA, and package-lock versions
- Add changelog notes for the release range

## Release notes
## v0.4.6 - 2026-07-08

### Added
- feat(skills): add GWS workflow, persona, and recipe skill library (`1eef488`)
- feat(deps): surface available dependency updates from PyPI and npm (`c4e6062`)
- feat(release): update the Homebrew tap formula on publish (`1d1b7b9`)
- feat(chat): live token count and elapsed time in the Working trace (`4e09d5b`)
- feat(web): first-run product tour overlay (`f257f41`)
- feat(voice): read messages aloud with cloud (OpenAI) or local (Kokoro) TTS (`44e26b7`)
- feat(settings): add open-source card linking to the GitHub repo (`6b12104`)

### Changed
- Anchor the SubagentPanel before the completion notice, not after the report. (`18bb2ef`)
- Merge pull request #42 from raffaelefarinaro/subagent-panel-placement (`fe99de0`)
- Emit localhost chat links so live updates work. (`563f3e1`)
- Nest the live SubagentPanel inside the Working trace while streaming. (`4cfce88`)
- Nest the live SubagentPanel inside the Working trace while streaming. (`9e4c3b6`)
- Merge pull request #43 from raffaelefarinaro/subagent-live-nesting (`de8d699`)
- Merge remote-tracking branch 'origin/main' into subagent-panel-live-nesting (`fd8bb91`)
- release: regenerate gws-* stock skills from the gws CLI (`1fa2fef`)
- polish(settings): tidy routine-context layout, drop redundant hint (`455ac28`)
- polish(settings): explain how to change the main workspace path (`18359e4`)
- refactor(prompt): move Ciaobot system instructions into system_prompt.md (`828ea3d`)

### Fixed
- fix(dag,skillevo): record non-OK node status + write stubs for under-cap no-proposal skills (`bc01710`)
- fix(schedules): wait for background subagents before auto-archive + robust classifier routing (`ec86289`)
- fix(settings): keep instruction expand chevron off the left edge (`c394a42`)

### Maintenance
- docs(readme): position Ciaobot for knowledge work and credit upstream tools (`d02bff7`)
- chore(models): default OpenRouter tiers to anthropic -latest aliases (`2bb4b38`)
- chore(models): move remaining OpenRouter defaults to -latest aliases (`c01b3cd`)
- docs(readme): illustrate chat annotations and pinned files with screenshots (`863990b`)
- test(models): align model-bucket expectation with -latest alias defaults (`72094d7`)
- chore(web): refresh bundled index.html from the latest PWA build (`e5eb2cf`)

## Testing
- pytest tests/
- cd web && npm run test
- cd web && npm run build
- ciao package-smoke --skip-frontend

## After approval
- Merge this PR
- Create and push tag `v0.4.6`
- Publish the package artifact from the tagged commit
