### PR TITLE
Rework welcome mascot greeting: hover previews, click pins

### DIFF
--- a/web/src/components/ChatLayout.vue
+++ b/web/src/components/ChatLayout.vue
@@ -39,7 +39,7 @@
           />
           <ChatPanel v-else-if="store.activeChat" @close="closeChat" @open-sidebar="sidebarCollapsed = false" />
           <div v-else class="empty-shell">
-            <PaneHeader title="Ciaobot" @open-sidebar="sidebarCollapsed = false" />
+            <PaneHeader title="ciaobot" @open-sidebar="sidebarCollapsed = false" />
             <div class="empty-state">
               <div class="empty-mark">
                 <button
@@ -47,6 +47,8 @@
                   class="empty-face-btn"
                   aria-label="Say hello"
                   @click="onFaceClick"
+                  @mouseenter="onFaceEnter"
+                  @mouseleave="onFaceLeave"
                 >
                   <Transition name="face-bubble">
                     <div v-if="speechGreeting" :key="speechGreeting" class="face-speech-bubble">
@@ -110,7 +112,7 @@
         />
         <ChatPanel v-else-if="store.activeChat" @close="closeChat" @open-sidebar="sidebarCollapsed = false" />
         <div v-else class="empty-shell">
-          <PaneHeader title="Ciaobot" @open-sidebar="sidebarCollapsed = false" />
+          <PaneHeader title="ciaobot" @open-sidebar="sidebarCollapsed = false" />
           <div class="empty-state">
             <div class="empty-mark">
               <button
@@ -118,6 +120,8 @@
                 class="empty-face-btn"
                 aria-label="Say hello"
                 @click="onFaceClick"
+                @mouseenter="onFaceEnter"
+                @mouseleave="onFaceLeave"
               >
                 <Transition name="face-bubble">
                   <div v-if="speechGreeting" :key="speechGreeting" class="face-speech-bubble">
@@ -310,8 +314,9 @@ function stopSplitDrag() {
   }
 }
 
-// Welcome-screen mascot. Click opens the mouth and shows a comic bubble
-// with "hello" in a different language each time.
+// Welcome-screen mascot. Hovering shows a comic bubble with "hello" in a
+// different language until the pointer leaves; clicking pins the bubble
+// on until the next click.
 const FACE_GREETINGS = [
   'Ciao!', '¡Hola!', 'Salut!', 'Hallo!', 'Olá!', 'Hello!',
   'こんにちは!', '안녕!', '你好!', 'مرحبا!', 'Привет!', 'नमस्ते!',
@@ -320,8 +325,8 @@ const FACE_GREETINGS = [
 ] as const
 
 const speechGreeting = ref<string | null>(null)
+const speechPinned = ref(false)
 let greetingQueue: string[] = []
-let speechHideTimer: ReturnType<typeof window.setTimeout> | null = null
 
 function shuffleGreetings(): string[] {
   const next = [...FACE_GREETINGS]
@@ -338,12 +343,16 @@ function nextGreeting(): string {
 }
 
 function onFaceClick() {
-  speechGreeting.value = nextGreeting()
-  if (speechHideTimer) window.clearTimeout(speechHideTimer)
-  speechHideTimer = window.setTimeout(() => {
-    speechGreeting.value = null
-    speechHideTimer = null
-  }, 2600)
+  speechPinned.value = !speechPinned.value
+  speechGreeting.value = speechPinned.value ? nextGreeting() : null
+}
+
+function onFaceEnter() {
+  if (!speechPinned.value) speechGreeting.value = nextGreeting()
+}
+
+function onFaceLeave() {
+  if (!speechPinned.value) speechGreeting.value = null
 }
 
 const faceSrc = computed(() => (speechGreeting.value ? '/face_scared.png' : '/face.png'))
@@ -594,7 +603,6 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
-  if (speechHideTimer) window.clearTimeout(speechHideTimer)
   stopLatestStatusSync()
   window.removeEventListener('resize', onResize)
   window.removeEventListener('touchstart', onTouchStart)
@@ -664,7 +672,6 @@ onBeforeUnmount(() => {
   user-select: none;
   transition: transform 120ms var(--ease);
 }
-.empty-state .empty-face-btn:hover { transform: scale(1.08); }
 .empty-state .empty-face-btn:active { transform: scale(0.94); }
 .empty-state .empty-face {
   display: block;


### PR DESCRIPTION
Fixes the welcome-screen mascot interaction in the PWA.

Before: clicking flashed a random-language greeting bubble for 2.6 seconds, and the face scaled up on hover.

Now:
- Hovering the face shows a greeting in a different language; moving the pointer away hides it.
- Clicking toggles the bubble on/off (pinned on stays visible until the next click).
- The hover scale effect is removed.
- The empty-view pane header title is lowercased to `ciaobot`, matching the sidebar wordmark.

Verified with `npm run build` (vue-tsc + vite) and `vitest run` (77 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)