### PR TITLE
fix(macos): window won't open after update — launch via venv python

### DIFF
--- a/ciao/menubar.py
+++ b/ciao/menubar.py
@@ -285,31 +285,19 @@ def _python_with_ciao() -> str:
     return sys.executable
 
 
-def _bundle_python() -> str | None:
-    """Path to Ciaobot.app's bundle-local ``python`` symlink, if installed.
-
-    Launching the window through the interpreter that lives inside
-    ``Ciaobot.app/Contents/MacOS`` makes macOS attribute the process to the
-    app bundle, so the Dock shows "Ciaobot" and its icon instead of a bare
-    "Python" rocket. The symlink targets the real interpreter (written by
-    cli.py's _write_menubar_helper), so ``ciao``/``webview`` still import.
-    """
-
-    for base in (Path.home() / "Applications", Path("/Applications")):
-        candidate = base / "Ciaobot.app" / "Contents" / "MacOS" / "python"
-        if candidate.exists():
-            return str(candidate)
-    return None
-
-
 def _window_launch_command(url: str, workspace: Path | None) -> list[str]:
     """argv that opens ``url`` in the native window (single-instance aware).
 
-    Prefer the app-bundle interpreter so the window carries Ciaobot's Dock
-    identity; fall back to any interpreter that can import ``ciao``.
+    Must run through :func:`_python_with_ciao` — the venv interpreter that can
+    import ``ciao``/``webview``. Do NOT route this through the app bundle's
+    ``Contents/MacOS/python`` symlink: invoking Python via that out-of-venv
+    symlink resolves ``sys.prefix`` to the base Homebrew framework instead of
+    the ciaobot keg venv, so ``import webview`` fails and the window never
+    opens. The Dock icon is set from inside the window instead (see
+    ciao.window._set_dock_icon).
     """
 
-    cmd = [_bundle_python() or _python_with_ciao(), "-m", "ciao.window", url]
+    cmd = [_python_with_ciao(), "-m", "ciao.window", url]
     if workspace is not None:
         cmd += ["--workspace", str(workspace)]
     return cmd

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -149,9 +149,10 @@ def test_open_command_prefers_browser_app_mode(monkeypatch) -> None:
     ]
 
 
-def test_window_launch_command_includes_workspace(tmp_path: Path, monkeypatch) -> None:
-    # No app bundle: falls back to an interpreter that can import ciao.
-    monkeypatch.setattr(menubar, "_bundle_python", lambda: None)
+def test_window_launch_command_uses_venv_python(tmp_path: Path) -> None:
+    # Must launch through the venv interpreter that can import ciao/webview —
+    # NOT the app-bundle python symlink, which resolves outside the venv and
+    # breaks `import webview` so the window never opens.
     interp = menubar._python_with_ciao()
     cmd = menubar._window_launch_command("http://localhost:8443/", tmp_path)
     assert cmd == [
@@ -168,14 +169,6 @@ def test_window_launch_command_includes_workspace(tmp_path: Path, monkeypatch) -
         "ciao.window",
         "http://localhost:8443/",
     ]
-
-
-def test_window_launch_command_prefers_bundle_python(monkeypatch) -> None:
-    # When Ciaobot.app is installed, launch the window through its bundle
-    # interpreter so macOS shows the Ciaobot Dock identity, not "Python".
-    monkeypatch.setattr(menubar, "_bundle_python", lambda: "/Apps/Ciaobot.app/Contents/MacOS/python")
-    cmd = menubar._window_launch_command("http://localhost:8443/", None)
-    assert cmd[0] == "/Apps/Ciaobot.app/Contents/MacOS/python"
 
 
 def _write_bundle(path: Path, *, bundle_id: str) -> None:


### PR DESCRIPTION
**Regression from 0.4.17 (#80).** After a Homebrew update the native window stops opening ("Ciaobot doesn't start"). The server is fine; only the window fails.

## Cause
#80 made `_window_launch_command` prefer `Ciaobot.app/Contents/MacOS/python` to give the window a Ciaobot Dock identity. But invoking Python through that **out-of-venv symlink** makes CPython resolve `sys.prefix` to the base Homebrew framework (`/opt/homebrew/opt/python@3.12/…`) instead of the ciaobot keg venv. Verified on the affected machine:

```
/Applications/Ciaobot.app/Contents/MacOS/python -c "import ciao"     # ModuleNotFoundError
/opt/homebrew/opt/ciaobot/libexec/bin/python     -c "import webview" # OK
```

So `import webview` (and `import ciao`) fail in the spawned window process and it dies before showing anything.

## Fix
Launch through `_python_with_ciao()` — the venv interpreter that imports `ciao`/`webview` correctly — and drop the broken `_bundle_python()` helper. The orange Dock icon still comes from `ciao.window._set_dock_icon()`; the window process shows as "Python" again, which is purely cosmetic next to it actually opening.

## Verification
On the real 0.4.17 keg: `_python_with_ciao()` → `…/Cellar/ciaobot/0.4.17/libexec/bin/python`, which imports `ciao`+`webview` (exit 0) → window opens.
Tests updated; `pytest tests/test_menubar.py tests/test_window.py` green.

Full Dock **name** identity ("Ciaobot" vs "Python") is a separate, harder problem (the bundle-symlink route is incompatible with venv resolution) — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)