### PR TITLE
fix(macos): tray 'Open Ciaobot' opens the app window (open -a --args was dropped)

### DIFF
--- a/ciao/menubar.py
+++ b/ciao/menubar.py
@@ -174,14 +174,26 @@ def _installed_browser_app_names() -> list[str]:
 
 
 def browser_app_mode_command(url: str) -> list[str] | None:
-    """Open ``url`` in a browser app window without a separate PWA install."""
+    """argv to open ``url`` in a chrome-less browser app-mode window.
+
+    Invoke the browser binary directly rather than ``open -a NAME --args
+    --app=URL``: ``open`` drops ``--args`` when the browser is already running,
+    so it just focuses the browser and never opens the window (the reported
+    "clicking Open Ciaobot only opens Chrome" bug). Running the binary opens
+    the app window whether or not the browser is already running.
+
+    The caller MUST launch this detached (Popen) — on a cold start the binary
+    stays in the foreground as the browser's main process.
+    """
 
     if sys.platform != "darwin":
         return None
     names = _installed_browser_app_names()
     if not names:
         return None
-    return ["open", "-a", names[0], "--args", f"--app={url}"]
+    name = names[0]
+    binary = Path("/Applications") / f"{name}.app" / "Contents" / "MacOS" / name
+    return [str(binary), f"--app={url}"]
 
 
 def browser_pwa_duplicate_paths(app_name: str = "Ciaobot") -> list[Path]:
@@ -264,9 +276,17 @@ def launch_ui(url: str, workspace: Path | None = None) -> None:
     /chat/<id> deep link) means the page lands on the right chat. ``workspace``
     is accepted for call-site compatibility but no longer used (there is no
     native window to de-duplicate).
+
+    Launched detached: app-mode invokes the browser binary directly, and a
+    cold browser start would otherwise block this menu-bar callback.
     """
 
-    subprocess.run(open_command(url), check=False)
+    subprocess.Popen(
+        open_command(url),
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
 def restart_server_command(uid: int | None = None) -> list[str]:
     resolved = os.getuid() if uid is None else uid
     return ["launchctl", "kickstart", "-k", f"gui/{resolved}/{SERVER_LAUNCHD_LABEL}"]

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -136,29 +136,33 @@ def test_open_url_without_token_falls_back_to_plain_url(
     ]
 
 
-def test_open_command_prefers_browser_app_mode(monkeypatch) -> None:
+def test_open_command_uses_browser_binary_for_app_mode(monkeypatch) -> None:
+    # Invoke the browser binary directly, NOT `open -a ... --args --app=`:
+    # `open` drops the args when the browser is already running, so the app
+    # window never opens (the "Open Ciaobot only focuses Chrome" bug).
     monkeypatch.setattr(sys, "platform", "darwin")
     monkeypatch.setattr(menubar, "_installed_browser_app_names", lambda: ["Google Chrome"])
 
     assert menubar.open_command("http://localhost:8443/") == [
-        "open",
-        "-a",
-        "Google Chrome",
-        "--args",
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
         "--app=http://localhost:8443/",
     ]
 
 
-def test_launch_ui_opens_url_in_browser(monkeypatch) -> None:
-    # The UI opens in the browser (no native window). Opening the URL directly
-    # — including a /chat/<id> deep link — lands the page on the right chat.
-    run_calls: list = []
+def test_launch_ui_spawns_detached_browser(monkeypatch) -> None:
+    # The UI opens in the browser (no native window), launched detached so a
+    # cold browser start can't block the menu-bar callback. Opening the URL
+    # directly — including a /chat/<id> deep link — lands on the right chat.
+    popen_calls: list = []
     monkeypatch.setattr(menubar, "open_command", lambda url: ["open", url])
-    monkeypatch.setattr(menubar.subprocess, "run", lambda *a, **k: run_calls.append(a[0]))
+    monkeypatch.setattr(
+        menubar.subprocess, "Popen", lambda *a, **k: popen_calls.append((a[0], k))
+    )
 
     menubar.launch_ui("http://localhost:8443/chat/chat-abc", None)
 
-    assert run_calls == [["open", "http://localhost:8443/chat/chat-abc"]]
+    assert popen_calls and popen_calls[0][0] == ["open", "http://localhost:8443/chat/chat-abc"]
+    assert popen_calls[0][1].get("start_new_session") is True
 
 
 def _write_bundle(path: Path, *, bundle_id: str) -> None:


### PR DESCRIPTION
**Bug:** clicking "Open Ciaobot" in the tray only focused Chrome — no Ciaobot window — when Chrome was already running.

**Cause:** `launch_ui` ran `open -a "Google Chrome" --args --app=<url>`. macOS `open` **discards `--args` when the target app is already running**, so it just activated Chrome and never opened the app window.

**Fix:** invoke the browser binary directly — `/Applications/<Browser>.app/Contents/MacOS/<Browser> --app=<url>` — which opens the chrome-less app-mode window whether or not the browser is already running (confirmed on the reporter's machine: opens a clean "… - ciaobot" window). Launch it **detached** (`Popen`, `start_new_session`) so a cold browser start can't block the menu-bar callback. Falls back to `open <url>` when no Chromium browser is installed.

Tests updated (binary app-mode command + detached launch); `pytest tests/` → 1219 passed, 1 skipped.

Follow-up to #95 (the PWA simplification). The double-click app launcher already uses `open "$url"` (reliable tab); this fixes the tray path.