### PR TITLE
ci: fix release automation (PyPI publish + develop sync)

### DIFF
--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -29,10 +29,15 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "tag=v${version}" >> "$GITHUB_OUTPUT"
 
+      # Create the release with a PAT, not GITHUB_TOKEN: releases created by
+      # GITHUB_TOKEN do not fire the `release: published` event, so publish.yml
+      # (PyPI + Homebrew) never runs. RELEASE_PAT must be a token with
+      # contents:write. Falls back to github.token when the secret is absent
+      # (release still cut, but publish must then be run manually).
       - name: Create GitHub release
         id: release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
           VERSION: ${{ steps.version.outputs.version }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |
@@ -69,13 +74,18 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # Check out with the PAT so the sync branch push and PR use a token that
+      # is allowed to open PRs. GITHUB_TOKEN cannot create PRs when the org
+      # setting "Allow GitHub Actions to create and approve pull requests" is
+      # off, which fails this job.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT || github.token }}
 
       - name: Sync develop with main
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
           VERSION: ${{ needs.release.outputs.version }}
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
The first release through `release-on-main.yml` (**v0.4.16**) exposed two breakages — the release was tagged and a GitHub release created, but it did **not** publish to PyPI and did **not** sync `develop`. Both were recovered manually; this fixes the automation.

## Root causes
1. **PyPI publish never fired.** `publish.yml` triggers on `release: published`, but releases created with the workflow's `GITHUB_TOKEN` do **not** trigger downstream workflows (GitHub's recursion guard). So the release was created but `publish.yml` never ran.
2. **`sync-develop` failed.** `GITHUB_TOKEN` cannot open PRs when the org setting *"Allow GitHub Actions to create and approve pull requests"* is off — the job errored at `gh pr create` (`GitHub Actions is not permitted to create or approve pull requests`).

## Fix
Use a `RELEASE_PAT` secret (contents:write, pull-requests:write) for:
- creating the GitHub release (so `release: published` fires → `publish.yml` runs), and
- the `sync-develop` checkout + PR (so the sync PR can be created/merged).

Both use `${{ secrets.RELEASE_PAT || github.token }}` — a graceful fallback: if the secret isn't set yet, behaviour is unchanged (release is still tagged; publish must be run manually), and it "activates" the moment the secret is added.

## ⚠️ Action required to activate
Add a repo secret **`RELEASE_PAT`** — a fine-grained PAT with **Contents: read/write** and **Pull requests: read/write** on this repo (classic PAT with `repo` scope also works). Without it, the next release will behave exactly as v0.4.16 did.

### Why not a reusable workflow instead of a PAT?
Calling `publish.yml` via `workflow_call` would avoid the PAT, but PyPI **trusted publishing** is configured against `publish.yml` as the direct trigger; routing it through a caller workflow risks breaking the OIDC subject match. Keeping `publish.yml` triggered by the real `release: published` event preserves trusted publishing exactly.

Note: v0.4.16 itself is already fully published (PyPI + Homebrew + release artifacts) via manual recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)