### PR TITLE
fix(push): drop dead placeholder default in PushManager

### DIFF
--- a/ciao/web/push.py
+++ b/ciao/web/push.py
@@ -26,7 +26,7 @@ def _b64url(data: bytes) -> str:
 class PushManager:
     """Persist VAPID keys + subscriptions, send Web Push notifications."""
 
-    def __init__(self, runtime_root: Path, subject: str = "mailto:admin@ciao.local") -> None:
+    def __init__(self, runtime_root: Path, subject: str = "") -> None:
         self._runtime = runtime_root
         self._runtime.mkdir(parents=True, exist_ok=True)
         self._vapid_path = runtime_root / "vapid.json"


### PR DESCRIPTION
## Summary
- `PushManager.__init__` had a leftover `subject: str = "mailto:admin@ciao.local"` default that was never actually reached — every call site (`ciao/main.py`) always passes an explicit resolved subject, either `""` (Web Push disabled) or the real operator contact.
- Changes the default to `""` so it matches the "never invent a fake default" policy already documented in `ciao/cli.py` and `ciao/main.py` for `CIAO_PUSH_CONTACT`.

## Test plan
- [x] `pytest tests/test_push_notification_log.py -q` — 3 passed
- [x] `pytest tests/ -k push -q` — 13 passed