### PR TITLE
chore: sync develop with main after v0.4.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.4.17 - 2026-07-14
+
+### Changed
+- Merge pull request #78 from raffaelefarinaro/chore/sync-develop-v0.4.16 (`edaeb8a`)
+- Merge pull request #80 from raffaelefarinaro/fix-macos-window-identity-and-upgrade (`b6b4e49`)
+
+### Fixed
+- fix(macos): native window Dock identity + self-heal server after brew upgrade (`4c7c7c1`)
+- fix(macos): persist WebKit localStorage so the welcome tour shows once (`c56d142`)
+
+### Maintenance
+- ci: fix release automation so publish and develop-sync actually run (`de45709`)
+
 ## v0.4.16 - 2026-07-13
 
 ### Changed

--- a/ciao/__init__.py
+++ b/ciao/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.16"
+__version__ = "0.4.17"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciaobot"
-version = "0.4.16"
+version = "0.4.17"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-pwa",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-pwa",
-      "version": "0.4.16",
+      "version": "0.4.17",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
         "dompurify": "^3.4.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-pwa",
   "private": true,
-  "version": "0.4.16",
+  "version": "0.4.17",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Automated sync branch pushed by the release workflow; the bot couldn't open the PR (Actions can't create PRs without RELEASE_PAT). Fast-forward of develop to main after v0.4.17.