### PR TITLE
fix(web): more visible working/pulse animation

### DIFF
--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -3138,15 +3138,22 @@ details[open] > .activity-summary::before {
 .activity-icon { font-size: var(--text-base); }
 
 .activity-spinner {
-  width: 10px;
-  height: 10px;
-  border: 2px solid var(--accent2);
-  border-top-color: var(--accent);
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
-  animation: spin 0.8s linear infinite;
+  background: var(--accent);
+  animation: activity-pulse 1.1s ease-in-out infinite;
 }
 
-@keyframes spin { to { transform: rotate(360deg); } }
+@keyframes activity-pulse {
+  0%, 100% { transform: scale(0.55); opacity: 0.35; }
+  50% { transform: scale(1); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .activity-spinner { animation-duration: 2.2s; }
+}
+
 @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 
 .activity-lines {

--- a/web/src/components/ProjectSidebar.vue
+++ b/web/src/components/ProjectSidebar.vue
@@ -814,30 +814,35 @@ async function confirmDeleteChat(chatId: string) {
 .brand:active { opacity: 0.7; }
 .brand--refreshing { opacity: 0.6; }
 
-/* Tiny spinning dot used inline next to project / chat names. */
+/* Pulsing dot used inline next to project / chat names to signal activity.
+   A breathing scale+opacity pulse reads as "alive" at a glance, unlike a
+   thin two-tone ring spin which is too subtle at this size to notice. */
 .spinner-dot {
   display: inline-block;
-  width: 10px;
-  height: 10px;
+  width: 8px;
+  height: 8px;
   margin-left: 6px;
-  border: 2px solid var(--accent2);
-  border-top-color: var(--accent);
   border-radius: 50%;
-  animation: ciao-spin 0.8s linear infinite;
+  background: var(--accent);
+  animation: ciao-pulse 1.1s ease-in-out infinite;
   vertical-align: middle;
   flex-shrink: 0;
 }
 
-@keyframes ciao-spin {
-  to { transform: rotate(360deg); }
+@keyframes ciao-pulse {
+  0%, 100% { transform: scale(0.55); opacity: 0.35; }
+  50% { transform: scale(1); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner-dot { animation-duration: 2.2s; }
 }
 
 /* Slower, dimmer variant: background subagents still working after the
    parent turn ended (no turn is streaming, but the chat isn't idle). */
 .spinner-dot.bg-agents {
-  border-color: var(--border);
-  border-top-color: var(--accent2);
-  animation-duration: 1.6s;
+  background: var(--accent2);
+  animation-duration: 1.8s;
 }
 
 .retry-dot {

--- a/web/src/components/SubagentPanel.vue
+++ b/web/src/components/SubagentPanel.vue
@@ -132,16 +132,20 @@ function renderMarkdown(text: string): string {
 .label { color: var(--fg2); }
 
 .running-spinner {
-  width: 10px;
-  height: 10px;
-  border: 2px solid var(--border);
-  border-top-color: var(--accent2);
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
-  animation: subagent-spin 0.9s linear infinite;
+  background: var(--accent2);
+  animation: subagent-pulse 1.1s ease-in-out infinite;
 }
 
-@keyframes subagent-spin {
-  to { transform: rotate(360deg); }
+@keyframes subagent-pulse {
+  0%, 100% { transform: scale(0.55); opacity: 0.35; }
+  50% { transform: scale(1); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .running-spinner { animation-duration: 2.2s; }
 }
 
 .status-chip {


### PR DESCRIPTION
## Summary
- The "working" indicator (small circle shown while a chat is streaming) was a 10px two-tone spin ring — at that size the rotation is barely perceptible, so it read as a static dot in screenshots and at a glance.
- Replaced it in all three places it's used with a scale+opacity breathing pulse, which is much more visibly changing:
  - `web/src/components/ProjectSidebar.vue` — `.spinner-dot` next to workspace/chat/project names
  - `web/src/components/ChatPanel.vue` — `.activity-spinner` in the live reasoning trace ("Working…"/"Thinking…")
  - `web/src/components/SubagentPanel.vue` — `.running-spinner` next to "Subagent activity"
- Kept the existing accent colors per component and added a `prefers-reduced-motion` fallback (slower pulse instead of removing motion entirely, consistent with the existing `.title-shimmer` pattern).

## Test plan
- [x] `cd web && npm run build` succeeds
- [ ] Visually confirm in the browser that the sidebar dot, chat trace spinner, and subagent panel spinner all pulse noticeably while a chat is streaming