### PR TITLE
fix(web): highlight only the active model, not same-tier models from other providers

### DIFF
--- a/web/src/components/ModelSelector.vue
+++ b/web/src/components/ModelSelector.vue
@@ -119,9 +119,12 @@ const triggerLabel = computed(() => {
   return v ? displayModelLabel(v) : props.placeholder
 })
 
+const explicitActiveModels = computed(() =>
+  props.activeModels.map((model) => model.trim()).filter(Boolean),
+)
+
 const activeModelSet = computed(() => {
-  const explicit = props.activeModels.map((model) => model.trim()).filter(Boolean)
-  if (explicit.length) return new Set(explicit)
+  if (explicitActiveModels.value.length) return new Set(explicitActiveModels.value)
   return new Set(
     (props.multiple ? (effectiveValue.value as string[]) : [effectiveValue.value as string])
       .map((model) => model.trim())
@@ -177,6 +180,12 @@ function isSelected(model: string): boolean {
 
 function isActive(model: string): boolean {
   if (activeModelSet.value.has(model)) return true
+  // Tier-alias fallback: a bare tier value (e.g. "opus") highlights the
+  // provider-native model carrying that tier badge. Only applies when no
+  // explicit activeModels were given — those are already the exact models in
+  // use (resolved per provider), so alias matching would wrongly light up
+  // same-tier models from other providers.
+  if (explicitActiveModels.value.length) return false
   const aliases = normalizedSections.value
     .find((section) => section.models.includes(model))
     ?.modelBadges?.[model] || []

--- a/web/src/components/__tests__/ModelSelector.test.ts
+++ b/web/src/components/__tests__/ModelSelector.test.ts
@@ -181,6 +181,24 @@ describe('ModelSelector', () => {
     expect(activeModels).toEqual(['kimi-k2.7-code:cloud'])
   })
 
+  it('highlights only the exact explicit active model, not same-tier models from other providers', async () => {
+    const sections: ModelSection[] = [
+      { key: 'anthropic', label: 'Anthropic', models: ['haiku', 'sonnet', 'opus'] },
+      {
+        key: 'codex',
+        label: 'OpenAI Codex',
+        models: ['gpt-5.6-sol'],
+        modelBadges: { 'gpt-5.6-sol': ['Opus'] },
+      },
+    ]
+    const wrapper = mountSelector({ sections, activeModels: ['opus'] })
+    await wrapper.find('.model-selector__trigger').trigger('click')
+    await flushPromises()
+
+    const activeModels = wrapper.findAll('.ms-item--active').map((el) => el.attributes('data-model'))
+    expect(activeModels).toEqual(['opus'])
+  })
+
   it('highlights a native model selected through its tier alias badge', async () => {
     const sections: ModelSection[] = [{
       key: 'codex',


### PR DESCRIPTION
## Problem

In the chat header model picker, selecting Anthropic **opus** also highlighted **gpt-5.6-sol** (badged `Opus`) under OpenAI Codex — every model sharing the tier lit up, not the one actually in use.

<img width="400" alt="before" src="https://github.com/user-attachments/assets/placeholder">

## Cause

The chat header passes explicit `activeModels` already resolved per provider (`opus` for Anthropic, the concrete model id for Codex). But `ModelSelector.isActive()` had a tier-alias fallback: any model whose tier badge (`Opus`) matched a value in the active set was also marked active. That fallback is meant for the **settings** pickers, which highlight a provider-native model from a bare tier value — but it bled across providers when the active model was already explicit.

## Fix

Skip the tier-alias fallback when `activeModels` is explicitly provided (those are already the exact models in use). Keep it for the implicit / `modelValue`-based path used by the settings pickers.

## Tests

- New test: explicit active `opus` highlights only Anthropic's `opus`, not the Codex model badged `Opus`.
- Existing alias-fallback test (settings-style, no explicit `activeModels`) still passes.
- `npm run build` clean; ModelSelector + modelSections + smoke suites green.