### PR TITLE
Interactive onboarding: tour deep links + getting-started checklist

### DIFF
--- a/ciao/web/static/index.html
+++ b/ciao/web/static/index.html
@@ -13,7 +13,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-180.png" />
     <title>Ciaobot</title>
-    <script type="module" crossorigin src="/assets/index-CeHB3EAP.js"></script>
+    <script type="module" crossorigin src="/assets/index-BycN-R4G.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DaXzHz2o.css">
   </head>
   <body>

--- a/web/src/components/ChatLayout.vue
+++ b/web/src/components/ChatLayout.vue
@@ -144,6 +144,7 @@
                 {{ action.isCreating ? 'Creating...' : `+ ${action.label} Chat` }}
               </button>
             </div>
+            <GettingStartedChecklist variant="home" @open-sidebar="sidebarCollapsed = false" />
           </div>
         </div>
       </template>
@@ -168,6 +169,7 @@ import FileViewerModal from './FileViewerModal.vue'
 import PinnedFilePanel from './PinnedFilePanel.vue'
 import PaneHeader from './PaneHeader.vue'
 import ProductTour from './ProductTour.vue'
+import GettingStartedChecklist from './GettingStartedChecklist.vue'
 
 const store = useProjectStore()
 const tourStore = useProductTourStore()

--- a/web/src/components/GettingStartedChecklist.vue
+++ b/web/src/components/GettingStartedChecklist.vue
@@ -1,0 +1,210 @@
+<template>
+  <section
+    v-if="visible"
+    class="getting-started card"
+    :class="{ 'getting-started--home': variant === 'home' }"
+    aria-label="Getting started checklist"
+  >
+    <div class="gs-header">
+      <div>
+        <p class="section-title">Getting started</p>
+        <p class="hint">Learn the app by doing — each step opens the page where it happens.</p>
+      </div>
+      <span class="gs-progress">{{ progress.doneCount }} / {{ progress.total }}</span>
+    </div>
+
+    <ul class="gs-list">
+      <li v-for="item in progress.items" :key="item.id" class="gs-row" :class="{ 'is-done': item.done }">
+        <span class="gs-mark" aria-hidden="true">{{ item.done ? '✓' : '○' }}</span>
+        <div class="gs-main">
+          <span class="gs-title">{{ item.title }}</span>
+          <p class="gs-body">{{ item.body }}</p>
+        </div>
+        <button
+          v-if="!item.done"
+          type="button"
+          class="btn-small gs-cta"
+          @click="go(item)"
+        >{{ item.cta }}</button>
+      </li>
+    </ul>
+
+    <div class="gs-footer">
+      <template v-if="variant === 'home'">
+        <button type="button" class="gs-dismiss" @click="store.dismiss()">Hide checklist</button>
+        <span class="hint">You can bring it back from Settings → Home.</span>
+      </template>
+      <template v-else>
+        <button
+          v-if="store.dismissed"
+          type="button"
+          class="btn-small"
+          @click="store.restore()"
+        >Show on home screen</button>
+        <button
+          v-else
+          type="button"
+          class="gs-dismiss"
+          @click="store.dismiss()"
+        >Hide from home screen</button>
+      </template>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useGettingStartedStore } from '../stores/gettingStarted'
+import type { GettingStartedItemStatus } from '../lib/gettingStarted'
+
+const props = withDefaults(defineProps<{
+  /** 'home' hides itself when dismissed or complete; 'settings' always shows. */
+  variant?: 'home' | 'settings'
+}>(), { variant: 'home' })
+
+const emit = defineEmits<{ 'open-sidebar': [] }>()
+
+const store = useGettingStartedStore()
+const router = useRouter()
+
+const progress = computed(() => store.progress)
+
+const visible = computed(() => {
+  if (props.variant === 'settings') return true
+  return !store.dismissed && !progress.value.allDone
+})
+
+async function go(item: GettingStartedItemStatus) {
+  if (item.opensSidebar) emit('open-sidebar')
+  if (router.currentRoute.value.path !== item.route) {
+    await router.push(item.route)
+  }
+}
+
+onMounted(() => {
+  if (!store.providerStatusLoaded) void store.fetchProviderStatus()
+})
+</script>
+
+<style scoped>
+.getting-started {
+  text-align: left;
+}
+
+/* On the home empty state there is no surrounding .card styling context;
+   give the checklist its own bounded panel. */
+.getting-started--home {
+  width: min(560px, 100%);
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+}
+
+.gs-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.gs-progress {
+  flex-shrink: 0;
+  font-size: var(--text-xs);
+  color: var(--fg3);
+  font-variant-numeric: tabular-nums;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 2px 8px;
+}
+
+.gs-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.gs-row {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding: 10px 0;
+  border-top: 1px dashed var(--border);
+}
+.gs-row:first-child {
+  border-top: none;
+}
+
+.gs-mark {
+  flex-shrink: 0;
+  width: 1.4em;
+  text-align: center;
+  color: var(--fg3);
+  line-height: 1.4;
+}
+.gs-row.is-done .gs-mark {
+  color: var(--success);
+}
+
+.gs-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.gs-title {
+  display: block;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--fg);
+  line-height: 1.4;
+}
+.gs-row.is-done .gs-title {
+  color: var(--fg3);
+  text-decoration: line-through;
+  text-decoration-color: var(--border-strong);
+}
+
+.gs-body {
+  margin: 2px 0 0;
+  font-size: var(--text-xs);
+  color: var(--fg3);
+  line-height: 1.45;
+}
+.gs-row.is-done .gs-body {
+  display: none;
+}
+
+.gs-cta {
+  flex-shrink: 0;
+  align-self: center;
+}
+
+.gs-footer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-2);
+  padding-top: var(--space-2);
+  border-top: 1px dashed var(--border);
+}
+
+.gs-dismiss {
+  min-height: var(--touch);
+  padding: 6px 10px;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--fg2);
+  font-family: var(--font);
+  font-size: var(--text-xs);
+  cursor: pointer;
+}
+.gs-dismiss:hover {
+  color: var(--fg);
+  border-color: var(--fg2);
+}
+</style>

--- a/web/src/components/ProductTour.vue
+++ b/web/src/components/ProductTour.vue
@@ -34,6 +34,13 @@
         />
         <p class="product-tour-body">{{ tour.currentStep.body }}</p>
         <p v-if="showMissingHint" class="product-tour-missing">{{ tour.currentStep.missingHint }}</p>
+        <button
+          v-if="tour.currentStep.action"
+          type="button"
+          class="product-tour-tryit"
+          :disabled="tour.preparing"
+          @click="tryIt(tour.currentStep.action)"
+        >{{ tour.currentStep.action.label }} →</button>
         <div class="product-tour-actions">
           <button type="button" class="product-tour-skip" @click="tour.skip()">Skip tour</button>
           <div class="product-tour-nav">
@@ -58,12 +65,23 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
 import { useProductTourStore } from '../stores/productTour'
 import { useProjectStore } from '../stores/projects'
 import { shouldShowMissingHint, tourTargetSelector } from '../lib/productTour'
 
 const tour = useProductTourStore()
 const projectStore = useProjectStore()
+const router = useRouter()
+
+// "Try it" hands control to the user on the real page; the tour has done its
+// job and can be replayed from Settings → Home.
+async function tryIt(action: { label: string; route: string }) {
+  tour.finish()
+  if (router.currentRoute.value.path !== action.route) {
+    await router.push(action.route)
+  }
+}
 
 const targetRect = ref<DOMRect | null>(null)
 const cardEl = ref<HTMLElement | null>(null)
@@ -302,6 +320,26 @@ onBeforeUnmount(() => {
   border: 1px solid var(--border-strong);
   border-left: 3px solid var(--accent2);
   border-radius: var(--radius-sm);
+}
+
+.product-tour-tryit {
+  display: block;
+  width: 100%;
+  min-height: var(--touch);
+  margin: 0 0 12px;
+  padding: 8px 12px;
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-elev));
+  border: 1px solid var(--accent);
+  border-radius: var(--radius);
+  color: var(--fg);
+  font-family: var(--font);
+  font-size: var(--text-sm);
+  text-align: left;
+  cursor: pointer;
+  transition: background 120ms var(--ease);
+}
+.product-tour-tryit:hover {
+  background: color-mix(in srgb, var(--accent) 18%, var(--bg-elev));
 }
 
 .product-tour-actions {

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -226,6 +226,9 @@
           </div>
         </div>
 
+        <!-- Getting started checklist -->
+        <GettingStartedChecklist variant="settings" @open-sidebar="emit('open-sidebar')" />
+
         <!-- Debug (dev mode only) -->
         <div v-if="localStatus?.dev_mode" class="card">
           <div class="settings-card-header">
@@ -1511,6 +1514,7 @@ import { useProductTourStore } from '../stores/productTour'
 import PaneHeader from './PaneHeader.vue'
 import ModelSelector from './ModelSelector.vue'
 import RestartOverlay from './RestartOverlay.vue'
+import GettingStartedChecklist from './GettingStartedChecklist.vue'
 import { providerModelBadges, sectionsFromModelOptions, type ModelSection } from '../lib/modelSections'
 
 const emit = defineEmits<{ 'open-sidebar': [] }>()

--- a/web/src/components/__tests__/mountSmoke.test.ts
+++ b/web/src/components/__tests__/mountSmoke.test.ts
@@ -323,6 +323,21 @@ describe('component mount smoke', () => {
     expect(errors).toEqual([])
   })
 
+  it('GettingStartedChecklist mounts and lists open items', async () => {
+    const router = makeRouter()
+    await router.push('/')
+    await router.isReady()
+    const mod = await import('../GettingStartedChecklist.vue')
+    const wrapper = mount(mod.default as never, {
+      global: { plugins: [router] },
+    })
+    await flushPromises()
+    // Fresh mocked state: nothing completed, checklist visible with all items.
+    expect(wrapper.text()).toContain('Getting started')
+    expect(wrapper.findAll('.gs-row').length).toBeGreaterThanOrEqual(5)
+    wrapper.unmount()
+  })
+
   it('SettingsView renders skills with custom and github labels on /settings/skills', async () => {
     const router = makeRouter()
     await router.push('/settings/skills')

--- a/web/src/lib/gettingStarted.test.ts
+++ b/web/src/lib/gettingStarted.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  GETTING_STARTED_ITEMS,
+  GETTING_STARTED_STORAGE_KEY,
+  clearChecklistDismissed,
+  countReadyProviders,
+  gettingStartedProgress,
+  isChecklistDismissed,
+  markChecklistDismissed,
+  type GettingStartedState,
+} from './gettingStarted'
+
+const FRESH: GettingStartedState = {
+  providerReadyCount: 1,
+  workspaceCount: 1,
+  userProjectCount: 0,
+  scheduleCount: 0,
+  activeChatCount: 0,
+}
+
+const VETERAN: GettingStartedState = {
+  providerReadyCount: 2,
+  workspaceCount: 2,
+  userProjectCount: 3,
+  scheduleCount: 1,
+  activeChatCount: 5,
+}
+
+describe('gettingStarted', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('every item deep-links to a route', () => {
+    for (const item of GETTING_STARTED_ITEMS) {
+      expect(item.route.startsWith('/')).toBe(true)
+      expect(item.cta.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('a fresh install has everything open except nothing', () => {
+    const progress = gettingStartedProgress(FRESH)
+    expect(progress.doneCount).toBe(0)
+    expect(progress.allDone).toBe(false)
+    expect(progress.total).toBe(GETTING_STARTED_ITEMS.length)
+  })
+
+  it('items complete from real state', () => {
+    const progress = gettingStartedProgress(VETERAN)
+    expect(progress.allDone).toBe(true)
+
+    const byId = (state: GettingStartedState) =>
+      Object.fromEntries(gettingStartedProgress(state).items.map(i => [i.id, i.done]))
+
+    expect(byId({ ...FRESH, activeChatCount: 1 })['first-chat']).toBe(true)
+    expect(byId({ ...FRESH, userProjectCount: 1 })['project']).toBe(true)
+    expect(byId({ ...FRESH, workspaceCount: 2 })['workspace']).toBe(true)
+    expect(byId({ ...FRESH, scheduleCount: 1 })['schedule']).toBe(true)
+    // The setup-wizard provider alone does not complete the provider item.
+    expect(byId({ ...FRESH, providerReadyCount: 1 })['provider']).toBe(false)
+    expect(byId({ ...FRESH, providerReadyCount: 2 })['provider']).toBe(true)
+  })
+
+  it('counts ready providers defensively', () => {
+    expect(countReadyProviders(undefined)).toBe(0)
+    expect(countReadyProviders(null)).toBe(0)
+    expect(countReadyProviders([])).toBe(0)
+    expect(countReadyProviders({ providers: 'oops' })).toBe(0)
+    expect(
+      countReadyProviders({
+        providers: {
+          claude: { ok: true },
+          codex: { ok: false },
+          ollama: { ok: true },
+          openrouter: null,
+        },
+      }),
+    ).toBe(2)
+  })
+
+  it('tracks dismissal in localStorage', () => {
+    expect(isChecklistDismissed()).toBe(false)
+    markChecklistDismissed()
+    expect(isChecklistDismissed()).toBe(true)
+    expect(localStorage.getItem(GETTING_STARTED_STORAGE_KEY)).toBe('1')
+    clearChecklistDismissed()
+    expect(isChecklistDismissed()).toBe(false)
+  })
+})

--- a/web/src/lib/gettingStarted.ts
+++ b/web/src/lib/gettingStarted.ts
@@ -1,0 +1,119 @@
+export const GETTING_STARTED_STORAGE_KEY = 'ciao-getting-started-dismissed'
+
+/** Snapshot of the app state the checklist derives completion from. */
+export type GettingStartedState = {
+  /** Providers reporting ok=true in /api/setup-status. */
+  providerReadyCount: number
+  workspaceCount: number
+  /** Projects created by the user (excludes auto/system projects). */
+  userProjectCount: number
+  scheduleCount: number
+  /** Chats that have seen at least one message (last_activity_at set). */
+  activeChatCount: number
+}
+
+export interface GettingStartedItem {
+  id: string
+  title: string
+  body: string
+  cta: string
+  /** Router path the CTA deep-links to. */
+  route: string
+  /** The target UI lives in the sidebar, so the CTA also opens it. */
+  opensSidebar?: boolean
+  done: (state: GettingStartedState) => boolean
+}
+
+export const GETTING_STARTED_ITEMS: GettingStartedItem[] = [
+  {
+    id: 'first-chat',
+    title: 'Send your first message',
+    body: 'Say hello, or ask "what can Ciaobot do?" for a guided walkthrough of memory, skills, and integrations.',
+    cta: 'Open a chat',
+    route: '/',
+    opensSidebar: true,
+    done: s => s.activeChatCount > 0,
+  },
+  {
+    id: 'project',
+    title: 'Create your first project',
+    body: 'Projects group related chats and inject durable context into every conversation. Use "+ Project" in the sidebar.',
+    cta: 'Show the sidebar',
+    route: '/',
+    opensSidebar: true,
+    done: s => s.userProjectCount > 0,
+  },
+  {
+    id: 'workspace',
+    title: 'Add a second workspace',
+    body: 'Split life areas — personal, work, a client. Each workspace gets its own vault, projects, and default model.',
+    cta: 'Open workspace settings',
+    route: '/settings/workspaces',
+    done: s => s.workspaceCount >= 2,
+  },
+  {
+    id: 'schedule',
+    title: 'Schedule a routine',
+    body: 'Dispatch recurring prompts into a project or chat — daily reviews, weekly digests, maintenance checks.',
+    cta: 'Open schedules',
+    route: '/schedules',
+    done: s => s.scheduleCount > 0,
+  },
+  {
+    id: 'provider',
+    title: 'Connect another provider',
+    body: 'Add a second backend — Claude Code, Codex, Ollama, or OpenRouter — and switch per workspace or per chat.',
+    cta: 'Open provider settings',
+    route: '/settings/providers',
+    done: s => s.providerReadyCount >= 2,
+  },
+]
+
+/** An item with its `done` predicate resolved against the current state. */
+export type GettingStartedItemStatus = Omit<GettingStartedItem, 'done'> & { done: boolean }
+
+export type GettingStartedProgress = {
+  items: GettingStartedItemStatus[]
+  doneCount: number
+  total: number
+  allDone: boolean
+}
+
+export function gettingStartedProgress(state: GettingStartedState): GettingStartedProgress {
+  const items = GETTING_STARTED_ITEMS.map(item => ({ ...item, done: item.done(state) }))
+  const doneCount = items.filter(i => i.done).length
+  return { items, doneCount, total: items.length, allDone: doneCount === items.length }
+}
+
+/** Defensive: /api/setup-status may be unreachable or oddly shaped. */
+export function countReadyProviders(status: unknown): number {
+  const providers = (status as { providers?: unknown } | null)?.providers
+  if (!providers || typeof providers !== 'object') return 0
+  return Object.values(providers as Record<string, unknown>).filter(
+    row => !!(row as { ok?: boolean } | null)?.ok,
+  ).length
+}
+
+export function isChecklistDismissed(): boolean {
+  try {
+    return localStorage.getItem(GETTING_STARTED_STORAGE_KEY) === '1'
+  } catch {
+    return false
+  }
+}
+
+export function markChecklistDismissed(): void {
+  try {
+    localStorage.setItem(GETTING_STARTED_STORAGE_KEY, '1')
+  } catch {
+    // ignore quota / private browsing
+  }
+}
+
+export function clearChecklistDismissed(): void {
+  try {
+    localStorage.removeItem(GETTING_STARTED_STORAGE_KEY)
+  } catch {
+    // ignore
+  }
+}

--- a/web/src/lib/productTour.test.ts
+++ b/web/src/lib/productTour.test.ts
@@ -38,6 +38,19 @@ describe('productTour', () => {
     expect(tourTargetSelector('chat-input')).toBe('[data-tour="chat-input"]')
   })
 
+  it('offers "Try it" deep links into the real pages', () => {
+    const withActions = Object.fromEntries(
+      PRODUCT_TOUR_STEPS.filter(s => s.action).map(s => [s.id, s.action!.route]),
+    )
+    expect(withActions['workspaces']).toBe('/settings/workspaces')
+    expect(withActions['schedules']).toBe('/schedules')
+    for (const step of PRODUCT_TOUR_STEPS) {
+      if (!step.action) continue
+      expect(step.action.route.startsWith('/')).toBe(true)
+      expect(step.action.label.length).toBeGreaterThan(0)
+    }
+  })
+
   it('shows missing hints when chat UI or projects are unavailable', () => {
     const modelStep = PRODUCT_TOUR_STEPS.find(s => s.id === 'model')!
     const fileStep = PRODUCT_TOUR_STEPS.find(s => s.id === 'file-cards')!

--- a/web/src/lib/productTour.ts
+++ b/web/src/lib/productTour.ts
@@ -17,6 +17,8 @@ export interface ProductTourStep {
   /** Illustrative screenshot shown in the card for features that may not be visible live. */
   image?: string
   imageAlt?: string
+  /** "Try it" deep link: ends the tour and navigates to the real page. */
+  action?: { label: string; route: string }
 }
 
 export type TourAvailabilityContext = {
@@ -57,6 +59,7 @@ export const PRODUCT_TOUR_STEPS: ProductTourStep[] = [
     beforeEnter: ['openSidebar', 'chatRoute'],
     missingHint:
       'You will see workspace tabs in the sidebar once the main view is open. A default personal/work split is created on first launch.',
+    action: { label: 'Try it: manage workspaces', route: '/settings/workspaces' },
   },
   {
     id: 'projects',
@@ -78,6 +81,7 @@ export const PRODUCT_TOUR_STEPS: ProductTourStep[] = [
     placement: 'bottom',
     beforeEnter: ['openSidebar', 'chatRoute'],
     missingHint: 'You will find the Schedules shortcut in the sidebar header once the sidebar is open.',
+    action: { label: 'Try it: open schedules', route: '/schedules' },
   },
   {
     id: 'model',
@@ -147,7 +151,7 @@ export const PRODUCT_TOUR_STEPS: ProductTourStep[] = [
     id: 'done',
     title: 'You are set',
     body:
-      'Ask "what can Ciaobot do?" in any chat for a deeper walkthrough of memory, skills, and integrations. Replay this UI tour from Settings → Home whenever you like.',
+      'The Getting started checklist on the home screen walks you through your first project, workspace, and schedule — each step opens the real page. Ask "what can Ciaobot do?" in any chat for a deeper walkthrough, and replay this UI tour from Settings → Home whenever you like.',
     placement: 'center',
   },
 ]

--- a/web/src/stores/gettingStarted.ts
+++ b/web/src/stores/gettingStarted.ts
@@ -1,0 +1,65 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import { api } from '../lib/api'
+import {
+  clearChecklistDismissed,
+  countReadyProviders,
+  gettingStartedProgress,
+  isChecklistDismissed,
+  markChecklistDismissed,
+  type GettingStartedState,
+} from '../lib/gettingStarted'
+import { useProjectStore } from './projects'
+import { useTaskStore } from './tasks'
+
+export const useGettingStartedStore = defineStore('gettingStarted', () => {
+  const dismissed = ref(isChecklistDismissed())
+  const providerReadyCount = ref(0)
+  const providerStatusLoaded = ref(false)
+
+  async function fetchProviderStatus() {
+    try {
+      const status = await api.get<unknown>('/api/setup-status')
+      providerReadyCount.value = countReadyProviders(status)
+    } catch {
+      // Endpoint unreachable: keep 0, the provider item just stays open.
+    } finally {
+      providerStatusLoaded.value = true
+    }
+  }
+
+  const state = computed<GettingStartedState>(() => {
+    const projects = useProjectStore()
+    const tasks = useTaskStore()
+    return {
+      providerReadyCount: providerReadyCount.value,
+      workspaceCount: projects.workspaceOptions.length,
+      userProjectCount: projects.projects.filter(p => !p.is_auto && !p.is_system).length,
+      scheduleCount: tasks.schedules.length,
+      activeChatCount: projects.chats.filter(c => c.last_activity_at).length,
+    }
+  })
+
+  const progress = computed(() => gettingStartedProgress(state.value))
+
+  function dismiss() {
+    dismissed.value = true
+    markChecklistDismissed()
+  }
+
+  function restore() {
+    dismissed.value = false
+    clearChecklistDismissed()
+  }
+
+  return {
+    dismissed,
+    providerReadyCount,
+    providerStatusLoaded,
+    fetchProviderStatus,
+    state,
+    progress,
+    dismiss,
+    restore,
+  }
+})


### PR DESCRIPTION
## What

Makes onboarding teach navigation by doing, instead of look-don't-touch:

1. **Product tour "Try it" actions** — tour steps can now carry an `action` deep link. The Workspaces step offers *Try it: manage workspaces* (→ `/settings/workspaces`) and the Schedules step offers *Try it: open schedules* (→ `/schedules`). Clicking ends the tour and lands the user on the real page (the tour stays replayable from Settings → Home, and the final step now points at the checklist).

2. **Getting-started checklist** — a new `GettingStartedChecklist` component rendered on the home empty state and in Settings → Home. Five items, each deep-linking to the page where the step happens, auto-completed from live app state:
   - Send your first message (a chat has `last_activity_at`)
   - Create your first project (any non-auto/system project)
   - Add a second workspace (≥2 workspaces)
   - Schedule a routine (≥1 schedule)
   - Connect another provider (≥2 providers `ok` in `/api/setup-status`)

   The checklist hides itself when complete, is dismissible (localStorage), and can be restored from Settings → Home. Sidebar-based steps also open the sidebar.

## Why

The first-run setup wizard can't walk users through real pages (nothing is configured until `setup/finish` restarts the server), and the existing tour was passive. This keeps time-to-first-chat short and teaches the app geography afterwards, at the moment each feature is wanted.

## Implementation

- `web/src/lib/gettingStarted.ts` — pure item definitions/predicates/progress + defensive `countReadyProviders`
- `web/src/stores/gettingStarted.ts` — Pinia store deriving state from projects/tasks stores, fetches `/api/setup-status` once
- `web/src/components/GettingStartedChecklist.vue` — variants: `home` (auto-hides) and `settings` (always visible, dismissal toggle)
- `web/src/lib/productTour.ts` + `ProductTour.vue` — optional `action` per step, styled "Try it" button
- No backend changes

## Verification

- `npm run test`: 14 files, 84 tests pass (new `gettingStarted` lib tests, tour action tests, mount-smoke for the checklist; ChatLayout/SettingsView smoke mounts exercise the wiring)
- `npm run build`: passes (vue-tsc + vite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)