### PR TITLE
fix(menubar): self-heal when Homebrew swaps the install out from under a running process

### DIFF
--- a/ciao/menubar.py
+++ b/ciao/menubar.py
@@ -109,6 +109,24 @@ def restart_menubar_command(uid: int | None = None) -> list[str]:
     return ["launchctl", "kickstart", "-k", f"gui/{resolved}/{MENUBAR_LAUNCHD_LABEL}"]
 
 
+def relaunch_stale_process(uid: int | None = None) -> None:
+    """Ask launchd to restart this menu bar process onto the current install.
+
+    A bundled resource (e.g. the status icon) going missing at runtime means
+    Homebrew swapped the installed version out from under this already-running
+    process — for example a bare `brew upgrade ciaobot` outside the app's own
+    Update button, followed by `brew cleanup` removing the old keg. The
+    process's already-imported ``ciao`` module keeps resolving resource paths
+    into that now-deleted directory for the rest of its life, so retrying
+    in-process can never succeed. `launchctl kickstart -k` re-resolves the
+    launchd plist's `/opt/homebrew/opt/ciaobot/...` symlink, which always
+    points at the current keg, so the relaunched process picks up the
+    current install.
+    """
+
+    subprocess.run(restart_menubar_command(uid), check=False)
+
+
 def stop_server_command(uid: int | None = None) -> list[str]:
     """Fully stop the server agent when quitting the menu bar.
 
@@ -482,7 +500,14 @@ def run_menubar(workspace: Path, port: int) -> int:
         # frames actually change frame-to-frame.
         if state["current_icon"] != path:
             state["current_icon"] = path
-            app.icon = path
+            try:
+                app.icon = path
+            except OSError:
+                # The icon file is gone from disk: see relaunch_stale_process.
+                # Fix it by relaunching rather than crash-looping on every
+                # animation frame for the rest of this process's life.
+                relaunch_stale_process()
+                os._exit(1)
 
     def on_toggle_mute(sender) -> None:
         muted = not state["banners_muted"]

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -138,6 +138,15 @@ def test_restart_menubar_command_targets_launchd_label() -> None:
     ]
 
 
+def test_relaunch_stale_process_kicks_launchd(monkeypatch) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        menubar.subprocess, "run", lambda cmd, **kwargs: calls.append(cmd)
+    )
+    menubar.relaunch_stale_process(uid=501)
+    assert calls == [["launchctl", "kickstart", "-k", "gui/501/com.ciao.menubar"]]
+
+
 def test_stop_server_command_boots_out_launchd_label() -> None:
     # bootout (not kill) because the server plist is KeepAlive=true, so a
     # plain kill would be relaunched; bootout takes it out of the domain.


### PR DESCRIPTION
## Summary
- The menu bar agent (`com.ciao.menubar`) doesn't get restarted when `ciaobot` is upgraded via a bare `brew upgrade ciaobot` (outside the app's own Update button) or by Homebrew's background auto-update.
- Once Homebrew removes the old Cellar keg, the already-running process's `_set_icon` throws `FileNotFoundError` on every animation frame trying to reload its status icon from the now-deleted path — crash-looping forever and freezing the tray menu at its last successfully-rendered state, so update banners never appear even though the server-side Settings page correctly shows one (observed in production: the process was pinned to a `0.4.7` install with the Cellar path deleted after a later upgrade to `0.4.8`).
- Fix: catch the failure in `_set_icon` and call a new `relaunch_stale_process()` helper, which runs `launchctl kickstart -k` on the menu bar's own launchd label. That re-resolves the plist's `/opt/homebrew/opt/ciaobot/...` symlink (which always points at the current keg), so the relaunched process picks up the current install instead of crash-looping on deleted files.

## Test plan
- [x] `pytest tests/test_menubar.py` — added `test_relaunch_stale_process_kicks_launchd`, all 40 pass
- [x] `pytest tests/` — full backend suite, 985 passed
- [x] Manually reproduced and fixed the live issue on this machine: found the running menu bar process pinned to a deleted `0.4.7` Cellar path, crash-looping in `ciao.menubar.stderr.log` on every refresh; `launchctl kickstart -k gui/<uid>/com.ciao.menubar` relaunched it cleanly onto the current install and the tray menu started showing the update item again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)