### PR TITLE
release: v0.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.4.11 - 2026-07-08
+
+### Maintenance
+- docs(readme): explain the etymology behind the "Ciaobot" name (`86f016b`)
+
 ## v0.4.10 - 2026-07-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 
 ## v0.4.11 - 2026-07-08
 
+### Added
+- feat(tray): open links in an installed PWA when available (`3ce183a`)
+
+### Fixed
+- fix(menubar): treat a no-op Homebrew/pip upgrade as a failed update (#58)
+
 ### Maintenance
 - docs(readme): explain the etymology behind the "Ciaobot" name (`86f016b`)
+- build(web): refresh bundled PWA assets for release/v0.4.11 (`9cd2b37`)
 
 ## v0.4.10 - 2026-07-08
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Ciaobot is an opinionated UI and UX layer for using Claude Code as a personal assistant and second brain. It is a local web app around agentic work: chats, projects, files, schedules, memory, and archived knowledge all live in one interface instead of being scattered across terminal sessions.
 
+## Why "Ciao"?
+
+*Ciao* isn't just Italian for "hi" and "bye" — it comes from the Venetian phrase *s-ciào vostro* ("[I am] your slave"), a servile greeting that shed its literal meaning over the centuries and became the everyday word Italians use today. Fitting for an assistant: yours to command. See the [etymology on Wikipedia](https://en.wikipedia.org/wiki/Ciao#Etymology) for the full history.
+
 ## Who it's for
 
 Ciaobot is built for **knowledge work, not software development**. It's where you brainstorm, research, draft, plan, and work through documents with an agent that already knows your context — the day-to-day thinking and writing that normally ends up scattered across chat windows, notes apps, and browser tabs.

--- a/ciao/__init__.py
+++ b/ciao/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.10"
+__version__ = "0.4.11"

--- a/ciao/cli.py
+++ b/ciao/cli.py
@@ -351,6 +351,12 @@ def _write_app_shortcut(
     # token" error page on every launch after the first. Once the token file
     # is gone we open the plain URL and rely on the session cookie -- matching
     # how the menu bar builds its "Open Ciaobot" URL (menubar.open_url).
+    #
+    # Before falling back to the default browser, look for a browser-installed
+    # PWA bundle (Chrome/Edge "Install Ciaobot", Safari's "Add to Dock") and
+    # open the URL in that instead -- excluding our own launcher bundle by its
+    # CFBundleIdentifier so this doesn't just relaunch itself. Mirrors
+    # menubar.find_installed_webapp / menubar.open_command.
     executable.write_text(
         "#!/bin/sh\n"
         f'if ! curl -s -o /dev/null --max-time 2 "http://localhost:{port}/"; then\n'
@@ -367,9 +373,30 @@ def _write_app_shortcut(
         '  || launchctl load -w "$HOME/Library/LaunchAgents/com.ciao.menubar.plist" 2>/dev/null\n'
         f'token=$(tr -d "[:space:]" < "{token_file}" 2>/dev/null)\n'
         "if [ -n \"$token\" ]; then\n"
-        f'  open "http://localhost:{port}/?setup=$token"\n'
+        f'  url="http://localhost:{port}/?setup=$token"\n'
         "else\n"
-        f'  open "http://localhost:{port}/"\n'
+        f'  url="http://localhost:{port}/"\n'
+        "fi\n"
+        'webapp=""\n'
+        "for candidate in \\\n"
+        '  "$HOME/Applications/Ciaobot.app" \\\n'
+        '  "$HOME/Applications/Chrome Apps.localized/Ciaobot.app" \\\n'
+        '  "/Applications/Ciaobot.app" \\\n'
+        '  "/Applications/Chrome Apps.localized/Ciaobot.app"\n'
+        "do\n"
+        '  if [ -d "$candidate" ]; then\n'
+        '    bundle_id=$(defaults read "$candidate/Contents/Info" CFBundleIdentifier 2>/dev/null)\n'
+        '    case "$bundle_id" in\n'
+        "      local.ciao.app|local.ciaobot.app) continue ;;\n"
+        "    esac\n"
+        '    webapp="$candidate"\n'
+        "    break\n"
+        "  fi\n"
+        "done\n"
+        'if [ -n "$webapp" ]; then\n'
+        '  open -a "$webapp" "$url"\n'
+        "else\n"
+        '  open "$url"\n'
         "fi\n",
         encoding="utf-8",
     )

--- a/ciao/menubar.py
+++ b/ciao/menubar.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+import plistlib
 import re
 import subprocess
 import sys
@@ -95,8 +96,58 @@ def open_url(workspace: Path, port: int) -> str:
     return f"{base}?setup={token}" if token else base
 
 
+# Bundle IDs of the native launcher this project installs itself (see
+# cli.py's _write_app_shortcut / _OUR_BUNDLE_IDS). A browser-installed PWA
+# can share the launcher's "Ciaobot.app" name, so find_installed_webapp()
+# excludes these IDs to avoid just relaunching the same shell-script wrapper.
+_OUR_LAUNCHER_BUNDLE_IDS = frozenset({"local.ciao.app", "local.ciaobot.app"})
+
+
+def _bundle_identifier(app_bundle: Path) -> str:
+    try:
+        with (app_bundle / "Contents" / "Info.plist").open("rb") as handle:
+            plist = plistlib.load(handle)
+    except (OSError, ValueError):
+        return ""
+    return str(plist.get("CFBundleIdentifier") or "")
+
+
+def find_installed_webapp(app_name: str = "Ciaobot") -> Path | None:
+    """Locate a browser-installed PWA bundle for ``app_name``, if any.
+
+    Chrome/Edge's "Install <app>" and Safari's "Add to Dock" each drop a real
+    .app bundle under one of a few well-known folders when the PWA is
+    installed. Opening links through that bundle (via ``open -a``) puts them
+    in the installed app's own window instead of a browser tab.
+    """
+
+    home = Path.home()
+    candidates = [
+        home / "Applications" / f"{app_name}.app",
+        home / "Applications" / "Chrome Apps.localized" / f"{app_name}.app",
+        Path("/Applications") / f"{app_name}.app",
+        Path("/Applications") / "Chrome Apps.localized" / f"{app_name}.app",
+    ]
+    for candidate in candidates:
+        if not candidate.is_dir():
+            continue
+        if _bundle_identifier(candidate) in _OUR_LAUNCHER_BUNDLE_IDS:
+            continue
+        return candidate
+    return None
+
+
+def open_command(url: str) -> list[str]:
+    """``open`` invocation for a URL, preferring an installed PWA when found."""
+
+    webapp = find_installed_webapp()
+    if webapp is not None:
+        return ["open", "-a", str(webapp), url]
+    return ["open", url]
+
+
 def open_app_command(workspace: Path, port: int) -> list[str]:
-    return ["open", open_url(workspace, port)]
+    return open_command(open_url(workspace, port))
 
 
 def restart_server_command(uid: int | None = None) -> list[str]:
@@ -434,7 +485,7 @@ def run_menubar(workspace: Path, port: int) -> int:
 
     def _open_chat_callback(chat_id: str):
         def _callback(_sender) -> None:
-            subprocess.run(["open", chat_url(workspace, port, chat_id)], check=False)
+            subprocess.run(open_command(chat_url(workspace, port, chat_id)), check=False)
 
         return _callback
 

--- a/ciao/package_version.py
+++ b/ciao/package_version.py
@@ -268,6 +268,38 @@ def _is_homebrew_cellar_path(path: Path) -> bool:
     return "Cellar/ciaobot" in text or "Cellar/ciao/" in text
 
 
+def _brew_installed_version(brew: str) -> str:
+    """Return the Cellar version of ``ciaobot`` per Homebrew, or "" if unknown."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            [brew, "list", "--versions", "ciaobot"],
+            capture_output=True, text=True, timeout=15, check=False,
+        )
+    except Exception:
+        return ""
+    parts = result.stdout.strip().split()
+    return parts[-1] if len(parts) >= 2 else ""
+
+
+def _pip_show_version(python_exe: str) -> str:
+    """Return the installed ``ciaobot`` version per ``pip show``, or "" if unknown."""
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            [python_exe, "-m", "pip", "show", "ciaobot"],
+            capture_output=True, text=True, timeout=15, check=False,
+        )
+    except Exception:
+        return ""
+    for line in result.stdout.splitlines():
+        if line.startswith("Version:"):
+            return line.split(":", 1)[1].strip()
+    return ""
+
+
 def detect_install_mode() -> str:
     """Return "homebrew", "pip_venv", "editable", or "unknown"."""
     import sys
@@ -350,6 +382,8 @@ def update_package(
             "command": "git pull",
         }
 
+    before_version = ""
+    check_version: Callable[[], str] = lambda: ""
     if mode == "homebrew":
         brew = _resolve_brew()
         if not brew:
@@ -360,6 +394,8 @@ def update_package(
                 "command": "brew upgrade ciaobot",
             }
         cmd = [brew, "upgrade", "ciaobot"]
+        check_version = lambda: _brew_installed_version(brew)
+        before_version = check_version()
     elif mode == "pip_venv":
         wheel_url, error = _latest_wheel_url(opener=opener, timeout=timeout)
         if not wheel_url:
@@ -370,6 +406,8 @@ def update_package(
                 "command": manual_command,
             }
         cmd = [sys.executable, "-m", "pip", "install", "-U", wheel_url]
+        check_version = lambda: _pip_show_version(sys.executable)
+        before_version = check_version()
     else:
         return {
             "ok": False,
@@ -382,6 +420,24 @@ def update_package(
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
         output = (result.stdout.strip() + "\n" + result.stderr.strip()).strip()
         if result.returncode == 0:
+            after_version = check_version()
+            if before_version and after_version and before_version == after_version:
+                # Exit 0 doesn't mean an upgrade happened: e.g. Homebrew reports
+                # success and no-ops when the tap formula hasn't caught up yet
+                # with the GitHub release the update banner is checking against,
+                # so the version never advances and the banner never clears.
+                return {
+                    "ok": False,
+                    "mode": mode,
+                    "error": (
+                        f"Still on {after_version} after running the upgrade — the "
+                        "package source has no newer version available yet. If "
+                        "this keeps happening, the release may not have "
+                        "propagated to it; try again shortly."
+                    ),
+                    "output": output,
+                    "command": " ".join(cmd),
+                }
             return {
                 "ok": True,
                 "mode": mode,

--- a/ciao/web/static/index.html
+++ b/ciao/web/static/index.html
@@ -13,7 +13,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-180.png" />
     <title>Ciaobot</title>
-    <script type="module" crossorigin src="/assets/index-CfAwokOZ.js"></script>
+    <script type="module" crossorigin src="/assets/index-BUGFnSTV.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DDpVIVK5.css">
   </head>
   <body>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciaobot"
-version = "0.4.10"
+version = "0.4.11"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -279,11 +279,19 @@ def test_setup_scaffolds_workspace_from_stock(tmp_path: Path) -> None:
     # into the URL -- otherwise a second launch shows "invalid setup token".
     token_file = workspace / ".runtime" / "setup-token"
     assert f'token=$(tr -d "[:space:]" < "{token_file}"' in app_text
-    assert 'open "http://localhost:9443/?setup=$token"' in app_text
-    assert 'open "http://localhost:9443/"' in app_text
+    assert 'url="http://localhost:9443/?setup=$token"' in app_text
+    assert 'url="http://localhost:9443/"' in app_text
     # The launcher starts the server and menu bar agents when they're down.
     assert 'launchctl kickstart "gui/$(id -u)/com.ciao.server"' in app_text
     assert 'launchctl kickstart "gui/$(id -u)/com.ciao.menubar"' in app_text
+    # Prefers a browser-installed PWA bundle over the default browser, but
+    # excludes our own launcher bundle so it doesn't just relaunch itself.
+    assert '"$HOME/Applications/Ciaobot.app"' in app_text
+    assert '"$HOME/Applications/Chrome Apps.localized/Ciaobot.app"' in app_text
+    assert '"/Applications/Ciaobot.app"' in app_text
+    assert "local.ciao.app|local.ciaobot.app) continue" in app_text
+    assert 'open -a "$webapp" "$url"' in app_text
+    assert 'open "$url"' in app_text
     setup_token = token_file.read_text(encoding="utf-8").strip()
     assert setup_token
     # The literal token value must not appear in the script -- it is read live.

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import plistlib
 import sys
 import urllib.error
 from pathlib import Path
@@ -102,7 +103,8 @@ def test_status_labels() -> None:
     )
 
 
-def test_open_app_command_uses_setup_token(tmp_path: Path) -> None:
+def test_open_app_command_uses_setup_token(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(menubar, "find_installed_webapp", lambda: None)
     token_path = tmp_path / ".runtime" / "setup-token"
     token_path.parent.mkdir(parents=True)
     token_path.write_text("tok123\n", encoding="utf-8")
@@ -113,11 +115,61 @@ def test_open_app_command_uses_setup_token(tmp_path: Path) -> None:
     ]
 
 
-def test_open_app_command_without_token_falls_back_to_plain_url(tmp_path: Path) -> None:
+def test_open_app_command_without_token_falls_back_to_plain_url(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(menubar, "find_installed_webapp", lambda: None)
+
     assert menubar.open_app_command(tmp_path, 8443) == [
         "open",
         "http://localhost:8443/",
     ]
+
+
+def test_open_app_command_prefers_installed_webapp(tmp_path: Path, monkeypatch) -> None:
+    webapp = tmp_path / "Ciaobot.app"
+    monkeypatch.setattr(menubar, "find_installed_webapp", lambda: webapp)
+
+    assert menubar.open_app_command(tmp_path, 8443) == [
+        "open",
+        "-a",
+        str(webapp),
+        "http://localhost:8443/",
+    ]
+
+
+def _write_bundle(path: Path, *, bundle_id: str) -> None:
+    contents = path / "Contents"
+    contents.mkdir(parents=True)
+    (contents / "Info.plist").write_bytes(
+        plistlib.dumps({"CFBundleIdentifier": bundle_id})
+    )
+
+
+def test_find_installed_webapp_finds_browser_installed_pwa(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(menubar.Path, "home", lambda: tmp_path)
+    webapp = tmp_path / "Applications" / "Ciaobot.app"
+    _write_bundle(webapp, bundle_id="org.chromium.Chromium.app.abc123")
+
+    assert menubar.find_installed_webapp() == webapp
+
+
+def test_find_installed_webapp_skips_our_own_launcher_bundle(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(menubar.Path, "home", lambda: tmp_path)
+    launcher = tmp_path / "Applications" / "Ciaobot.app"
+    _write_bundle(launcher, bundle_id="local.ciaobot.app")
+
+    assert menubar.find_installed_webapp() is None
+
+
+def test_find_installed_webapp_absent_returns_none(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(menubar.Path, "home", lambda: tmp_path)
+
+    assert menubar.find_installed_webapp() is None
 
 
 def test_restart_server_command_targets_launchd_label() -> None:

--- a/tests/test_package_update.py
+++ b/tests/test_package_update.py
@@ -71,20 +71,45 @@ def test_update_package_homebrew_upgrade(monkeypatch) -> None:
     monkeypatch.setattr("ciao.package_version.detect_install_mode", lambda: "homebrew")
     monkeypatch.setattr("ciao.package_version._resolve_brew", lambda: "/opt/homebrew/bin/brew")
 
-    captured: dict[str, list[str]] = {}
+    calls: list[list[str]] = []
 
     def fake_run(cmd, **kwargs):
-        captured["cmd"] = cmd
+        calls.append(cmd)
         result = MagicMock()
-        result.stdout = "ciaobot 0.4.6"
         result.stderr = ""
         result.returncode = 0
+        if cmd[1:] == ["upgrade", "ciaobot"]:
+            result.stdout = "==> Upgrading ciaobot"
+        else:
+            upgraded = any(c[1:] == ["upgrade", "ciaobot"] for c in calls[:-1])
+            result.stdout = "ciaobot 0.4.7" if upgraded else "ciaobot 0.4.6"
         return result
 
     monkeypatch.setattr("subprocess.run", fake_run)
     res = update_package()
     assert res["ok"] is True
-    assert captured["cmd"] == ["/opt/homebrew/bin/brew", "upgrade", "ciaobot"]
+    assert ["/opt/homebrew/bin/brew", "upgrade", "ciaobot"] in calls
+
+
+def test_update_package_homebrew_noop_reports_failure(monkeypatch) -> None:
+    # brew upgrade can exit 0 without installing anything when the tap
+    # formula hasn't caught up with the GitHub release yet — that must not
+    # be reported as a successful update (it would restart the app for
+    # nothing and leave the "update available" banner stuck forever).
+    monkeypatch.setattr("ciao.package_version.detect_install_mode", lambda: "homebrew")
+    monkeypatch.setattr("ciao.package_version._resolve_brew", lambda: "/opt/homebrew/bin/brew")
+
+    def fake_run(cmd, **kwargs):
+        result = MagicMock()
+        result.stderr = ""
+        result.returncode = 0
+        result.stdout = "Warning: ciaobot 0.4.6 already installed" if cmd[1:] == ["upgrade", "ciaobot"] else "ciaobot 0.4.6"
+        return result
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    res = update_package()
+    assert res["ok"] is False
+    assert "0.4.6" in res["error"]
 
 
 def test_update_package_homebrew_without_brew(monkeypatch) -> None:
@@ -120,24 +145,59 @@ def test_update_package_pip_venv_installs_release_wheel(monkeypatch) -> None:
         ],
     })
 
-    mock_run = MagicMock()
-    mock_run.stdout = "Successfully installed ciao-0.3.0"
-    mock_run.stderr = ""
-    mock_run.returncode = 0
-
-    captured: dict[str, list[str]] = {}
+    install_cmd = [sys.executable, "-m", "pip", "install", "-U", wheel_url]
+    calls: list[list[str]] = []
 
     def fake_run(cmd, **kwargs):
-        captured["cmd"] = cmd
-        return mock_run
+        calls.append(cmd)
+        result = MagicMock()
+        result.stderr = ""
+        result.returncode = 0
+        if cmd == install_cmd:
+            result.stdout = "Successfully installed ciao-0.3.0"
+        else:
+            upgraded = any(c == install_cmd for c in calls[:-1])
+            result.stdout = "Version: 0.3.0" if upgraded else "Version: 0.2.0"
+        return result
 
     monkeypatch.setattr("subprocess.run", fake_run)
     res = update_package(opener=opener)
     assert res["ok"] is True
-    assert captured["cmd"] == [sys.executable, "-m", "pip", "install", "-U", wheel_url]
+    assert install_cmd in calls
     assert wheel_url in res["command"]
     assert "pip install -U ciao" not in res["command"].replace(wheel_url, "")
     assert "Successfully installed ciao-0.3.0" in res["output"]
+
+
+def test_update_package_pip_venv_noop_reports_failure(monkeypatch) -> None:
+    # `pip install -U <wheel>` exits 0 without reinstalling when the same
+    # version is already present — that must surface as a failed update
+    # rather than a restart that leaves the banner stuck.
+    monkeypatch.setattr("ciao.package_version.detect_install_mode", lambda: "pip_venv")
+
+    wheel_url = (
+        "https://github.com/raffaelefarinaro/ciaobot/releases/download/"
+        "v0.3.0/ciao-0.3.0-py3-none-any.whl"
+    )
+    opener = _release_opener({
+        "tag_name": "v0.3.0",
+        "assets": [{"name": "ciao-0.3.0-py3-none-any.whl", "browser_download_url": wheel_url}],
+    })
+
+    def fake_run(cmd, **kwargs):
+        result = MagicMock()
+        result.stderr = ""
+        result.returncode = 0
+        if cmd[-2:] == ["show", "ciaobot"]:
+            result.stdout = "Version: 0.3.0"
+        else:
+            result.stdout = "Requirement already satisfied"
+        return result
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    res = update_package(opener=opener)
+    assert res["ok"] is False
+    assert "0.3.0" in res["error"]
 
 
 def test_update_package_pip_venv_without_wheel_asset(monkeypatch) -> None:

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-pwa",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-pwa",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
         "dompurify": "^3.4.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-pwa",
   "private": true,
-  "version": "0.4.10",
+  "version": "0.4.11",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
Cuts v0.4.11.

### Added
- feat(tray): open links in an installed PWA when available (`3ce183a`)

### Fixed
- fix(menubar): treat a no-op Homebrew/pip upgrade as a failed update (#58) — Update button was reporting success and restarting the app even when the underlying Homebrew/pip install was a no-op (e.g. the tap formula hadn't caught up with the GitHub release yet), leaving the "update available" banner stuck with no error shown, in both the menu bar and the PWA Settings page.

### Maintenance
- docs(readme): explain the etymology behind the "Ciaobot" name (`86f016b`)
- build(web): refresh bundled PWA assets to pick up the already-merged chat-pane fix (#56) (`9cd2b37`)
- docs(changelog): list the above in the v0.4.11 entry (`2a723a7`)

## Test plan
- [x] `pytest tests/` — full backend suite passes
- [x] `cd web && npm run build` — typecheck + build passes, bundle matches what's committed

## Next steps (not done by this PR — needs a human)
- [ ] Merge this PR into `main`
- [ ] Tag `v0.4.11` and publish a GitHub Release on that commit — this triggers `.github/workflows/publish.yml` (PyPI publish + Homebrew tap update), so it should be a deliberate, reviewed action rather than automated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)