### PR TITLE
fix(macos): self-heal the app bundle on upgrade (helper venv + auto-refresh)

### DIFF
--- a/ciao/cli.py
+++ b/ciao/cli.py
@@ -322,11 +322,19 @@ def _write_menubar_helper(*, app_root: Path, python_path: str) -> Path:
     if bundle_python.exists() or bundle_python.is_symlink():
         bundle_python.unlink()
     bundle_python.symlink_to(python_path)
+    # Resolve the symlink to its real target before exec: invoking Python
+    # *through* the Contents/MacOS/python symlink makes CPython resolve
+    # sys.prefix to the base framework instead of the ciaobot venv, so
+    # `import ciao` fails and the menu bar crashes on launch (no tray icon).
+    # Running the resolved target keeps the venv while still living in the
+    # bundle for Notification Center identity.
     helper = macos / "CiaobotMenuBar"
     helper.write_text(
         "#!/bin/sh\n"
         'DIR="$(cd "$(dirname "$0")" && pwd)"\n'
-        'exec "$DIR/python" -m ciao.cli menubar\n',
+        'PY="$DIR/python"\n'
+        'if [ -L "$PY" ]; then PY="$(readlink "$PY")"; fi\n'
+        'exec "$PY" -m ciao.cli menubar\n',
         encoding="utf-8",
     )
     helper.chmod(0o755)

--- a/ciao/cli.py
+++ b/ciao/cli.py
@@ -460,7 +460,69 @@ def _write_app_shortcut(
         python_path=python_path or sys.executable,
     )
     _register_app_with_launchservices(app_root)
+    # Record the version that wrote this bundle so the server can refresh it
+    # automatically after an upgrade (see refresh_app_bundle_if_stale).
+    _write_app_bundle_marker(workspace)
     return app_root
+
+
+def _app_bundle_marker_path(workspace: Path) -> Path:
+    return workspace.expanduser() / ".runtime" / "app-bundle-version"
+
+
+def _write_app_bundle_marker(workspace: Path) -> None:
+    from ciao import __version__
+
+    marker = _app_bundle_marker_path(workspace)
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(__version__ + "\n", encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _installed_app_dir() -> Path | None:
+    """Directory holding the installed ``Ciaobot.app``, if any."""
+
+    for base in (Path.home() / "Applications", Path("/Applications")):
+        if (base / "Ciaobot.app").is_dir():
+            return base
+    return None
+
+
+def refresh_app_bundle_if_stale(
+    workspace: Path, port: int, *, python_path: str | None = None
+) -> Path | None:
+    """Rewrite ``Ciaobot.app`` when the running version differs from the one
+    that last wrote it. Returns the app root when refreshed, else ``None``.
+
+    macOS only. Makes ``brew upgrade`` self-contained: the server, restarted
+    onto the new keg by the stale-install self-heal, regenerates the app
+    bundle (launcher + menu-bar helper + icon) so the double-click launcher
+    and tray helper aren't left on the previous version's scripts. Only the
+    app bundle is touched — the LaunchAgent plists point at the stable opt/
+    symlink and must not be rewritten under a running launchd.
+    """
+
+    if sys.platform != "darwin":
+        return None
+    from ciao import __version__
+
+    app_dir = _installed_app_dir()
+    if app_dir is None:
+        return None  # setup never created a bundle; nothing to refresh
+    try:
+        last = _app_bundle_marker_path(workspace).read_text(encoding="utf-8").strip()
+    except OSError:
+        last = ""
+    if last == __version__:
+        return None
+    return _write_app_shortcut(
+        workspace=workspace,
+        app_dir=app_dir,
+        port=port,
+        python_path=python_path,
+    )
 
 
 _LSREGISTER = (

--- a/ciao/main.py
+++ b/ciao/main.py
@@ -797,6 +797,27 @@ async def _async_main() -> int:
 
     asyncio.create_task(_heal_stale_install())
 
+    # ── App bundle refresh on upgrade ────────────────────────
+    # `brew upgrade` swaps the Python package but doesn't rewrite Ciaobot.app,
+    # so its double-click launcher and menu-bar helper keep running the old
+    # version's scripts until `ciao setup` is re-run by hand. When restarted
+    # onto a new version (by the stale-install self-heal above), regenerate the
+    # bundle once so upgrades are self-contained. App bundle only — never the
+    # LaunchAgent plists (they use the stable opt/ symlink).
+    async def _refresh_app_bundle() -> None:
+        try:
+            from ciao.cli import refresh_app_bundle_if_stale
+
+            refreshed = await asyncio.to_thread(
+                refresh_app_bundle_if_stale, config.workspace_root, config.pwa_port
+            )
+            if refreshed is not None:
+                logger.info("Refreshed %s for the current version.", refreshed)
+        except Exception:
+            logger.exception("App bundle refresh failed")
+
+    asyncio.create_task(_refresh_app_bundle())
+
     async def _shutdown_providers() -> None:
         # Disconnect every active provider before uvicorn finishes its
         # lifespan shutdown. Otherwise the Claude SDK subprocess transports

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -331,6 +331,57 @@ def test_setup_scaffolds_workspace_from_stock(tmp_path: Path) -> None:
     assert (menubar_app_exe.parent / "python").is_symlink()
 
 
+def test_refresh_app_bundle_skips_when_version_current(tmp_path: Path, monkeypatch) -> None:
+    import ciao
+
+    monkeypatch.setattr(cli.sys, "platform", "darwin")
+    monkeypatch.setattr(ciao, "__version__", "9.9.9")
+    monkeypatch.setattr(cli, "_installed_app_dir", lambda: tmp_path / "Applications")
+    marker = cli._app_bundle_marker_path(tmp_path)
+    marker.parent.mkdir(parents=True)
+    marker.write_text("9.9.9\n", encoding="utf-8")
+    calls: list = []
+    monkeypatch.setattr(cli, "_write_app_shortcut", lambda **k: calls.append(k))
+
+    assert cli.refresh_app_bundle_if_stale(tmp_path, 8443) is None
+    assert calls == []  # bundle already current — not rewritten
+
+
+def test_refresh_app_bundle_rewrites_when_stale(tmp_path: Path, monkeypatch) -> None:
+    import ciao
+
+    monkeypatch.setattr(cli.sys, "platform", "darwin")
+    monkeypatch.setattr(ciao, "__version__", "9.9.9")
+    app_dir = tmp_path / "Applications"
+    monkeypatch.setattr(cli, "_installed_app_dir", lambda: app_dir)
+    marker = cli._app_bundle_marker_path(tmp_path)
+    marker.parent.mkdir(parents=True)
+    marker.write_text("9.9.8\n", encoding="utf-8")  # previous version
+    calls: list = []
+    monkeypatch.setattr(
+        cli, "_write_app_shortcut", lambda **k: calls.append(k) or (k["app_dir"] / "Ciaobot.app")
+    )
+
+    result = cli.refresh_app_bundle_if_stale(tmp_path, 8443)
+    assert result == app_dir / "Ciaobot.app"
+    assert calls[0]["workspace"] == tmp_path and calls[0]["port"] == 8443
+
+
+def test_refresh_app_bundle_noop_without_installed_bundle(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(cli.sys, "platform", "darwin")
+    monkeypatch.setattr(cli, "_installed_app_dir", lambda: None)
+    called: list = []
+    monkeypatch.setattr(cli, "_write_app_shortcut", lambda **k: called.append(k))
+
+    assert cli.refresh_app_bundle_if_stale(tmp_path, 8443) is None
+    assert called == []
+
+
+def test_refresh_app_bundle_noop_off_darwin(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(cli.sys, "platform", "linux")
+    assert cli.refresh_app_bundle_if_stale(tmp_path, 8443) is None
+
+
 def test_setup_removes_our_legacy_ciao_app_only(tmp_path: Path) -> None:
     apps = tmp_path / "Applications"
     ours = apps / "Ciao.app" / "Contents"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -324,7 +324,10 @@ def test_setup_scaffolds_workspace_from_stock(tmp_path: Path) -> None:
     menubar_info = (apps / "Ciaobot.app" / "Contents" / "Info.plist").read_text(encoding="utf-8")
     assert "<string>local.ciaobot.app</string>" in menubar_info
     menubar_script = menubar_app_exe.read_text(encoding="utf-8")
-    assert 'exec "$DIR/python" -m ciao.cli menubar' in menubar_script
+    # Resolves the bundle python symlink to the real venv interpreter so
+    # `import ciao` works (invoking the symlink resolves outside the venv).
+    assert 'if [ -L "$PY" ]; then PY="$(readlink "$PY")"; fi' in menubar_script
+    assert 'exec "$PY" -m ciao.cli menubar' in menubar_script
     assert (menubar_app_exe.parent / "python").is_symlink()
 
 


### PR DESCRIPTION
Makes `Ciaobot.app` upgrades self-healing, so the tray/launcher can't be left broken or stale after `brew upgrade`.

## 1. Menu-bar helper resolves the venv python
`CiaobotMenuBar` ran `$DIR/python -m ciao.cli menubar`; invoking Python through the bundle symlink resolves `sys.prefix` to the base framework, not the venv → `No module named 'ciao'` → the menu bar crashes on launch (**no tray icon**). Same venv-symlink bug as the window launcher (#86); this helper was missed. Now it resolves the symlink to the real target before exec (readlink). Notification Center identity is unaffected.

## 2. Auto-refresh the app bundle on upgrade
`brew upgrade` swaps the Python package but doesn't rewrite `Ciaobot.app`, so its launcher + menu-bar helper stay on the old version's scripts until `ciao setup` is re-run by hand (which is how today's stale/broken bundle happened).

- `_write_app_shortcut` now records the version that wrote the bundle (a `.runtime/app-bundle-version` marker).
- On server startup, `refresh_app_bundle_if_stale` regenerates the bundle (launcher + helper + icon) when the running version differs from the marker.
- This chains with the existing stale-install self-heal: `brew upgrade` → server auto-restarts onto the new keg → app bundle auto-refreshes. Fully hands-off; no manual `ciao setup` for upgrades.

**Scope:** app bundle only. The LaunchAgent plists use the stable `opt/` symlink and survive upgrades; the server does **not** rewrite its own launch config on boot. macOS only, best-effort, once per version.

Together these mean the disappearing-tray / stale-launcher class can't recur across upgrades.

## Tests
- Menu-bar helper asserts the resolved-symlink form.
- `refresh_app_bundle_if_stale`: skips when current, rewrites when stale, no-ops without an installed bundle or off-macOS.
- `pytest tests/` → 1224 passed.

Rides 0.4.20 with the `ciao setup` guard (#89).