### PR TITLE
Release v0.4.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.4.18 - 2026-07-14
+
+### Changed
+- Merge pull request #82 from raffaelefarinaro/chore/sync-develop-v0.4.17 (`3153b2c`)
+- Merge pull request #83 from raffaelefarinaro/fix-window-venv-launch (`d6b7761`)
+
+### Fixed
+- fix(macos): open the window via the venv python, not the app-bundle symlink (`8358a5d`)
+
 ## v0.4.17 - 2026-07-14
 
 ### Changed

--- a/ciao/__init__.py
+++ b/ciao/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.17"
+__version__ = "0.4.18"

--- a/ciao/menubar.py
+++ b/ciao/menubar.py
@@ -285,31 +285,19 @@ def _python_with_ciao() -> str:
     return sys.executable
 
 
-def _bundle_python() -> str | None:
-    """Path to Ciaobot.app's bundle-local ``python`` symlink, if installed.
-
-    Launching the window through the interpreter that lives inside
-    ``Ciaobot.app/Contents/MacOS`` makes macOS attribute the process to the
-    app bundle, so the Dock shows "Ciaobot" and its icon instead of a bare
-    "Python" rocket. The symlink targets the real interpreter (written by
-    cli.py's _write_menubar_helper), so ``ciao``/``webview`` still import.
-    """
-
-    for base in (Path.home() / "Applications", Path("/Applications")):
-        candidate = base / "Ciaobot.app" / "Contents" / "MacOS" / "python"
-        if candidate.exists():
-            return str(candidate)
-    return None
-
-
 def _window_launch_command(url: str, workspace: Path | None) -> list[str]:
     """argv that opens ``url`` in the native window (single-instance aware).
 
-    Prefer the app-bundle interpreter so the window carries Ciaobot's Dock
-    identity; fall back to any interpreter that can import ``ciao``.
+    Must run through :func:`_python_with_ciao` — the venv interpreter that can
+    import ``ciao``/``webview``. Do NOT route this through the app bundle's
+    ``Contents/MacOS/python`` symlink: invoking Python via that out-of-venv
+    symlink resolves ``sys.prefix`` to the base Homebrew framework instead of
+    the ciaobot keg venv, so ``import webview`` fails and the window never
+    opens. The Dock icon is set from inside the window instead (see
+    ciao.window._set_dock_icon).
     """
 
-    cmd = [_bundle_python() or _python_with_ciao(), "-m", "ciao.window", url]
+    cmd = [_python_with_ciao(), "-m", "ciao.window", url]
     if workspace is not None:
         cmd += ["--workspace", str(workspace)]
     return cmd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciaobot"
-version = "0.4.17"
+version = "0.4.18"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -149,9 +149,10 @@ def test_open_command_prefers_browser_app_mode(monkeypatch) -> None:
     ]
 
 
-def test_window_launch_command_includes_workspace(tmp_path: Path, monkeypatch) -> None:
-    # No app bundle: falls back to an interpreter that can import ciao.
-    monkeypatch.setattr(menubar, "_bundle_python", lambda: None)
+def test_window_launch_command_uses_venv_python(tmp_path: Path) -> None:
+    # Must launch through the venv interpreter that can import ciao/webview —
+    # NOT the app-bundle python symlink, which resolves outside the venv and
+    # breaks `import webview` so the window never opens.
     interp = menubar._python_with_ciao()
     cmd = menubar._window_launch_command("http://localhost:8443/", tmp_path)
     assert cmd == [
@@ -168,14 +169,6 @@ def test_window_launch_command_includes_workspace(tmp_path: Path, monkeypatch) -
         "ciao.window",
         "http://localhost:8443/",
     ]
-
-
-def test_window_launch_command_prefers_bundle_python(monkeypatch) -> None:
-    # When Ciaobot.app is installed, launch the window through its bundle
-    # interpreter so macOS shows the Ciaobot Dock identity, not "Python".
-    monkeypatch.setattr(menubar, "_bundle_python", lambda: "/Apps/Ciaobot.app/Contents/MacOS/python")
-    cmd = menubar._window_launch_command("http://localhost:8443/", None)
-    assert cmd[0] == "/Apps/Ciaobot.app/Contents/MacOS/python"
 
 
 def _write_bundle(path: Path, *, bundle_id: str) -> None:

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-pwa",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-pwa",
-      "version": "0.4.17",
+      "version": "0.4.18",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
         "dompurify": "^3.4.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-pwa",
   "private": true,
-  "version": "0.4.17",
+  "version": "0.4.18",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Release Ciaobot v0.4.18 to `main`
- Update package, PWA, and package-lock versions
- Add changelog notes for the release range

## Release notes
## v0.4.18 - 2026-07-14

### Changed
- Merge pull request #78 from raffaelefarinaro/chore/sync-develop-v0.4.16 (`edaeb8a`)
- Merge pull request #80 from raffaelefarinaro/fix-macos-window-identity-and-upgrade (`b6b4e49`)

### Fixed
- fix(macos): native window Dock identity + self-heal server after brew upgrade (`4c7c7c1`)
- fix(macos): persist WebKit localStorage so the welcome tour shows once (`c56d142`)

### Maintenance
- ci: fix release automation so publish and develop-sync actually run (`de45709`)

## Testing
- Not run

## After approval
- Merge this PR into `main`
- GitHub Actions will create tag `v0.4.18`, publish the GitHub release, and sync `develop`
