### PR TITLE
fix(setup): guard ciao setup against hijacking the workspace

### DIFF
--- a/ciao/cli.py
+++ b/ciao/cli.py
@@ -7,6 +7,7 @@ import html
 import http.cookiejar
 import json
 import os
+import plistlib
 import secrets
 import shutil
 import sqlite3
@@ -838,7 +839,64 @@ def setup_workspace(
     return written
 
 
+def _looks_like_source_checkout(path: Path) -> bool:
+    """True if ``path`` is the Ciaobot source repo or a git worktree of it.
+
+    ``ciao setup`` treats the target directory as the workspace and repoints
+    the LaunchAgents at it, so running it inside the code checkout silently
+    hijacks the real workspace. A workspace never contains the app's own
+    source tree, so the packaged markers are a safe signal.
+    """
+
+    if (path / "pyproject.toml").is_file() and (path / "ciao" / "__init__.py").is_file():
+        return True
+    return "/.claude/worktrees/" in path.as_posix()
+
+
+def _plist_workspace(launch_agents_dir: Path) -> Path | None:
+    """Workspace the server LaunchAgent currently points at, if set up."""
+
+    plist = launch_agents_dir.expanduser() / "com.ciao.server.plist"
+    try:
+        with plist.open("rb") as handle:
+            data = plistlib.load(handle)
+    except (OSError, ValueError):
+        return None
+    workspace = (data.get("EnvironmentVariables") or {}).get("CIAO_WORKSPACE")
+    if not workspace:
+        return None
+    try:
+        return Path(str(workspace)).expanduser().resolve()
+    except OSError:
+        return None
+
+
 def _setup_command(args: argparse.Namespace) -> int:
+    root = Path(args.workspace).expanduser().resolve()
+
+    # Guard against the two ways `ciao setup` silently hijacks the workspace:
+    # running it inside the source checkout, or re-pointing an already
+    # configured workspace to the current directory. --yes overrides.
+    if not args.yes:
+        if _looks_like_source_checkout(root):
+            print(
+                f"Error: {root} looks like the Ciaobot source checkout, not a "
+                "workspace.\ncd to your workspace folder and run `ciao setup` "
+                "there, or pass --workspace <path> (or --yes to override).",
+                file=sys.stderr,
+            )
+            return 1
+        existing = _plist_workspace(Path(args.launch_agents_dir))
+        if existing is not None and existing != root:
+            print(
+                f"Error: Ciaobot is already set up with workspace {existing}.\n"
+                f"Running setup here would move it to {root}.\nRe-run from the "
+                "existing workspace, pass --workspace, or add --yes to confirm "
+                "the move.",
+                file=sys.stderr,
+            )
+            return 1
+
     written = setup_workspace(
         args.workspace,
         auth_token=args.auth_token,
@@ -854,7 +912,6 @@ def _setup_command(args: argparse.Namespace) -> int:
         Path(args.launch_agents_dir).expanduser() / name
         for name in ("com.ciao.server.plist", "com.ciao.menubar.plist")
     ]
-    root = Path(args.workspace).expanduser().resolve()
     if args.load_launchd:
         rc = 0
         for plist in plists:
@@ -1383,6 +1440,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--load-launchd",
         action="store_true",
         help="Run launchctl unload/load after writing the LaunchAgent.",
+    )
+    setup_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip safety guards (setting up inside the source checkout, or "
+        "moving an already-configured workspace to this directory).",
     )
     setup_parser.set_defaults(func=_setup_command)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -328,6 +328,62 @@ def test_setup_scaffolds_workspace_from_stock(tmp_path: Path) -> None:
     assert (menubar_app_exe.parent / "python").is_symlink()
 
 
+def _setup_argv(workspace: Path, launch_agents: Path, apps: Path, *, yes: bool = False) -> list[str]:
+    argv = [
+        "setup",
+        "--workspace", str(workspace),
+        "--launch-agents-dir", str(launch_agents),
+        "--app-dir", str(apps),
+        "--python", "/opt/ciao/bin/python",
+        "--port", "9443",
+    ]
+    if yes:
+        argv.append("--yes")
+    return argv
+
+
+def test_setup_refuses_source_checkout(tmp_path: Path, capsys) -> None:
+    # A directory that looks like the Ciaobot source repo must be rejected so
+    # setup can't hijack the real workspace by repointing the LaunchAgents.
+    checkout = tmp_path / "ciaobot"
+    (checkout / "ciao").mkdir(parents=True)
+    (checkout / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+    (checkout / "ciao" / "__init__.py").write_text("", encoding="utf-8")
+
+    rc = cli.main(_setup_argv(checkout, tmp_path / "LaunchAgents", tmp_path / "Applications"))
+
+    assert rc == 1
+    assert "source checkout" in capsys.readouterr().err
+    assert not (checkout / ".env").exists()  # nothing scaffolded
+
+
+def test_setup_refuses_to_repoint_existing_workspace(tmp_path: Path, capsys) -> None:
+    launch_agents = tmp_path / "LaunchAgents"
+    apps = tmp_path / "Applications"
+    first = tmp_path / "ws-one"
+    second = tmp_path / "ws-two"
+
+    assert cli.main(_setup_argv(first, launch_agents, apps)) == 0
+    capsys.readouterr()
+
+    # A second setup pointed elsewhere must refuse rather than silently move it.
+    rc = cli.main(_setup_argv(second, launch_agents, apps))
+    assert rc == 1
+    assert "already set up" in capsys.readouterr().err
+    assert not (second / ".env").exists()
+
+
+def test_setup_yes_overrides_repoint_guard(tmp_path: Path) -> None:
+    launch_agents = tmp_path / "LaunchAgents"
+    apps = tmp_path / "Applications"
+    first = tmp_path / "ws-one"
+    second = tmp_path / "ws-two"
+
+    assert cli.main(_setup_argv(first, launch_agents, apps)) == 0
+    assert cli.main(_setup_argv(second, launch_agents, apps, yes=True)) == 0
+    assert (second / ".env").exists()
+
+
 def test_setup_removes_our_legacy_ciao_app_only(tmp_path: Path) -> None:
     apps = tmp_path / "Applications"
     ours = apps / "Ciao.app" / "Contents"


### PR DESCRIPTION
`ciao setup` uses the **current directory** as the workspace and repoints the LaunchAgents at it — so running it from the wrong place silently migrates a live workspace. This bit us: a `ciao setup` run from a source worktree repointed the real workspace's server/menu-bar plists to the worktree.

## Fix
Two guards on `ciao setup` (both overridable with `--yes`):
1. **Refuse the source checkout / worktree** — if the target has `pyproject.toml` + `ciao/__init__.py`, or its path contains `.claude/worktrees/`, error: *"looks like the Ciaobot source checkout, not a workspace."*
2. **Refuse a silent re-point** — if the server LaunchAgent already points at a *different* workspace, error and require `--workspace <path>` or `--yes`, instead of quietly moving everything to the current dir.

Re-running setup from the **same** workspace still works (target == existing), so idempotent re-setup is unaffected.

## Tests
- Refuses a source-checkout-shaped dir (nothing scaffolded).
- Refuses re-pointing an already-configured workspace.
- `--yes` overrides the re-point guard.
- `pytest tests/` → **1223 passed**.

Follow-up to the release/launch reliability work (#86). Independent; can ride 0.4.20.