### PR TITLE
fix(web): unbreak Vite dev proxy writes and WebSockets with auth off

### DIFF
--- a/ciao/web/auth.py
+++ b/ciao/web/auth.py
@@ -65,7 +65,7 @@ def _split_host(value: str) -> tuple[str, int | None]:
         return host, None
 
 
-def _same_origin(request: Request, origin: str) -> bool:
+def _same_origin(request: Request | WebSocket, origin: str) -> bool:
     from urllib.parse import urlsplit
 
     try:
@@ -98,6 +98,27 @@ def _state_change_origin_allowed(request: Request) -> bool:
     referer = request.headers.get("referer")
     if referer:
         return _same_origin(request, referer)
+    return True
+
+
+async def authorize_websocket(websocket: WebSocket) -> bool:
+    """Handshake gate for `/ws/*`, mirroring the HTTP policy in AuthMiddleware.
+
+    Cross-origin browser connections are always rejected (WebSockets are not
+    covered by CORS, so an unchecked handshake allows cross-site hijacking);
+    a session cookie is required only when auth is enabled, same as `/api/*`.
+    Closes the socket and returns False when the connection is not allowed.
+    """
+    origin = websocket.headers.get("origin")
+    if origin and not _same_origin(websocket, origin):
+        await websocket.close(code=4003, reason="forbidden origin")
+        return False
+    config = getattr(websocket.app.state, "config", None)
+    if getattr(config, "pwa_auth_required", False) and not verify_session(
+        websocket, websocket.app.state.serializer
+    ):
+        await websocket.close(code=4001, reason="unauthorized")
+        return False
     return True
 
 

--- a/ciao/web/routes_chat.py
+++ b/ciao/web/routes_chat.py
@@ -22,7 +22,7 @@ import logging
 
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
-from ciao.web.auth import verify_session
+from ciao.web.auth import authorize_websocket
 from ciao.web.chat_broker import ChatStream
 from ciao.models import ImageAttachment
 
@@ -71,9 +71,7 @@ async def _attach_streams(websocket: WebSocket, pcm, chat_id: str) -> None:
 
 async def ws_chat(websocket: WebSocket) -> None:
     """Per-chat streaming WebSocket."""
-    serializer = websocket.app.state.serializer
-    if not verify_session(websocket, serializer):
-        await websocket.close(code=4001, reason="unauthorized")
+    if not await authorize_websocket(websocket):
         return
 
     await websocket.accept()
@@ -225,9 +223,7 @@ async def ws_events(websocket: WebSocket) -> None:
     On connect, sends a snapshot of currently-active streams so a fresh client
     can paint sidebar indicators without waiting for the next event.
     """
-    serializer = websocket.app.state.serializer
-    if not verify_session(websocket, serializer):
-        await websocket.close(code=4001, reason="unauthorized")
+    if not await authorize_websocket(websocket):
         return
 
     await websocket.accept()

--- a/tests/test_ws_auth.py
+++ b/tests/test_ws_auth.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from itsdangerous import URLSafeTimedSerializer
+from starlette.applications import Starlette
+from starlette.routing import WebSocketRoute
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from ciao.web.auth import SESSION_COOKIE
+from ciao.web.routes_chat import ws_events
+
+
+async def _never_yield():
+    await asyncio.Event().wait()
+    yield  # pragma: no cover
+
+
+def _events_app(*, auth_required: bool) -> Starlette:
+    app = Starlette(routes=[WebSocketRoute("/ws/events", ws_events)])
+    app.state.serializer = URLSafeTimedSerializer("test-secret")
+    app.state.config = SimpleNamespace(pwa_auth_required=auth_required)
+    app.state.project_chat_manager = SimpleNamespace(
+        active_stream_chat_ids=lambda: [],
+        get_chat=lambda _cid: None,
+        background_agent_counts={},
+        events=SimpleNamespace(subscribe=_never_yield),
+    )
+    return app
+
+
+def test_ws_connects_without_session_when_auth_off() -> None:
+    client = TestClient(_events_app(auth_required=False))
+    with client.websocket_connect(
+        "/ws/events", headers={"Origin": "http://testserver"}
+    ) as ws:
+        assert ws.receive_json()["type"] == "snapshot"
+
+
+def test_ws_requires_session_when_auth_on() -> None:
+    client = TestClient(_events_app(auth_required=True))
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect("/ws/events"):
+            pass
+
+
+def test_ws_accepts_session_cookie_when_auth_on() -> None:
+    app = _events_app(auth_required=True)
+    client = TestClient(app)
+    client.cookies.set(SESSION_COOKIE, app.state.serializer.dumps({"user": "owner"}))
+    with client.websocket_connect("/ws/events") as ws:
+        assert ws.receive_json()["type"] == "snapshot"
+
+
+def test_ws_rejects_cross_origin() -> None:
+    client = TestClient(_events_app(auth_required=False))
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect(
+            "/ws/events", headers={"Origin": "http://evil.example"}
+        ):
+            pass

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -16,7 +16,11 @@ export default defineConfig({
   },
   server: {
     proxy: {
-      '/api': backendUrl,
+      // Object form keeps changeOrigin off so the browser's Host header
+      // reaches the backend; its same-origin check compares Origin against
+      // Host, and the string shorthand rewrites Host to the target, turning
+      // every dev-server write request into a 403.
+      '/api': { target: backendUrl },
       '/ws': { target: backendWsUrl, ws: true },
     },
   },


### PR DESCRIPTION
## Problem

Running the app from source (backend on 8543 + Vite dev server on 5173) is unusable:

1. Every POST through the dev proxy returns **403 `forbidden origin`**. Vite's string-shorthand proxy entry (`'/api': backendUrl`) implies `changeOrigin: true`, which rewrites the `Host` header to `127.0.0.1:8543`. The backend CSRF check in `ciao/web/auth.py` compares the browser's `Origin` (`http://localhost:5173`) against that rewritten Host, so the hostnames never match.
2. Every WebSocket handshake (`/ws/events`, `/ws/chat/*`) is **rejected with 403**. `ws_chat`/`ws_events` called `verify_session` unconditionally, but auth is off by default since 4a9a6bb and nothing sets a session cookie in that mode — so chat streaming and sidebar events are dead for any fresh browser profile, on the production port too.

## Fix

- `web/vite.config.ts`: use the object proxy form so `changeOrigin` stays off and the browser's Host header reaches the backend.
- `ciao/web/auth.py` + `ciao/web/routes_chat.py`: new `authorize_websocket` helper mirrors the HTTP policy — session cookie required only when `pwa_auth_required` is set, and same-origin enforced on the handshake (WebSockets aren't covered by CORS, so an unchecked handshake allows cross-site hijacking).

## Verification

- New `tests/test_ws_auth.py`: WS connects without a session when auth is off, requires/accepts a session when auth is on, rejects cross-origin handshakes.
- Full suite: 1018 passed.
- `cd web && npm run build` (vue-tsc + vite) passes; regenerated static assets restored, not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)