### PR TITLE
fix(web): stop chat pane getting squeezed when a file is pinned

### DIFF
--- a/web/src/components/ChatLayout.vue
+++ b/web/src/components/ChatLayout.vue
@@ -159,8 +159,11 @@ const MIN_SIDEBAR_WIDTH = 180
 const MAX_SIDEBAR_WIDTH = 500
 const SIDEBAR_SNAP_THRESHOLD = 15 // px
 
-const DEFAULT_SPLIT_RATIO = 0.5
-const MIN_PANE_WIDTH = 360
+// Chat gets a larger guaranteed floor than the pinned-file side: it's the
+// primary reading surface, while the side panel is more often skimmed.
+const DEFAULT_SPLIT_RATIO = 0.55
+const MIN_CHAT_PANE_WIDTH = 480
+const MIN_SIDE_PANE_WIDTH = 360
 const SPLIT_SNAP_THRESHOLD = 15 // px
 const LATEST_STATUS_SYNC_MS = 15000
 
@@ -262,8 +265,8 @@ function handleSplitDrag(e: MouseEvent) {
   const clientX = e.clientX
   let newLeftWidth = clientX - dragContainerLeft
   
-  const minLeft = MIN_PANE_WIDTH
-  const maxLeft = dragContainerWidth - MIN_PANE_WIDTH
+  const minLeft = MIN_CHAT_PANE_WIDTH
+  const maxLeft = dragContainerWidth - MIN_SIDE_PANE_WIDTH
   
   if (maxLeft < minLeft) {
     chatSplitRatio.value = 0.5
@@ -637,23 +640,26 @@ onBeforeUnmount(() => {
 @keyframes fade-in { from { opacity: 0 } to { opacity: 1 } }
 
 /* Split-screen layout for pinned file viewer.
-   Both panes share the available width 50/50 (clamped to a sensible
-   minimum), so the file viewer doesn't get squeezed below ~45% on
-   wide screens the way it did when capped at 720px. */
+   Chat defaults to a larger share (55/45) and has a taller min-width floor
+   than the side panel, since the chat column is where sustained reading
+   happens; the pinned file is more often skimmed. min-width acts as a
+   hard floor so a narrow ratio persisted from a wider viewport (or a
+   drag near the limit) can never squeeze either pane below a readable
+   width. */
 .chat-split {
   flex-direction: row;
 }
 .chat-split-main {
-  width: 50%;
+  width: 55%;
   flex: 1 1 0;
-  min-width: 360px;
+  min-width: 480px;
   display: flex;
   flex-direction: column;
   min-height: 0;
   overflow: hidden;
 }
 .chat-split-side {
-  width: 50%;
+  width: 45%;
   flex: 1 1 0;
   min-width: 360px;
   border-left: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- When a file/doc is pinned open (split view), the chat pane and the file pane shared one `min-width: 360px` floor and a straight 50/50 default split.
- The split ratio is persisted to `localStorage` and never re-clamped, so a ratio dragged toward the file side (e.g. from a wider viewport, or to give a doc more room at the time) leaves the chat column pinned at ~360px on reload — too narrow for comfortable reading, especially once the file panel's own comment sidebar eats further into its share.
- Gave chat a taller floor (`480px` vs `360px` for the file side) and defaulted the split to `55/45` in chat's favor, since the chat is the primary reading surface and the pinned file is more often skimmed/referenced.
- `handleSplitDrag`'s clamp now uses the same two constants, so dragging still respects both floors correctly.

## Test plan
- [x] `cd web && npm run build` succeeds
- [ ] Open a chat, pin a file to trigger split view, drag the splitter to the far left/right and confirm neither pane can go below its floor
- [ ] Confirm the default split (no prior drag) now favors the chat column