### PR TITLE
chore: sync develop with main after v0.4.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.4.18 - 2026-07-14
+
+### Changed
+- Merge pull request #82 from raffaelefarinaro/chore/sync-develop-v0.4.17 (`3153b2c`)
+- Merge pull request #83 from raffaelefarinaro/fix-window-venv-launch (`d6b7761`)
+
+### Fixed
+- fix(macos): open the window via the venv python, not the app-bundle symlink (`8358a5d`)
+
 ## v0.4.17 - 2026-07-14
 
 ### Changed

--- a/ciao/__init__.py
+++ b/ciao/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.17"
+__version__ = "0.4.18"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciaobot"
-version = "0.4.17"
+version = "0.4.18"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-pwa",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-pwa",
-      "version": "0.4.17",
+      "version": "0.4.18",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
         "dompurify": "^3.4.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-pwa",
   "private": true,
-  "version": "0.4.17",
+  "version": "0.4.18",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Automated sync branch from the release workflow (bot can't open PRs without RELEASE_PAT). Fast-forward of develop to main after v0.4.18.