### PR TITLE
Add Scrapling as an optional web-scraping fallback (issue #64)

### DIFF
--- a/ciao/dependency_review.py
+++ b/ciao/dependency_review.py
@@ -63,6 +63,7 @@ KNOWN_REPOS = {
     "defuddle": "https://github.com/kepano/defuddle/releases",
     "claude-code": "https://github.com/anthropics/claude-code/releases",
     "apfel": "https://github.com/Arthur-Ficial/apfel/releases",
+    "scrapling": "https://github.com/D4Vinci/Scrapling/releases",
     "starlette": "https://github.com/encode/starlette/releases",
     "uvicorn": "https://github.com/encode/uvicorn/releases",
     "itsdangerous": "https://github.com/pallets/itsdangerous/releases",

--- a/ciao/stock/skills/web-research/SKILL.md
+++ b/ciao/stock/skills/web-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: web-research
-description: Reliable web lookup workflow using provider-native web search plus defuddle for source verification.
+description: Reliable web lookup workflow using provider-native web search plus defuddle (with optional Scrapling fallback) for source verification.
 ---
 
 # Web Research
@@ -15,7 +15,10 @@ Use this skill for web questions and URL verification.
 2. Read
 - For **GitHub URLs** (`github.com/...`, `gist.github.com/...`), use `gh` CLI instead of defuddle. It hits the API directly: cleaner output, fewer tokens, and it works on private repos. See the GitHub URL mapping below.
 - For all other URLs, use `defuddle parse <url> --md`. This is the default for the rest of the web; it strips clutter and reduces token usage.
-- If defuddle returns empty or stub content (JS-rendered pages, SPAs, login-gated content, dashboards), say so clearly and ask the user to paste the content or try from a machine where they can access it.
+- If defuddle returns empty or stub content (JS-rendered pages, SPAs, login-gated content, dashboards), fall back to Scrapling when it is installed (`command -v scrapling`):
+  1. `scrapling extract get '<url>' /tmp/page.md --impersonate chrome` — fast HTTP fetch with browser impersonation, then read the output file.
+  2. If still empty or stub, `scrapling extract fetch '<url>' /tmp/page.md` — renders the page in a headless browser, so it handles JS-only content. Slower; use it only after step 1 fails.
+- If Scrapling is not installed or both attempts fail, say so clearly and ask the user to paste the content or try from a machine where they can access it. (Scrapling is an optional install: `pip install 'scrapling[fetchers]' && scrapling install`.)
 - Only fall back to WebFetch for non-HTML targets (API endpoints, raw files, binary content).
 
 ### GitHub URL mapping

--- a/ciao/upgrade.py
+++ b/ciao/upgrade.py
@@ -304,6 +304,36 @@ async def upgrade_libreoffice() -> UpgradeResult:
     )
 
 
+async def upgrade_scrapling() -> UpgradeResult:
+    """Upgrade the optional Scrapling web-scraping fallback via pip.
+
+    Scrapling is opt-in (it pulls in headless-browser fetchers), so this never
+    installs it fresh: it only upgrades an existing install, then refreshes the
+    browser binaries when the package version changed.
+    """
+    if shutil.which("scrapling") is None:
+        return UpgradeResult(
+            command=[], changed=False, success=True,
+            stdout="scrapling not installed (optional)", stderr="",
+            before_version="", after_version="",
+        )
+    result = await run_upgrade(
+        install_command=[sys.executable, "-m", "pip", "install", "--upgrade", "scrapling[fetchers]"],
+        version_command=[sys.executable, "-m", "pip", "show", "scrapling"],
+    )
+    if result.changed:
+        try:
+            process = await asyncio.create_subprocess_exec(
+                "scrapling", "install",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await process.communicate()
+        except (FileNotFoundError, OSError):
+            logger.warning("scrapling browser-binaries refresh failed")
+    return result
+
+
 async def upgrade_all(project_root: str) -> str | None:
     """Run all upgrades (pip deps + root npm + web npm + gws + defuddle
     + claude + codex). Returns a summary or *None*."""
@@ -319,13 +349,15 @@ async def upgrade_all(project_root: str) -> str | None:
     web_npm_task = asyncio.create_task(upgrade_web_npm(project_root))
     apfel_task = asyncio.create_task(upgrade_apfel())
     libreoffice_task = asyncio.create_task(upgrade_libreoffice())
+    scrapling_task = asyncio.create_task(upgrade_scrapling())
     (
         pip_changed, gws_result, defuddle_result,
         claude_result, codex_result, root_npm_result, web_npm_result,
-        apfel_result, libreoffice_result,
+        apfel_result, libreoffice_result, scrapling_result,
     ) = await asyncio.gather(
         pip_task, gws_task, defuddle_task, claude_task, codex_task,
         root_npm_task, web_npm_task, apfel_task, libreoffice_task,
+        scrapling_task,
     )
 
     # Failures get logged + surfaced in the summary even when nothing changed,
@@ -340,6 +372,7 @@ async def upgrade_all(project_root: str) -> str | None:
         ("web-npm", web_npm_result),
         ("apfel", apfel_result),
         ("libreoffice", libreoffice_result),
+        ("scrapling", scrapling_result),
     ]
 
     for pkg, (before, after) in pip_changed.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,12 @@ voice-local = [
 tts-local = [
   "kokoro-onnx==0.5.0",
 ]
+# Optional web-scraping fallback for the web-research skill (JS-rendered
+# pages defuddle cannot read). Browser binaries are installed separately
+# with `scrapling install`, keeping the base install light.
+scraping = [
+  "scrapling[fetchers]==0.4.10",
+]
 # macOS menu bar companion (`ciao menubar`). Kept for compatibility: the same
 # pin ships in the main dependencies with a Darwin platform marker.
 menubar = [

--- a/tests/test_dependency_review.py
+++ b/tests/test_dependency_review.py
@@ -147,6 +147,16 @@ def test_every_tracked_tool_has_repo() -> None:
         assert t["key"]
 
 
+def test_scrapling_optional_dep_is_tracked() -> None:
+    # The `scraping` extra must flow into dependency tracking with a known
+    # repo URL, so the weekly review can bump its pin.
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    deps = depreview.parse_pyproject_dependencies(pyproject)
+    assert "scrapling" in deps
+    assert deps["scrapling"].startswith("==")
+    assert depreview.KNOWN_REPOS["scrapling"] == "https://github.com/D4Vinci/Scrapling/releases"
+
+
 def test_pinned_version_extracts_from_python_and_npm_specs() -> None:
     assert _pinned_version("==0.2.111") == "0.2.111"
     assert _pinned_version("^5.0.0") == "5.0.0"

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -16,6 +16,7 @@ from ciao.upgrade import (
     upgrade_gws,
     upgrade_apfel,
     upgrade_root_npm,
+    upgrade_scrapling,
     upgrade_web_npm,
 )
 
@@ -144,6 +145,7 @@ async def test_upgrade_all_returns_none_when_nothing_changed(monkeypatch, tmp_pa
     monkeypatch.setattr("ciao.upgrade.upgrade_web_npm", AsyncMock(return_value=_UNCHANGED))
     monkeypatch.setattr("ciao.upgrade.upgrade_apfel", AsyncMock(return_value=_UNCHANGED))
     monkeypatch.setattr("ciao.upgrade.upgrade_libreoffice", AsyncMock(return_value=_UNCHANGED))
+    monkeypatch.setattr("ciao.upgrade.upgrade_scrapling", AsyncMock(return_value=_UNCHANGED))
 
     with caplog.at_level(logging.INFO):
         result = await upgrade_all(str(tmp_path))
@@ -171,6 +173,7 @@ async def test_upgrade_all_reports_changes(monkeypatch, tmp_path, caplog) -> Non
     monkeypatch.setattr("ciao.upgrade.upgrade_web_npm", AsyncMock(return_value=_UNCHANGED))
     monkeypatch.setattr("ciao.upgrade.upgrade_apfel", AsyncMock(return_value=_UNCHANGED))
     monkeypatch.setattr("ciao.upgrade.upgrade_libreoffice", AsyncMock(return_value=_UNCHANGED))
+    monkeypatch.setattr("ciao.upgrade.upgrade_scrapling", AsyncMock(return_value=_UNCHANGED))
 
     with caplog.at_level(logging.INFO):
         result = await upgrade_all(str(tmp_path))
@@ -202,6 +205,7 @@ async def test_upgrade_all_surfaces_silent_failures(monkeypatch, tmp_path, caplo
     monkeypatch.setattr("ciao.upgrade.upgrade_web_npm", AsyncMock(return_value=_UNCHANGED))
     monkeypatch.setattr("ciao.upgrade.upgrade_apfel", AsyncMock(return_value=_UNCHANGED))
     monkeypatch.setattr("ciao.upgrade.upgrade_libreoffice", AsyncMock(return_value=_UNCHANGED))
+    monkeypatch.setattr("ciao.upgrade.upgrade_scrapling", AsyncMock(return_value=_UNCHANGED))
 
     with caplog.at_level(logging.WARNING):
         result = await upgrade_all(str(tmp_path))
@@ -258,6 +262,65 @@ def test_upgrade_apfel_runs_upgrade_when_installed(monkeypatch) -> None:
     assert result.success is True
     assert result.changed is False
     assert result.before_version == "1.5.2"
+
+
+def test_upgrade_scrapling_skips_when_not_installed(monkeypatch) -> None:
+    # Scrapling is opt-in: a missing binary is not a failure and must not
+    # trigger an install.
+    monkeypatch.setattr("ciao.upgrade.shutil.which", lambda cmd: None)
+    result = asyncio.run(upgrade_scrapling())
+    assert result.success is True
+    assert result.changed is False
+    assert result.command == []
+    assert "not installed (optional)" in result.stdout
+
+
+def test_upgrade_scrapling_upgrades_when_installed(monkeypatch) -> None:
+    import sys as _sys
+    monkeypatch.setattr(
+        "ciao.upgrade.shutil.which",
+        lambda cmd: "/usr/local/bin/scrapling" if cmd == "scrapling" else None,
+    )
+
+    async def mock_run_upgrade(install_command, version_command):
+        assert install_command == [
+            _sys.executable, "-m", "pip", "install", "--upgrade", "scrapling[fetchers]",
+        ]
+        assert version_command == [_sys.executable, "-m", "pip", "show", "scrapling"]
+        return UpgradeResult(
+            command=install_command, changed=False, success=True,
+            stdout="", stderr="", before_version="0.4.10", after_version="0.4.10",
+        )
+
+    monkeypatch.setattr("ciao.upgrade.run_upgrade", mock_run_upgrade)
+    result = asyncio.run(upgrade_scrapling())
+    assert result.success is True
+    assert result.before_version == "0.4.10"
+
+
+def test_upgrade_scrapling_refreshes_browsers_on_change(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "ciao.upgrade.shutil.which",
+        lambda cmd: "/usr/local/bin/scrapling" if cmd == "scrapling" else None,
+    )
+    bumped = UpgradeResult(
+        command=[], changed=True, success=True,
+        stdout="", stderr="", before_version="0.4.9", after_version="0.4.10",
+    )
+    monkeypatch.setattr("ciao.upgrade.run_upgrade", AsyncMock(return_value=bumped))
+
+    exec_calls = []
+
+    async def mock_exec(*cmd, **kwargs):
+        exec_calls.append(list(cmd))
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        return proc
+
+    monkeypatch.setattr("ciao.upgrade.asyncio.create_subprocess_exec", mock_exec)
+    result = asyncio.run(upgrade_scrapling())
+    assert result.changed is True
+    assert exec_calls == [["scrapling", "install"]]
 
 
 def test_upgrade_root_npm_uses_prefix(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
Implements #64: Scrapling as an opt-in fallback for pages defuddle cannot read (JS-rendered SPAs, anti-bot sites).

## What changed

- **`ciao/stock/skills/web-research/SKILL.md`** — when defuddle returns empty/stub content and `scrapling` is on PATH, the skill now tries `scrapling extract get <url> --impersonate chrome` (fast HTTP with browser impersonation), then `scrapling extract fetch` (headless browser rendering) before asking the user to paste content. Includes the install hint (`pip install 'scrapling[fetchers]' && scrapling install`).
- **`pyproject.toml`** — new `scraping` optional extra pinning `scrapling[fetchers]==0.4.10` (BSD-3-Clause). Browser binaries install separately via `scrapling install`, so the base install stays light.
- **`ciao/upgrade.py`** — `upgrade_scrapling()` wired into `upgrade_all`. It never installs Scrapling fresh (opt-in, matching the lazy-install policy for apfel/whisper/kokoro); it only upgrades an existing install and refreshes browser binaries when the version changed.
- **`ciao/dependency_review.py`** — `KNOWN_REPOS` entry so the weekly review tracks the pin (the `scraping` extra is already picked up by `parse_pyproject_dependencies`).

## Deliberate deviations from the issue checklist

- **No `ciao/web_scraper.py` adapter** — the skill is guidance-only; the agent invokes CLIs (defuddle, gh, scrapling) directly, so a Python adapter would have no caller.
- **No live-URL comparison tests** — network tests are flaky; the new code paths are covered by unit tests instead (opt-in skip, upgrade command shape, browser-binary refresh, dependency tracking).

## Answers to the issue's open questions

1. Fallback is automatic when Scrapling is installed, but installation itself stays manual/opt-in.
2. Default order: impersonated HTTP fetch (`extract get`) first, dynamic browser (`extract fetch`) second; StealthyFetcher left out of the default path.
3. No caching for now — can be added later if browser launches prove costly in practice.

## Verification

- `pytest tests/`: 1080 passed, 1 skipped.
- Base is `release/v0.4.14` (the skill wording this replaces only exists there; basing on main would conflict with commit 7c7f368).

🤖 Generated with [Claude Code](https://claude.com/claude-code)