### PR TITLE
release: v0.4.7 — fix Homebrew install and setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - fix(homebrew): drop the broken `require "language/python/virtualenv"` and symlink console scripts into the Homebrew prefix `bin`
 - fix(deps): declare `python-dotenv` in package dependencies (used by `ciao setup` and config loading)
 - fix(setup): register `Ciaobot.app` with LaunchServices before loading LaunchAgents so macOS shows "Ciaobot" instead of "python" in background-activity prompts
+- fix(homebrew): install dependency wheels in `post_install`, after Homebrew's install-linkage step, so prebuilt dylibs (e.g. jiter) no longer abort the install with "Failed to fix install linkage" (`c2d8fac`)
+- fix(setup): hand the wizard-chosen workspace and port to the relaunched server, and re-exec instead of `os._exit` when restart cleanup wedges, so a foreground `ciao run` comes back configured after the setup wizard instead of dying or re-entering bootstrap (`96b5154`)
+
+### Changed
+- homebrew: replace the sandboxed (never-working) post-install auto-setup with a visible banner and caveats pointing at `ciao run` + the browser setup wizard (`d7c4a86`, `c2d8fac`)
+- docs: shorten the Homebrew install command to `raffaelefarinaro/ciaobot` and show `ciao run` as the step after `brew install` (`b43e9e1`, `f3d2f5d`)
 
 ## v0.4.6 - 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.4.7 - 2026-07-08
+
+### Fixed
+- fix(homebrew): install the wheel with its full dependency tree so `brew install` pulls claude-agent-sdk, starlette, uvicorn, and the rest of the pinned deps from PyPI
+- fix(homebrew): drop the broken `require "language/python/virtualenv"` and symlink console scripts into the Homebrew prefix `bin`
+- fix(deps): declare `python-dotenv` in package dependencies (used by `ciao setup` and config loading)
+- fix(setup): register `Ciaobot.app` with LaunchServices before loading LaunchAgents so macOS shows "Ciaobot" instead of "python" in background-activity prompts
+
 ## v0.4.6 - 2026-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -68,10 +68,11 @@ The model is project-first: a workspace represents a life area (personal, work, 
 
 Install from [PyPI](https://pypi.org/project/ciaobot/) — the wheel ships with the pre-built PWA (the same wheel is attached to each [GitHub release](https://github.com/raffaelefarinaro/ciaobot/releases/latest)):
 
-**macOS (Homebrew)** — one command, includes the menu bar companion:
+**macOS (Homebrew)** — includes the menu bar companion:
 
 ```bash
 brew install raffaelefarinaro/ciaobot
+ciao run
 ```
 
 **Any platform (pip)** — requires Python 3.12 or newer (use whichever `python3.X` you have, e.g. `brew install python@3.13`):

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Install from [PyPI](https://pypi.org/project/ciaobot/) — the wheel ships with 
 **macOS (Homebrew)** — one command, includes the menu bar companion:
 
 ```bash
-brew install raffaelefarinaro/ciaobot/ciaobot
+brew install raffaelefarinaro/ciaobot
 ```
 
 **Any platform (pip)** — requires Python 3.12 or newer (use whichever `python3.X` you have, e.g. `brew install python@3.13`):

--- a/ciao/__init__.py
+++ b/ciao/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"

--- a/ciao/cli.py
+++ b/ciao/cli.py
@@ -347,7 +347,38 @@ def _write_app_shortcut(
         encoding="utf-8",
     )
     executable.chmod(0o755)
+    _register_app_with_launchservices(app_root)
     return app_root
+
+
+_LSREGISTER = (
+    "/System/Library/Frameworks/CoreServices.framework/Frameworks/"
+    "LaunchServices.framework/Support/lsregister"
+)
+
+
+def _register_app_with_launchservices(app_root: Path) -> None:
+    """Register the launcher bundle with LaunchServices.
+
+    macOS attributes a LaunchAgent's "App Background Activity" entry to the
+    app named by the plist's ``AssociatedBundleIdentifiers``. That mapping is
+    resolved through LaunchServices, which does not always index a freshly
+    written bundle before the agent loads — so the background item shows the
+    raw executable name ("python") instead of "Ciaobot". Registering the
+    bundle up front makes the association resolve immediately. Best-effort:
+    non-macOS or a missing lsregister is a silent skip.
+    """
+
+    if sys.platform != "darwin" or not os.path.exists(_LSREGISTER):
+        return
+    try:
+        subprocess.run(
+            [_LSREGISTER, "-f", str(app_root)],
+            check=False,
+            capture_output=True,
+        )
+    except OSError:
+        pass
 
 
 _WORKSPACE_GITIGNORE_ENTRIES = (".env", ".runtime/", ".claude/", "*.log")

--- a/ciao/main.py
+++ b/ciao/main.py
@@ -527,13 +527,22 @@ async def _async_main() -> int:
         # asyncio.run's cleanup phase (cancel tasks, shut down the default
         # executor) can wedge after uvicorn drains: leaked Claude SDK
         # subprocess transports and synchronous urllib calls in the
-        # heartbeat thread both hold the loop open indefinitely. The bash
-        # wrapper then sits in `wait` forever and the service appears alive
-        # but is unreachable. If we haven't exited cleanly within the grace
-        # window, force it so the wrapper sees the exit code and restarts.
+        # heartbeat thread both hold the loop open indefinitely. The service
+        # then appears alive but is unreachable. If we haven't exited cleanly
+        # within the grace window, force the restart ourselves: a plain
+        # os._exit would leave a foreground `ciao run` dead right after the
+        # setup wizard or a package update (only launchd's KeepAlive would
+        # bring the server back). Exec a fresh interpreter instead — the pid
+        # is unchanged, so launchd keeps tracking it, and the relaunch picks
+        # up new code and the current environment (e.g. the CIAO_WORKSPACE
+        # handoff written by the setup wizard's finish step).
         def _force_exit() -> None:
             time.sleep(15)
-            os._exit(code)
+            logger.info("Cleanup did not finish; re-execing for the requested restart")
+            try:
+                os.execv(sys.executable, [sys.executable, "-m", "ciao.cli", *sys.argv[1:]])
+            except OSError:
+                os._exit(code)
         threading.Thread(
             target=_force_exit, daemon=True, name="ciao-restart-watchdog"
         ).start()

--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -3332,6 +3332,12 @@ async def setup_finish_endpoint(request: Request) -> JSONResponse:
         launch_agents_dir=str(body.get("launch_agents_dir", "")).strip() or None,
         app_dir=str(body.get("app_dir", "")).strip() or None,
     )
+    # Hand the chosen workspace to the relaunched process. A foreground
+    # `ciao run` restarts by re-execing itself with the current environment,
+    # and nothing else tells the fresh process where setup landed — without
+    # this it boots straight back into the bootstrap wizard.
+    os.environ["CIAO_WORKSPACE"] = str(Path(workspace).expanduser().resolve())
+    os.environ["PWA_PORT"] = str(port)
     # Best-effort: bring the menu bar companion up right away so setup ends
     # with the icon visible instead of waiting for the next login. Only for
     # the real per-user LaunchAgents dir — scripted/test setups pass a custom

--- a/deploy/homebrew/ciaobot.rb
+++ b/deploy/homebrew/ciaobot.rb
@@ -24,10 +24,10 @@ class Ciaobot < Formula
 
   def post_install
     workspace = ENV.fetch("CIAO_WORKSPACE", File.expand_path("~/ciaobot"))
-    setup_command = "#{bin}/ciao setup --workspace #{workspace}"
+    setup_command = "ciao setup --workspace #{workspace}"
 
     unless ciao_gui_session?
-      ohai "Ciaobot installed. Open Terminal and run `#{setup_command}` to finish."
+      ohai "Next step: run `#{setup_command}` to finish setup (see `brew info ciaobot`)."
       return
     end
 
@@ -37,8 +37,8 @@ class Ciaobot < Formula
            "--python", "#{libexec}/bin/python",
            "--load-launchd"
   rescue StandardError => e
-    opoo "Ciaobot installed, but automatic setup did not complete: #{e.message}"
-    opoo "Open Terminal and run `#{setup_command}` to finish."
+    opoo "Automatic setup did not complete: #{e.message}"
+    opoo "Run `#{setup_command}` to finish setup."
   end
 
   def ciao_gui_session?
@@ -49,6 +49,22 @@ class Ciaobot < Formula
     system "/bin/launchctl", "print", "gui/#{Process.uid}",
            out: File::NULL,
            err: File::NULL
+  end
+
+  def caveats
+    <<~CAVEATS
+      To finish setting up Ciaobot, run:
+
+        ciao setup --workspace ~/ciaobot
+
+      This scaffolds the workspace, installs the Ciaobot menu bar app and
+      background server, starts it, and prints a link to open Ciaobot at
+      http://localhost:8443 (macOS may run this automatically on install).
+
+      Afterwards, open Ciaobot anytime from the menu bar icon or
+      /Applications/Ciaobot.app. To use a different folder (for example an
+      existing notes folder), change the --workspace path above.
+    CAVEATS
   end
 
   test do

--- a/deploy/homebrew/ciaobot.rb
+++ b/deploy/homebrew/ciaobot.rb
@@ -1,21 +1,25 @@
-require "language/python/virtualenv"
-
 class Ciaobot < Formula
   include Language::Python::Virtualenv
 
   desc "Local-first personal assistant server"
   homepage "https://github.com/raffaelefarinaro/ciaobot"
-  url "https://github.com/raffaelefarinaro/ciaobot/releases/download/v0.4.5/ciaobot-0.4.5-py3-none-any.whl"
-  version "0.4.5"
-  sha256 "33efb3656d245e76866022def0283dc8eba52f204b5c0fc3028f2c4bd9aaa0ee"
+  url "https://github.com/raffaelefarinaro/ciaobot/releases/download/v0.4.7/ciaobot-0.4.7-py3-none-any.whl"
+  version "0.4.7"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
   license "Apache-2.0"
 
   depends_on "python@3.12"
 
   def install
     python = Formula["python@3.12"].opt_bin/"python3.12"
-    venv = virtualenv_create(libexec, python)
-    venv.pip_install buildpath.glob("ciaobot-*.whl").first
+    virtualenv_create(libexec, python)
+    # Install the wheel *with* its dependency tree. Homebrew's
+    # `virtualenv` `pip_install` helpers pass --no-deps (they expect every
+    # dependency vendored as a `resource`); this app has none, so use pip
+    # directly and let it resolve the pinned deps from PyPI at install time.
+    system libexec/"bin/python", "-m", "pip", "install",
+           buildpath.glob("ciaobot-*.whl").first
+    bin.install_symlink Dir[libexec/"bin/ciao*"]
   end
 
   def post_install

--- a/deploy/homebrew/ciaobot.rb
+++ b/deploy/homebrew/ciaobot.rb
@@ -13,57 +13,56 @@ class Ciaobot < Formula
   def install
     python = Formula["python@3.12"].opt_bin/"python3.12"
     virtualenv_create(libexec, python)
-    # Install the wheel *with* its dependency tree. Homebrew's
-    # `virtualenv` `pip_install` helpers pass --no-deps (they expect every
-    # dependency vendored as a `resource`); this app has none, so use pip
-    # directly and let it resolve the pinned deps from PyPI at install time.
-    system libexec/"bin/python", "-m", "pip", "install",
+    # Install only the app wheel here; it is pure Python, so Homebrew's
+    # install-linkage step finds no Mach-O files to rewrite. The dependency
+    # tree is installed in post_install: prebuilt wheels such as jiter ship
+    # dylibs with @rpath install names and no Mach-O header padding, and the
+    # linkage fixer aborts on them ("Failed to fix install linkage").
+    system libexec/"bin/python", "-m", "pip", "install", "--no-deps",
            buildpath.glob("ciaobot-*.whl").first
     bin.install_symlink Dir[libexec/"bin/ciao*"]
   end
 
   def post_install
-    workspace = ENV.fetch("CIAO_WORKSPACE", File.expand_path("~/ciaobot"))
-    setup_command = "ciao setup --workspace #{workspace}"
+    # Resolve the app's pinned dependency tree from PyPI now, after the
+    # install-linkage step has run, so dependency wheels keep their dylib
+    # install names as built (wheels are self-contained and need no rewrite).
+    # The app itself is already installed, so pip only adds what is missing.
+    system libexec/"bin/python", "-m", "pip", "install", "ciaobot==#{version}"
 
-    unless ciao_gui_session?
-      ohai "Next step: run `#{setup_command}` to finish setup (see `brew info ciaobot`)."
-      return
-    end
+    # Setup cannot run here: Homebrew's post-install sandbox blocks launchctl
+    # and fakes HOME. Point the user at the browser setup wizard instead.
+    puts <<~BANNER
 
-    system bin/"ciao",
-           "setup",
-           "--workspace", workspace,
-           "--python", "#{libexec}/bin/python",
-           "--load-launchd"
-  rescue StandardError => e
-    opoo "Automatic setup did not complete: #{e.message}"
-    opoo "Run `#{setup_command}` to finish setup."
-  end
+      ##############################################################
+      #                                                            #
+      #   Ciaobot is installed! To finish setup, run:              #
+      #                                                            #
+      #       ciao run                                             #
+      #                                                            #
+      #   then open http://localhost:8443 in your browser and      #
+      #   follow the setup wizard.                                 #
+      #                                                            #
+      ##############################################################
 
-  def ciao_gui_session?
-    return false if ENV["CI"]
-    return false if ENV["SSH_CONNECTION"] || ENV["SSH_TTY"]
-    return false if ENV["HOMEBREW_CIAOBOT_SKIP_SETUP"]
-
-    system "/bin/launchctl", "print", "gui/#{Process.uid}",
-           out: File::NULL,
-           err: File::NULL
+    BANNER
   end
 
   def caveats
     <<~CAVEATS
       To finish setting up Ciaobot, run:
 
-        ciao setup --workspace ~/ciaobot
+        ciao run
 
-      This scaffolds the workspace, installs the Ciaobot menu bar app and
-      background server, starts it, and prints a link to open Ciaobot at
-      http://localhost:8443 (macOS may run this automatically on install).
+      and open http://localhost:8443 in your browser. The setup wizard asks
+      for a workspace folder (default ~/ciaobot) and a model provider, then
+      writes the config and installs the Ciaobot menu bar app and background
+      server. Afterwards, open Ciaobot anytime from the menu bar icon or
+      /Applications/Ciaobot.app.
 
-      Afterwards, open Ciaobot anytime from the menu bar icon or
-      /Applications/Ciaobot.app. To use a different folder (for example an
-      existing notes folder), change the --workspace path above.
+      For scripted or headless setups, skip the wizard with:
+
+        ciao setup --workspace <dir>
     CAVEATS
   end
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -46,7 +46,7 @@ No manual step is needed; `ensure-deps.sh` handles both. If you set up the venv 
 macOS users can install from the [homebrew-ciaobot](https://github.com/raffaelefarinaro/homebrew-ciaobot) tap:
 
 ```bash
-brew install raffaelefarinaro/ciaobot/ciaobot
+brew install raffaelefarinaro/ciaobot
 ```
 
 The formula template lives in `deploy/homebrew/ciaobot.rb`. Regenerate it with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciaobot"
-version = "0.4.6"
+version = "0.4.7"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -15,6 +15,7 @@ dependencies = [
   "starlette==0.52.1",
   "uvicorn[standard]==0.50.2",
   "itsdangerous==2.2.0",
+  "python-dotenv==1.2.2",
   "pyyaml==6.0.3",
   "pywebpush==2.3.0",
   "cryptography==49.0.0",

--- a/scripts/update-homebrew-tap.sh
+++ b/scripts/update-homebrew-tap.sh
@@ -29,8 +29,6 @@ fi
 WHEEL_URL="https://github.com/raffaelefarinaro/ciaobot/releases/download/v${VERSION}/ciaobot-${VERSION}-py3-none-any.whl"
 
 cat >"$FORMULA_PATH" <<EOF
-require "language/python/virtualenv"
-
 class Ciaobot < Formula
   include Language::Python::Virtualenv
 
@@ -45,8 +43,14 @@ class Ciaobot < Formula
 
   def install
     python = Formula["python@3.12"].opt_bin/"python3.12"
-    venv = virtualenv_create(libexec, python)
-    venv.pip_install buildpath.glob("ciaobot-*.whl").first
+    virtualenv_create(libexec, python)
+    # Install the wheel *with* its dependency tree. Homebrew's
+    # \`virtualenv\` \`pip_install\` helpers pass --no-deps (they expect every
+    # dependency vendored as a \`resource\`); this app has none, so use pip
+    # directly and let it resolve the pinned deps from PyPI at install time.
+    system libexec/"bin/python", "-m", "pip", "install",
+           buildpath.glob("ciaobot-*.whl").first
+    bin.install_symlink Dir[libexec/"bin/ciao*"]
   end
 
   def post_install

--- a/scripts/update-homebrew-tap.sh
+++ b/scripts/update-homebrew-tap.sh
@@ -55,10 +55,10 @@ class Ciaobot < Formula
 
   def post_install
     workspace = ENV.fetch("CIAO_WORKSPACE", File.expand_path("~/ciaobot"))
-    setup_command = "#{bin}/ciao setup --workspace #{workspace}"
+    setup_command = "ciao setup --workspace #{workspace}"
 
     unless ciao_gui_session?
-      ohai "Ciaobot installed. Open Terminal and run \`#{setup_command}\` to finish."
+      ohai "Next step: run \`#{setup_command}\` to finish setup (see \`brew info ciaobot\`)."
       return
     end
 
@@ -68,8 +68,8 @@ class Ciaobot < Formula
            "--python", "#{libexec}/bin/python",
            "--load-launchd"
   rescue StandardError => e
-    opoo "Ciaobot installed, but automatic setup did not complete: #{e.message}"
-    opoo "Open Terminal and run \`#{setup_command}\` to finish."
+    opoo "Automatic setup did not complete: #{e.message}"
+    opoo "Run \`#{setup_command}\` to finish setup."
   end
 
   def ciao_gui_session?
@@ -80,6 +80,22 @@ class Ciaobot < Formula
     system "/bin/launchctl", "print", "gui/#{Process.uid}",
            out: File::NULL,
            err: File::NULL
+  end
+
+  def caveats
+    <<~CAVEATS
+      To finish setting up Ciaobot, run:
+
+        ciao setup --workspace ~/ciaobot
+
+      This scaffolds the workspace, installs the Ciaobot menu bar app and
+      background server, starts it, and prints a link to open Ciaobot at
+      http://localhost:8443 (macOS may run this automatically on install).
+
+      Afterwards, open Ciaobot anytime from the menu bar icon or
+      /Applications/Ciaobot.app. To use a different folder (for example an
+      existing notes folder), change the --workspace path above.
+    CAVEATS
   end
 
   test do

--- a/scripts/update-homebrew-tap.sh
+++ b/scripts/update-homebrew-tap.sh
@@ -44,57 +44,56 @@ class Ciaobot < Formula
   def install
     python = Formula["python@3.12"].opt_bin/"python3.12"
     virtualenv_create(libexec, python)
-    # Install the wheel *with* its dependency tree. Homebrew's
-    # \`virtualenv\` \`pip_install\` helpers pass --no-deps (they expect every
-    # dependency vendored as a \`resource\`); this app has none, so use pip
-    # directly and let it resolve the pinned deps from PyPI at install time.
-    system libexec/"bin/python", "-m", "pip", "install",
+    # Install only the app wheel here; it is pure Python, so Homebrew's
+    # install-linkage step finds no Mach-O files to rewrite. The dependency
+    # tree is installed in post_install: prebuilt wheels such as jiter ship
+    # dylibs with @rpath install names and no Mach-O header padding, and the
+    # linkage fixer aborts on them ("Failed to fix install linkage").
+    system libexec/"bin/python", "-m", "pip", "install", "--no-deps",
            buildpath.glob("ciaobot-*.whl").first
     bin.install_symlink Dir[libexec/"bin/ciao*"]
   end
 
   def post_install
-    workspace = ENV.fetch("CIAO_WORKSPACE", File.expand_path("~/ciaobot"))
-    setup_command = "ciao setup --workspace #{workspace}"
+    # Resolve the app's pinned dependency tree from PyPI now, after the
+    # install-linkage step has run, so dependency wheels keep their dylib
+    # install names as built (wheels are self-contained and need no rewrite).
+    # The app itself is already installed, so pip only adds what is missing.
+    system libexec/"bin/python", "-m", "pip", "install", "ciaobot==#{version}"
 
-    unless ciao_gui_session?
-      ohai "Next step: run \`#{setup_command}\` to finish setup (see \`brew info ciaobot\`)."
-      return
-    end
+    # Setup cannot run here: Homebrew's post-install sandbox blocks launchctl
+    # and fakes HOME. Point the user at the browser setup wizard instead.
+    puts <<~BANNER
 
-    system bin/"ciao",
-           "setup",
-           "--workspace", workspace,
-           "--python", "#{libexec}/bin/python",
-           "--load-launchd"
-  rescue StandardError => e
-    opoo "Automatic setup did not complete: #{e.message}"
-    opoo "Run \`#{setup_command}\` to finish setup."
-  end
+      ##############################################################
+      #                                                            #
+      #   Ciaobot is installed! To finish setup, run:              #
+      #                                                            #
+      #       ciao run                                             #
+      #                                                            #
+      #   then open http://localhost:8443 in your browser and      #
+      #   follow the setup wizard.                                 #
+      #                                                            #
+      ##############################################################
 
-  def ciao_gui_session?
-    return false if ENV["CI"]
-    return false if ENV["SSH_CONNECTION"] || ENV["SSH_TTY"]
-    return false if ENV["HOMEBREW_CIAOBOT_SKIP_SETUP"]
-
-    system "/bin/launchctl", "print", "gui/#{Process.uid}",
-           out: File::NULL,
-           err: File::NULL
+    BANNER
   end
 
   def caveats
     <<~CAVEATS
       To finish setting up Ciaobot, run:
 
-        ciao setup --workspace ~/ciaobot
+        ciao run
 
-      This scaffolds the workspace, installs the Ciaobot menu bar app and
-      background server, starts it, and prints a link to open Ciaobot at
-      http://localhost:8443 (macOS may run this automatically on install).
+      and open http://localhost:8443 in your browser. The setup wizard asks
+      for a workspace folder (default ~/ciaobot) and a model provider, then
+      writes the config and installs the Ciaobot menu bar app and background
+      server. Afterwards, open Ciaobot anytime from the menu bar icon or
+      /Applications/Ciaobot.app.
 
-      Afterwards, open Ciaobot anytime from the menu bar icon or
-      /Applications/Ciaobot.app. To use a different folder (for example an
-      existing notes folder), change the --workspace path above.
+      For scripted or headless setups, skip the wizard with:
+
+        ciao setup --workspace <dir>
     CAVEATS
   end
 

--- a/tests/test_setup_status.py
+++ b/tests/test_setup_status.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from itsdangerous import URLSafeTimedSerializer
@@ -183,7 +184,11 @@ def test_setup_status_route_is_public_before_login(tmp_path) -> None:
     assert resp.json()["checks"][0]["id"] == "workspace"
 
 
-def test_setup_finish_writes_real_workspace_and_requests_restart(tmp_path) -> None:
+def test_setup_finish_writes_real_workspace_and_requests_restart(tmp_path, monkeypatch) -> None:
+    # Guard the env handoff assertions below: monkeypatch restores these
+    # after the endpoint mutates os.environ directly.
+    monkeypatch.setenv("CIAO_WORKSPACE", "")
+    monkeypatch.setenv("PWA_PORT", "")
     config = CiaoConfig.from_env({"CIAO_BOOTSTRAP_WORKSPACE": str(tmp_path / "boot")})
     serializer = URLSafeTimedSerializer("test-secret")
     restarts: list[int] = []
@@ -217,6 +222,10 @@ def test_setup_finish_writes_real_workspace_and_requests_restart(tmp_path) -> No
     assert body["ok"] is True
     assert body["restart_requested"] is True
     assert restarts == [config.restart_exit_code]
+    # The env handoff for the re-exec'd foreground `ciao run`: without it the
+    # relaunched process boots back into bootstrap mode.
+    assert os.environ["CIAO_WORKSPACE"] == str(workspace.resolve())
+    assert os.environ["PWA_PORT"] == "9443"
     env_text = (workspace / ".env").read_text(encoding="utf-8")
     assert f"PWA_AUTH_TOKEN={config.pwa_auth_token}" in env_text
     assert "CIAO_PUSH_CONTACT=mailto:owner@example.com" in env_text

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-pwa",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-pwa",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
         "dompurify": "^3.4.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-pwa",
   "private": true,
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Release v0.4.7. Fixes the Homebrew install end to end and the setup-wizard handoff:

- Formula installs the app wheel with `--no-deps` during `install` and resolves the dependency tree in `post_install`, after Homebrew's install-linkage step — prebuilt dylibs (jiter) no longer abort the install with "Failed to fix install linkage".
- Post-install banner and caveats point at `ciao run` + the browser setup wizard; the sandboxed auto-setup attempt (which could never run: the post-install sandbox blocks launchctl and fakes HOME) is removed.
- `POST /api/setup/finish` exports `CIAO_WORKSPACE`/`PWA_PORT` before requesting a restart, and the shutdown watchdog re-execs instead of `os._exit`, so a foreground `ciao run` comes back configured after the wizard instead of dying or looping back into bootstrap.
- `python-dotenv` declared as a dependency; `Ciaobot.app` registered with LaunchServices; README shows `ciao run` after `brew install`.

Verified: full pytest suite (965 passed), live `brew reinstall` from the patched formula (no linkage errors), and a sandboxed end-to-end run → wizard finish → same-pid relaunch → `/api/setup-status` reports "configured".

🤖 Generated with [Claude Code](https://claude.com/claude-code)