### PR TITLE
fix(menubar): treat a no-op Homebrew/pip upgrade as a failed update

### DIFF
--- a/ciao/package_version.py
+++ b/ciao/package_version.py
@@ -268,6 +268,38 @@ def _is_homebrew_cellar_path(path: Path) -> bool:
     return "Cellar/ciaobot" in text or "Cellar/ciao/" in text
 
 
+def _brew_installed_version(brew: str) -> str:
+    """Return the Cellar version of ``ciaobot`` per Homebrew, or "" if unknown."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            [brew, "list", "--versions", "ciaobot"],
+            capture_output=True, text=True, timeout=15, check=False,
+        )
+    except Exception:
+        return ""
+    parts = result.stdout.strip().split()
+    return parts[-1] if len(parts) >= 2 else ""
+
+
+def _pip_show_version(python_exe: str) -> str:
+    """Return the installed ``ciaobot`` version per ``pip show``, or "" if unknown."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            [python_exe, "-m", "pip", "show", "ciaobot"],
+            capture_output=True, text=True, timeout=15, check=False,
+        )
+    except Exception:
+        return ""
+    for line in result.stdout.splitlines():
+        if line.startswith("Version:"):
+            return line.split(":", 1)[1].strip()
+    return ""
+
+
 def detect_install_mode() -> str:
     """Return "homebrew", "pip_venv", "editable", or "unknown"."""
     import sys
@@ -350,6 +382,8 @@ def update_package(
             "command": "git pull",
         }
 
+    before_version = ""
+    check_version: Callable[[], str] = lambda: ""
     if mode == "homebrew":
         brew = _resolve_brew()
         if not brew:
@@ -360,6 +394,8 @@ def update_package(
                 "command": "brew upgrade ciaobot",
             }
         cmd = [brew, "upgrade", "ciaobot"]
+        check_version = lambda: _brew_installed_version(brew)
+        before_version = check_version()
     elif mode == "pip_venv":
         wheel_url, error = _latest_wheel_url(opener=opener, timeout=timeout)
         if not wheel_url:
@@ -370,6 +406,8 @@ def update_package(
                 "command": manual_command,
             }
         cmd = [sys.executable, "-m", "pip", "install", "-U", wheel_url]
+        check_version = lambda: _pip_show_version(sys.executable)
+        before_version = check_version()
     else:
         return {
             "ok": False,
@@ -382,6 +420,24 @@ def update_package(
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
         output = (result.stdout.strip() + "\n" + result.stderr.strip()).strip()
         if result.returncode == 0:
+            after_version = check_version()
+            if before_version and after_version and before_version == after_version:
+                # Exit 0 doesn't mean an upgrade happened: e.g. Homebrew reports
+                # success and no-ops when the tap formula hasn't caught up yet
+                # with the GitHub release the update banner is checking against,
+                # so the version never advances and the banner never clears.
+                return {
+                    "ok": False,
+                    "mode": mode,
+                    "error": (
+                        f"Still on {after_version} after running the upgrade — the "
+                        "package source has no newer version available yet. If "
+                        "this keeps happening, the release may not have "
+                        "propagated to it; try again shortly."
+                    ),
+                    "output": output,
+                    "command": " ".join(cmd),
+                }
             return {
                 "ok": True,
                 "mode": mode,

--- a/tests/test_package_update.py
+++ b/tests/test_package_update.py
@@ -71,20 +71,45 @@ def test_update_package_homebrew_upgrade(monkeypatch) -> None:
     monkeypatch.setattr("ciao.package_version.detect_install_mode", lambda: "homebrew")
     monkeypatch.setattr("ciao.package_version._resolve_brew", lambda: "/opt/homebrew/bin/brew")
 
-    captured: dict[str, list[str]] = {}
+    calls: list[list[str]] = []
 
     def fake_run(cmd, **kwargs):
-        captured["cmd"] = cmd
+        calls.append(cmd)
         result = MagicMock()
-        result.stdout = "ciaobot 0.4.6"
         result.stderr = ""
         result.returncode = 0
+        if cmd[1:] == ["upgrade", "ciaobot"]:
+            result.stdout = "==> Upgrading ciaobot"
+        else:
+            upgraded = any(c[1:] == ["upgrade", "ciaobot"] for c in calls[:-1])
+            result.stdout = "ciaobot 0.4.7" if upgraded else "ciaobot 0.4.6"
         return result
 
     monkeypatch.setattr("subprocess.run", fake_run)
     res = update_package()
     assert res["ok"] is True
-    assert captured["cmd"] == ["/opt/homebrew/bin/brew", "upgrade", "ciaobot"]
+    assert ["/opt/homebrew/bin/brew", "upgrade", "ciaobot"] in calls
+
+
+def test_update_package_homebrew_noop_reports_failure(monkeypatch) -> None:
+    # brew upgrade can exit 0 without installing anything when the tap
+    # formula hasn't caught up with the GitHub release yet — that must not
+    # be reported as a successful update (it would restart the app for
+    # nothing and leave the "update available" banner stuck forever).
+    monkeypatch.setattr("ciao.package_version.detect_install_mode", lambda: "homebrew")
+    monkeypatch.setattr("ciao.package_version._resolve_brew", lambda: "/opt/homebrew/bin/brew")
+
+    def fake_run(cmd, **kwargs):
+        result = MagicMock()
+        result.stderr = ""
+        result.returncode = 0
+        result.stdout = "Warning: ciaobot 0.4.6 already installed" if cmd[1:] == ["upgrade", "ciaobot"] else "ciaobot 0.4.6"
+        return result
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    res = update_package()
+    assert res["ok"] is False
+    assert "0.4.6" in res["error"]
 
 
 def test_update_package_homebrew_without_brew(monkeypatch) -> None:
@@ -120,24 +145,59 @@ def test_update_package_pip_venv_installs_release_wheel(monkeypatch) -> None:
         ],
     })
 
-    mock_run = MagicMock()
-    mock_run.stdout = "Successfully installed ciao-0.3.0"
-    mock_run.stderr = ""
-    mock_run.returncode = 0
-
-    captured: dict[str, list[str]] = {}
+    install_cmd = [sys.executable, "-m", "pip", "install", "-U", wheel_url]
+    calls: list[list[str]] = []
 
     def fake_run(cmd, **kwargs):
-        captured["cmd"] = cmd
-        return mock_run
+        calls.append(cmd)
+        result = MagicMock()
+        result.stderr = ""
+        result.returncode = 0
+        if cmd == install_cmd:
+            result.stdout = "Successfully installed ciao-0.3.0"
+        else:
+            upgraded = any(c == install_cmd for c in calls[:-1])
+            result.stdout = "Version: 0.3.0" if upgraded else "Version: 0.2.0"
+        return result
 
     monkeypatch.setattr("subprocess.run", fake_run)
     res = update_package(opener=opener)
     assert res["ok"] is True
-    assert captured["cmd"] == [sys.executable, "-m", "pip", "install", "-U", wheel_url]
+    assert install_cmd in calls
     assert wheel_url in res["command"]
     assert "pip install -U ciao" not in res["command"].replace(wheel_url, "")
     assert "Successfully installed ciao-0.3.0" in res["output"]
+
+
+def test_update_package_pip_venv_noop_reports_failure(monkeypatch) -> None:
+    # `pip install -U <wheel>` exits 0 without reinstalling when the same
+    # version is already present — that must surface as a failed update
+    # rather than a restart that leaves the banner stuck.
+    monkeypatch.setattr("ciao.package_version.detect_install_mode", lambda: "pip_venv")
+
+    wheel_url = (
+        "https://github.com/raffaelefarinaro/ciaobot/releases/download/"
+        "v0.3.0/ciao-0.3.0-py3-none-any.whl"
+    )
+    opener = _release_opener({
+        "tag_name": "v0.3.0",
+        "assets": [{"name": "ciao-0.3.0-py3-none-any.whl", "browser_download_url": wheel_url}],
+    })
+
+    def fake_run(cmd, **kwargs):
+        result = MagicMock()
+        result.stderr = ""
+        result.returncode = 0
+        if cmd[-2:] == ["show", "ciaobot"]:
+            result.stdout = "Version: 0.3.0"
+        else:
+            result.stdout = "Requirement already satisfied"
+        return result
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    res = update_package(opener=opener)
+    assert res["ok"] is False
+    assert "0.3.0" in res["error"]
 
 
 def test_update_package_pip_venv_without_wheel_asset(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- A tester's Ciaobot Update button — in both the menu bar **and** the PWA Settings page — restarted the app but the "update available" banner never cleared, with no visible error.
- Root cause: `update_package()` in `ciao/package_version.py` is the single implementation behind both entry points (`ciao/menubar.py`'s `on_update` and `ciao/web/routes_api.py`'s `package_update_endpoint`). It only checked the upgrade subprocess's exit code. Both `brew upgrade ciaobot` and `pip install -U <wheel>` exit `0` without installing anything when the target is already at that version — e.g. the Homebrew tap formula hasn't caught up yet with the GitHub release the update banner is comparing against, or the wheel version is already installed.
  - Menu bar: reported success, restarted the server + menu bar for nothing.
  - PWA: reported success (HTTP 200, `ok: true`), which triggers a restart-and-reload — the page comes back showing the exact same outdated version, which reads as "nothing happens."
- Fix: the installed version is now captured before and after the upgrade command; if it didn't actually change, `update_package()` reports failure with a clear message instead of a silent no-op success. Both callers already handle the failure path correctly (menu bar shows an alert, PWA surfaces `res.error` via `web/src/lib/api.ts`'s error handling) — no frontend changes needed.

## Test plan
- [x] `pytest tests/test_package_update.py tests/test_menubar.py` — added two regression tests (Homebrew and pip no-op cases) covering the new behavior
- [x] `pytest tests/` — full suite passes (985 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)