### PR TITLE
fix(setup): stop stock agent/command seeding from writing through symlinks

### DIFF
--- a/ciao/cli.py
+++ b/ciao/cli.py
@@ -70,7 +70,15 @@ def _copy_tree(src, dest: Path) -> None:
         if item.is_dir():
             _copy_tree(item, dest / item.name)
         else:
-            (dest / item.name).write_bytes(item.read_bytes())
+            target = dest / item.name
+            # sync-skills turns stock .claude/agents|commands entries into
+            # symlinks once a workspace promotes one to a custom copy
+            # (subagents/ or commands/). write_bytes() follows symlinks, so
+            # without this a setup re-run would silently overwrite the
+            # user's custom file through the link instead of the stock copy.
+            if target.is_symlink():
+                target.unlink()
+            target.write_bytes(item.read_bytes())
 
 
 def _copy_tree_if_missing(src, dest: Path) -> list[Path]:

--- a/tests/test_workspace_git.py
+++ b/tests/test_workspace_git.py
@@ -254,6 +254,38 @@ def test_setup_workspace_rerun_honors_existing_env_vault_root(
     assert "CIAO_VAULT_ROOT=brain-a" in env_before
 
 
+def test_setup_workspace_rerun_does_not_clobber_custom_agent_through_symlink(
+    tmp_path: Path,
+) -> None:
+    """sync-skills turns a stock .claude/agents/<name>.md entry into a
+    symlink once a workspace promotes it to a custom copy under
+    subagents/<name>.md. A setup re-run must not write the packaged stock
+    bytes through that symlink and silently overwrite the custom content."""
+    ws = tmp_path / "workspace"
+    setup_workspace(
+        ws,
+        launch_agents_dir=tmp_path / "LaunchAgents",
+        app_dir=tmp_path / "Applications",
+    )
+    installed = sorted(p.name for p in (ws / ".claude" / "agents").glob("*.md"))
+    assert installed, "setup_workspace should seed at least one stock agent"
+    name = installed[0]
+
+    custom = ws / "subagents" / name
+    custom.write_text("# custom override\n", encoding="utf-8")
+    link = ws / ".claude" / "agents" / name
+    link.unlink()
+    link.symlink_to(custom)
+
+    setup_workspace(
+        ws,
+        launch_agents_dir=tmp_path / "LaunchAgents",
+        app_dir=tmp_path / "Applications",
+    )
+
+    assert custom.read_text(encoding="utf-8") == "# custom override\n"
+
+
 def test_setup_workspace_existing_mode_adopts_folder_as_vault(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- `_copy_tree` (used to seed stock subagents/commands into `.claude/agents` and `.claude/commands` on `ciao setup`) wrote bytes via `write_bytes()`, which follows symlinks.
- Once `sync-skills` promotes a stock item to a custom copy (turns the `.claude/agents/<name>.md` entry into a symlink pointing at `subagents/<name>.md`), a setup re-run would write the packaged stock content straight through that symlink, silently clobbering the user's custom edits.
- Fix: unlink the destination first if it's a symlink, so setup always writes a fresh plain file instead of writing through an existing link.

## Test plan
- [x] Added `test_setup_workspace_rerun_does_not_clobber_custom_agent_through_symlink`, confirmed it fails without the fix (custom content gets overwritten with stock frontmatter) and passes with it.
- [x] `pytest tests/` — 985 passed.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>