### PR TITLE
fix(web): drop 'phone' from notification settings copy

### DIFF
--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -133,7 +133,7 @@
           <div class="settings-card-header">
             <p class="section-title">Notifications</p>
             <p class="hint">
-              Get a phone notification when a chat replies and the app is not focused.
+              Get a notification when a chat replies and the app is not focused.
             </p>
           </div>
           <div v-if="needsIosInstall" class="hint hint--warn">


### PR DESCRIPTION
## Summary
- Notification settings hint said "Get a phone notification..." but push notifications apply to desktop browsers too, not just phones. Changed to "Get a notification...".

## Test plan
- [ ] Visual check of Settings > Notifications card copy