### PR TITLE
Release v0.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.9 - 2026-07-08
+
+### Fixed
+- fix(setup): pin LaunchAgents to the opt interpreter, not the Cellar keg (`16b97e6`)
+
 ## v0.4.8 - 2026-07-08
 
 ### Added

--- a/ciao/__init__.py
+++ b/ciao/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.8"
+__version__ = "0.4.9"

--- a/ciao/cli.py
+++ b/ciao/cli.py
@@ -92,6 +92,24 @@ def _write_if_missing(path: Path, text: str) -> None:
         path.write_text(text, encoding="utf-8")
 
 
+def _stable_python_path(python_path: str) -> str:
+    """Map a Homebrew Cellar interpreter to its upgrade-stable opt path.
+
+    `brew upgrade` deletes the old keg, so a LaunchAgent pinned to
+    .../Cellar/<pkg>/<version>/... dies with it (the running server loses
+    its site-packages and every request 500s until the agents are
+    re-rendered). The <prefix>/opt/<pkg> symlink always points at the
+    currently installed keg, so plists must record that instead.
+    """
+    import re
+
+    m = re.match(r"(.*)/Cellar/([^/]+)/[^/]+/(.*)$", python_path)
+    if not m:
+        return python_path
+    stable = Path(f"{m.group(1)}/opt/{m.group(2)}/{m.group(3)}")
+    return str(stable) if stable.exists() else python_path
+
+
 def _render_launchd_plist(
     *,
     workspace: Path,
@@ -100,6 +118,7 @@ def _render_launchd_plist(
     path: str = "",
     template_name: str = "com.ciao.server.plist.tmpl",
 ) -> str:
+    python_path = _stable_python_path(python_path)
     template = resources.files("ciao.stock").joinpath(
         "deploy", template_name
     ).read_text(encoding="utf-8")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciaobot"
-version = "0.4.8"
+version = "0.4.9"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_deploy_cleanup.py
+++ b/tests/test_deploy_cleanup.py
@@ -57,6 +57,51 @@ def test_render_launchd_plist_substitutes_path() -> None:
     assert "/opt/homebrew/bin:/usr/bin:/bin" in out
 
 
+def test_render_launchd_plist_maps_cellar_python_to_opt(tmp_path: Path) -> None:
+    """A Homebrew Cellar interpreter is recorded via the upgrade-stable
+    opt symlink: `brew upgrade` deletes the versioned keg, which killed the
+    LaunchAgents (and the running server) pinned to it."""
+    from ciao.cli import _render_launchd_plist
+
+    cellar_python = tmp_path / "Cellar" / "ciaobot" / "0.4.8" / "libexec" / "bin" / "python"
+    opt_python = tmp_path / "opt" / "ciaobot" / "libexec" / "bin" / "python"
+    for p in (cellar_python, opt_python):
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("", encoding="utf-8")
+
+    out = _render_launchd_plist(
+        workspace=Path("/tmp/ciao-ws"),
+        python_path=str(cellar_python),
+        port=8443,
+    )
+    assert str(opt_python) in out
+    assert "/Cellar/" not in out
+
+
+def test_render_launchd_plist_keeps_non_cellar_python(tmp_path: Path) -> None:
+    """Non-Homebrew interpreters (and Cellar paths without an opt mirror)
+    are recorded as given."""
+    from ciao.cli import _render_launchd_plist
+
+    out = _render_launchd_plist(
+        workspace=Path("/tmp/ciao-ws"),
+        python_path="/Users/me/.ciaobot-venv/bin/python",
+        port=8443,
+    )
+    assert "/Users/me/.ciaobot-venv/bin/python" in out
+
+    orphan = tmp_path / "Cellar" / "ciaobot" / "9.9.9" / "bin" / "python"
+    orphan.parent.mkdir(parents=True, exist_ok=True)
+    orphan.write_text("", encoding="utf-8")
+    out = _render_launchd_plist(
+        workspace=Path("/tmp/ciao-ws"),
+        python_path=str(orphan),
+        port=8443,
+    )
+    # No opt mirror exists for this keg: the path is left untouched.
+    assert str(orphan) in out
+
+
 def test_run_step_reports_missing_binary_as_failed_step() -> None:
     from ciao.web.routes_api import _run_step
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-pwa",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-pwa",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
         "dompurify": "^3.4.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-pwa",
   "private": true,
-  "version": "0.4.8",
+  "version": "0.4.9",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Prepare Ciaobot v0.4.9
- Update package, PWA, and package-lock versions
- Add changelog notes for the release range

## Release notes
## v0.4.9 - 2026-07-08

### Fixed
- fix(setup): pin LaunchAgents to the opt interpreter, not the Cellar keg (`16b97e6`)

## Testing
- pytest tests/
- cd web && npm run test
- cd web && npm run build
- ciao package-smoke --skip-frontend

## After approval
- Merge this PR
- Create and push tag `v0.4.9`
- Publish the package artifact from the tagged commit
