### PR TITLE
Release v0.4.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,20 +8,6 @@
 - Merge pull request #86 from raffaelefarinaro/harden-window-launch-and-release (`3392435`)
 - release: prepare v0.4.19 (`28b0b44`)
 
-## v0.4.19 - 2026-07-14
-
-### Changed
-- Merge pull request #82 from raffaelefarinaro/chore/sync-develop-v0.4.17 (`3153b2c`)
-- Merge pull request #83 from raffaelefarinaro/fix-window-venv-launch (`d6b7761`)
-- release: prepare v0.4.18 (`3b61568`)
-- Merge pull request #84 from raffaelefarinaro/release/v0.4.18 (`7e10414`)
-- Merge pull request #85 from raffaelefarinaro/chore/sync-develop-v0.4.18 (`4a937db`)
-- harden: guarantee the app opens + stop releases from stale local develop (`896d513`)
-- Merge pull request #86 from raffaelefarinaro/harden-window-launch-and-release (`3392435`)
-
-### Fixed
-- fix(macos): open the window via the venv python, not the app-bundle symlink (`8358a5d`)
-
 ## v0.4.18 - 2026-07-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v0.4.19 - 2026-07-14
+
+### Changed
+- Merge pull request #82 from raffaelefarinaro/chore/sync-develop-v0.4.17 (`3153b2c`)
+- Merge pull request #83 from raffaelefarinaro/fix-window-venv-launch (`d6b7761`)
+- release: prepare v0.4.18 (`3b61568`)
+- Merge pull request #84 from raffaelefarinaro/release/v0.4.18 (`7e10414`)
+- Merge pull request #85 from raffaelefarinaro/chore/sync-develop-v0.4.18 (`4a937db`)
+- harden: guarantee the app opens + stop releases from stale local develop (`896d513`)
+- Merge pull request #86 from raffaelefarinaro/harden-window-launch-and-release (`3392435`)
+
+### Fixed
+- fix(macos): open the window via the venv python, not the app-bundle symlink (`8358a5d`)
+
 ## v0.4.18 - 2026-07-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## v0.4.19 - 2026-07-14
 
 ### Changed
+- Merge pull request #85 from raffaelefarinaro/chore/sync-develop-v0.4.18 (`4a937db`)
+- harden: guarantee the app opens + stop releases from stale local develop (`896d513`)
+- Merge pull request #86 from raffaelefarinaro/harden-window-launch-and-release (`3392435`)
+- release: prepare v0.4.19 (`28b0b44`)
+
+## v0.4.19 - 2026-07-14
+
+### Changed
 - Merge pull request #82 from raffaelefarinaro/chore/sync-develop-v0.4.17 (`3153b2c`)
 - Merge pull request #83 from raffaelefarinaro/fix-window-venv-launch (`d6b7761`)
 - release: prepare v0.4.18 (`3b61568`)

--- a/ciao/__init__.py
+++ b/ciao/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.18"
+__version__ = "0.4.19"

--- a/ciao/cli.py
+++ b/ciao/cli.py
@@ -397,6 +397,12 @@ def _write_app_shortcut(
     # workspace lets that process de-duplicate: if a Ciaobot window is already
     # open it focuses it instead of stacking another one (ciao.window's
     # single-instance lock).
+    #
+    # Resolve the bundle-local python symlink to its real target before running
+    # it: invoking Python *through* the Contents/MacOS/python symlink resolves
+    # sys.prefix to the base framework, not the venv, so `import webview`/`ciao`
+    # fail and the window never opens. If the window still can't start, fall
+    # back to `open` so double-clicking the app always opens the UI.
     executable.write_text(
         "#!/bin/sh\n"
         "start_agent() {\n"
@@ -431,9 +437,11 @@ def _write_app_shortcut(
         f'  url="http://localhost:{port}/"\n'
         "fi\n"
         'DIR="$(cd "$(dirname "$0")" && pwd)"\n'
+        'PY="$DIR/python"\n'
+        'if [ -L "$PY" ]; then PY="$(readlink "$PY")"; fi\n'
         "open_ciaobot_url() {\n"
         '  target="$1"\n'
-        f'  exec "$DIR/python" -m ciao.window "$target" --workspace "{workspace}"\n'
+        f'  "$PY" -m ciao.window "$target" --workspace "{workspace}" || open "$target"\n'
         "}\n"
         'open_ciaobot_url "$url"\n',
         encoding="utf-8",

--- a/ciao/menubar.py
+++ b/ciao/menubar.py
@@ -303,22 +303,58 @@ def _window_launch_command(url: str, workspace: Path | None) -> list[str]:
     return cmd
 
 
+_WINDOW_INTERP_OK: dict[str, bool] = {}
+
+
+def _window_interpreter_ok(interp: str) -> bool:
+    """True if ``interp`` can import the window module (i.e. resolves ``ciao``).
+
+    Guards the native-window path: an interpreter that can't ``import
+    ciao.window`` — e.g. an app-bundle python symlink that resolves outside the
+    venv — would exit before drawing anything, so the window silently never
+    opens. When this is False the caller opens the URL in the browser instead,
+    so the app *always* opens. Result cached per interpreter path.
+    """
+
+    cached = _WINDOW_INTERP_OK.get(interp)
+    if cached is not None:
+        return cached
+    ok = False
+    try:
+        completed = subprocess.run(
+            [interp, "-c", "import ciao.window"],
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+        ok = completed.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        ok = False
+    _WINDOW_INTERP_OK[interp] = ok
+    return ok
+
+
 def launch_ui(url: str, workspace: Path | None = None) -> None:
     """Open the Ciaobot UI without blocking the caller (menu bar callbacks).
 
     On macOS the URL opens in the native WebKit window (``ciao.window``);
     passing ``workspace`` lets it focus an already-open window instead of
-    stacking a duplicate.
+    stacking a duplicate. If the resolved interpreter can't load the window
+    module, fall back to opening the URL in the browser so the app still opens.
     """
 
     if sys.platform == "darwin":
-        subprocess.Popen(
-            _window_launch_command(url, workspace),
-            start_new_session=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        return
+        cmd = _window_launch_command(url, workspace)
+        if _window_interpreter_ok(cmd[0]):
+            subprocess.Popen(
+                cmd,
+                start_new_session=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return
+        # Interpreter can't load ciao.window (misconfigured install): don't
+        # leave the user with nothing — open the URL in the browser.
     subprocess.run(open_command(url), check=False)
 
 

--- a/ciao/package_smoke.py
+++ b/ciao/package_smoke.py
@@ -30,10 +30,16 @@ def _venv_python(venv_dir: Path) -> Path:
 
 def _installed_probe(require_stock: bool) -> str:
     return f"""
+import sys
 from pathlib import Path
 from importlib import resources
 
 import ciao
+import ciao.window  # menu bar "Open Ciaobot" launches this; must import
+if sys.platform == "darwin":
+    # The native window backend must ship on macOS, or the tray/app opens
+    # nothing. This is the regression class that left the window unopenable.
+    import webview  # noqa: F401
 from ciao.config import CiaoConfig
 from ciao.web.app import create_app
 from starlette.testclient import TestClient

--- a/ciao/release.py
+++ b/ciao/release.py
@@ -311,12 +311,18 @@ def _ensure_clean(root: Path, *, allow_dirty: bool) -> None:
 
 
 def _resolve_source_ref(root: Path, source: str) -> str:
-    local = _git(root, ["rev-parse", "--verify", source], check=False)
-    if local:
-        return source
+    # Prefer the freshly-fetched remote branch over a same-named local branch.
+    # _checkout_release_branch fetches origin/<source> right before this; a
+    # local `develop` that lagged origin would otherwise cut the release from a
+    # stale tree, silently shipping a version that omits already-merged PRs.
+    # Fall back to a local ref only when there is no remote (tags, SHAs,
+    # detached work).
     remote = _git(root, ["rev-parse", "--verify", f"origin/{source}"], check=False)
     if remote:
         return f"origin/{source}"
+    local = _git(root, ["rev-parse", "--verify", source], check=False)
+    if local:
+        return source
     raise ReleaseError(
         f"could not resolve release source branch {source!r}; "
         "fetch origin or check out the branch locally"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciaobot"
-version = "0.4.18"
+version = "0.4.19"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -305,8 +305,12 @@ def test_setup_scaffolds_workspace_from_stock(tmp_path: Path) -> None:
         'start_agent "com.ciao.menubar" "$HOME/Library/LaunchAgents/com.ciao.menubar.plist"'
         in app_text
     )
-    # Opens the native Ciaobot window (WebKit via pywebview).
-    assert 'exec "$DIR/python" -m ciao.window "$target"' in app_text
+    # Opens the native Ciaobot window (WebKit via pywebview), resolving the
+    # bundle python symlink to the real venv interpreter and falling back to
+    # the browser if the window can't start.
+    assert 'if [ -L "$PY" ]; then PY="$(readlink "$PY")"; fi' in app_text
+    assert '"$PY" -m ciao.window "$target"' in app_text
+    assert '|| open "$target"' in app_text
     assert 'open_ciaobot_url "$url"' in app_text
     setup_token = token_file.read_text(encoding="utf-8").strip()
     assert setup_token

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -171,6 +171,47 @@ def test_window_launch_command_uses_venv_python(tmp_path: Path) -> None:
     ]
 
 
+def test_window_interpreter_ok_true_for_real_python(monkeypatch) -> None:
+    menubar._WINDOW_INTERP_OK.clear()
+    # The test interpreter can import ciao.window.
+    assert menubar._window_interpreter_ok(sys.executable) is True
+    # Result is cached.
+    assert menubar._WINDOW_INTERP_OK[sys.executable] is True
+
+
+def test_window_interpreter_ok_false_for_broken_python(monkeypatch) -> None:
+    menubar._WINDOW_INTERP_OK.clear()
+    assert menubar._window_interpreter_ok("/nonexistent/python") is False
+
+
+def test_launch_ui_opens_browser_when_interpreter_broken(monkeypatch) -> None:
+    # The core guarantee: a launch interpreter that can't load the window
+    # module must NOT leave the user with nothing — fall back to the browser.
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(menubar, "_window_interpreter_ok", lambda interp: False)
+    monkeypatch.setattr(menubar, "open_command", lambda url: ["open", url])
+    popen_calls: list = []
+    run_calls: list = []
+    monkeypatch.setattr(menubar.subprocess, "Popen", lambda *a, **k: popen_calls.append(a))
+    monkeypatch.setattr(menubar.subprocess, "run", lambda *a, **k: run_calls.append(a))
+
+    menubar.launch_ui("http://localhost:8443/", None)
+
+    assert popen_calls == []  # native window not spawned
+    assert run_calls and run_calls[0][0] == ["open", "http://localhost:8443/"]
+
+
+def test_launch_ui_spawns_window_when_interpreter_ok(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(menubar, "_window_interpreter_ok", lambda interp: True)
+    popen_calls: list = []
+    monkeypatch.setattr(menubar.subprocess, "Popen", lambda *a, **k: popen_calls.append(a[0]))
+
+    menubar.launch_ui("http://localhost:8443/", None)
+
+    assert popen_calls and popen_calls[0][1:3] == ["-m", "ciao.window"]
+
+
 def _write_bundle(path: Path, *, bundle_id: str) -> None:
     contents = path / "Contents"
     contents.mkdir(parents=True)

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -5,14 +5,44 @@ from pathlib import Path
 
 import pytest
 
+import ciao.release as release_mod
 from ciao.release import (
     CommitSummary,
     ReleaseError,
+    _resolve_source_ref,
     apply_release_files,
     bump_version,
     read_versions,
     render_changelog_section,
 )
+
+
+def test_resolve_source_prefers_remote_over_stale_local(tmp_path: Path, monkeypatch) -> None:
+    # Cutting a release must use the freshly-fetched origin/<source>, not a
+    # same-named local branch that may lag behind (which would silently ship a
+    # version missing already-merged PRs).
+    calls: list[list[str]] = []
+
+    def fake_git(root, args, check=False):
+        calls.append(args)
+        if args == ["rev-parse", "--verify", "origin/develop"]:
+            return "abc123"  # remote exists
+        return "def456"  # local also exists
+
+    monkeypatch.setattr(release_mod, "_git", fake_git)
+    assert _resolve_source_ref(tmp_path, "develop") == "origin/develop"
+    # The remote was checked first.
+    assert calls[0] == ["rev-parse", "--verify", "origin/develop"]
+
+
+def test_resolve_source_falls_back_to_local_when_no_remote(tmp_path: Path, monkeypatch) -> None:
+    def fake_git(root, args, check=False):
+        if args == ["rev-parse", "--verify", "origin/develop"]:
+            return ""  # no remote (e.g. a tag or local-only branch)
+        return "def456"
+
+    monkeypatch.setattr(release_mod, "_git", fake_git)
+    assert _resolve_source_ref(tmp_path, "develop") == "develop"
 
 
 def _write_release_tree(root: Path) -> None:

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-pwa",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-pwa",
-      "version": "0.4.18",
+      "version": "0.4.19",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
         "dompurify": "^3.4.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-pwa",
   "private": true,
-  "version": "0.4.18",
+  "version": "0.4.19",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Release Ciaobot v0.4.19 to `main`
- Update package, PWA, and package-lock versions
- Add changelog notes for the release range

## Release notes
## v0.4.19 - 2026-07-14

### Changed
- Merge pull request #82 from raffaelefarinaro/chore/sync-develop-v0.4.17 (`3153b2c`)
- Merge pull request #83 from raffaelefarinaro/fix-window-venv-launch (`d6b7761`)
- release: prepare v0.4.18 (`3b61568`)
- Merge pull request #84 from raffaelefarinaro/release/v0.4.18 (`7e10414`)
- Merge pull request #85 from raffaelefarinaro/chore/sync-develop-v0.4.18 (`4a937db`)
- harden: guarantee the app opens + stop releases from stale local develop (`896d513`)
- Merge pull request #86 from raffaelefarinaro/harden-window-launch-and-release (`3392435`)

### Fixed
- fix(macos): open the window via the venv python, not the app-bundle symlink (`8358a5d`)

## Testing
- Not run

## After approval
- Merge this PR into `main`
- GitHub Actions will create tag `v0.4.19`, publish the GitHub release, and sync `develop`
