### PR TITLE
docs: use the full brew install path raffaelefarinaro/ciaobot/ciaobot

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The model is project-first: a workspace represents a life area (personal, work, 
 **macOS (Homebrew)** — includes the menu bar companion:
 
 ```bash
-brew install raffaelefarinaro/ciaobot
+brew install raffaelefarinaro/ciaobot/ciaobot
 ciao run
 ```
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -46,7 +46,7 @@ No manual step is needed; `ensure-deps.sh` handles both. If you set up the venv 
 macOS users can install from the [homebrew-ciaobot](https://github.com/raffaelefarinaro/homebrew-ciaobot) tap:
 
 ```bash
-brew install raffaelefarinaro/ciaobot
+brew install raffaelefarinaro/ciaobot/ciaobot
 ```
 
 The formula template lives in `deploy/homebrew/ciaobot.rb`. Regenerate it with:


### PR DESCRIPTION
The shortened `brew install raffaelefarinaro/ciaobot` from b43e9e1 doesn't resolve — brew needs the full tap/formula form. Fixes README and docs/DEVELOPMENT.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)