### PR TITLE
Reliable local notifications + Ciaobot icon; stop archived-chat resurrection

### DIFF
--- a/ciao/menubar.py
+++ b/ciao/menubar.py
@@ -462,12 +462,18 @@ def _menubar_app_candidates() -> list[Path]:
 def _ensure_notification_bundle() -> None:
     """Make Notification Center attribute alerts to Ciaobot, not Python.
 
-    When launchd starts ``python -m ciao.cli menubar`` directly, macOS has no
-    app identity and groups alerts under "Python". Setup writes a
-    ``CiaobotMenuBar`` helper inside ``Ciaobot.app`` and the LaunchAgent
-    should exec the bundle-local ``python`` symlink so alerts stay under the
-    existing Ciaobot app. As a fallback, load that bundle explicitly when we
-    can find it.
+    launchd starts the menu bar via ``Ciaobot.app``'s ``CiaobotMenuBar``
+    helper, but that helper ``exec``s the real (Homebrew) ``python``, whose
+    Mach-O executable lives outside the bundle — so the process's *main*
+    bundle is ``Python.app`` and Notification Center shows the Python rocket.
+
+    NSUserNotification (what rumps posts through) attributes an alert to the
+    app whose bundle identifier is in the main bundle's info dictionary. So we
+    overwrite that in-memory identifier with Ciaobot's: Notification Center
+    then resolves it to the installed ``Ciaobot.app`` and uses its name and
+    icon. Loading the bundle as well makes its resources available. This must
+    run before the first notification is posted (it does — from
+    ``run_menubar`` before the rumps app starts).
     """
 
     if sys.platform != "darwin":
@@ -477,16 +483,33 @@ def _ensure_notification_bundle() -> None:
     except Exception:
         return
 
-    main = NSBundle.mainBundle()
-    if main is not None:
-        ident = main.bundleIdentifier()
-        if ident and ident not in ("org.python.python", "com.apple.python"):
-            return
+    app_root = next(iter(_menubar_app_candidates()), None)
+    target_id = (_bundle_identifier(app_root) if app_root else "") or "local.ciaobot.app"
 
-    for app_root in _menubar_app_candidates():
-        bundle = NSBundle.bundleWithPath_(str(app_root))
-        if bundle is not None and bundle.load():
-            return
+    main = NSBundle.mainBundle()
+    if main is None:
+        return
+    if main.bundleIdentifier() == target_id:
+        return  # already attributed to Ciaobot (e.g. a real bundled launch)
+
+    # Override the running process's main-bundle identity so alerts carry
+    # Ciaobot's name + icon instead of Python's.
+    try:
+        info = main.localizedInfoDictionary() or main.infoDictionary()
+        if info is not None:
+            info["CFBundleIdentifier"] = target_id
+            info["CFBundleName"] = "Ciaobot"
+    except Exception:
+        pass
+
+    # Load Ciaobot.app so its icon resource is registered for the alert.
+    if app_root is not None:
+        try:
+            bundle = NSBundle.bundleWithPath_(str(app_root))
+            if bundle is not None:
+                bundle.load()
+        except Exception:
+            pass
 
 
 def spin_icon_paths() -> list[str]:

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -2514,6 +2514,14 @@ class ProjectChatManager:
         chat = self._chats.get(chat_id)
         if chat is None:
             return None
+        if chat.archived:
+            # Never resurrect an archived chat in place: this clears its
+            # archived flag and archive_path, leaving an empty active chat
+            # that reappears in the sidebar/menu bar (an archive "comes back"
+            # with no transcript). Continuing an archived chat is
+            # continue_archived_chat()'s job — it spawns a fresh chat and
+            # leaves the archived one untouched.
+            raise ValueError("Cannot start a new session in an archived chat")
         # Archive existing transcript
         ctx = ChatContext.for_web(chat_id)
         self._transcripts.archive_session(

--- a/ciao/web/push.py
+++ b/ciao/web/push.py
@@ -159,35 +159,53 @@ class PushManager:
     # ── Send ────────────────────────────────────────────────────────────
 
     def send(self, payload: dict[str, Any]) -> None:
-        """Deliver via Web Push, logging a native-banner fallback only when
-        this machine did not receive it via a local push subscription.
+        """Notify this machine via the always-on menu bar, and other devices
+        via Web Push.
 
-        notifications.jsonl is the menu bar's fallback queue: an entry is
-        written exactly when Web Push did NOT successfully reach a subscription
-        created from this machine (loopback). So the menu bar posts a native
-        banner precisely when the local browser/PWA won't — no duplicates, and
-        transient/persistent push failures (or no local subscription at all)
-        still surface as native banners rather than being silently dropped.
+        The local machine ALWAYS gets a native menu-bar banner (queued in
+        notifications.jsonl; the menu bar posts it when its Notifications
+        toggle is on). Web Push is used only to reach *remote* subscriptions
+        (other devices) — never the local browser.
+
+        Why not trust Web Push for the local browser: the push service returns
+        2xx as soon as it *accepts* the message, which is not the same as the
+        browser *displaying* it. A browser with notifications disabled at the
+        OS level (e.g. System Settings → Notifications → Chrome = off) silently
+        drops the push while the push service still reports success. Suppressing
+        the native banner on that unverifiable signal made notifications vanish
+        entirely. The menu bar is always running and reliable, so it owns the
+        local notification; Web Push is a best-effort channel for other devices.
         """
-        if not self._deliver_to_local(payload):
-            self._log_notification(payload)
+        self._log_notification(payload)
+        remote = [s for s in self._subs if not s.get("local")]
+        self._deliver(remote, payload)
 
-    def _deliver_to_local(self, payload: dict[str, Any]) -> bool:
-        """Push to every subscription; return True iff delivery succeeded to at
-        least one *local* (this-machine) subscription. Prunes dead endpoints."""
-        if not self._subs or not self._subject:
-            return False
+    def send_test(self, payload: dict[str, Any]) -> dict[str, int]:
+        """Push a test notification to *local* subscriptions so the user can
+        confirm the browser actually displays it — the one thing neither the
+        server nor the Web Notification API can detect (see ``send``). Returns
+        the local subscription count and how many the push service accepted."""
+        local = [s for s in self._subs if s.get("local")]
+        accepted = self._deliver(local, payload)
+        return {"local_subscriptions": len(local), "accepted": accepted}
+
+    def _deliver(self, subs: list[dict[str, Any]], payload: dict[str, Any]) -> int:
+        """Web Push to the given subscriptions. Returns how many the push
+        service *accepted* (2xx) — which is not a guarantee of display. Prunes
+        404/410 (permanently gone) endpoints from the stored set."""
+        if not subs or not self._subject:
+            return 0
         try:
             from pywebpush import WebPushException, webpush
         except Exception:
             logger.warning("pywebpush not installed, skipping push")
-            return False
+            return 0
 
         body = json.dumps(payload)
         claims = {"sub": self._subject}
         dead: list[str] = []
-        delivered_local = False
-        for sub in list(self._subs):
+        accepted = 0
+        for sub in list(subs):
             info = {k: v for k, v in sub.items() if k != "local"}
             try:
                 webpush(
@@ -198,8 +216,7 @@ class PushManager:
                     ttl=60,
                     timeout=10,
                 )
-                if sub.get("local"):
-                    delivered_local = True
+                accepted += 1
             except WebPushException as exc:  # type: ignore[misc]
                 status = getattr(getattr(exc, "response", None), "status_code", None)
                 if status in (404, 410):
@@ -212,4 +229,4 @@ class PushManager:
             with self._lock:
                 self._subs = [s for s in self._subs if s.get("endpoint") not in dead]
                 self._save_subs()
-        return delivered_local
+        return accepted

--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -1868,7 +1868,10 @@ async def chat_detail(request: Request) -> JSONResponse:
 async def chat_new_session(request: Request) -> JSONResponse:
     pcm = request.app.state.project_chat_manager
     chat_id = request.path_params["chat_id"]
-    chat = pcm.new_session(chat_id)
+    try:
+        chat = pcm.new_session(chat_id)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
     if chat is None:
         return JSONResponse({"error": "not found"}, status_code=404)
     return JSONResponse(chat.to_dict(local=True))

--- a/tests/test_push_notification_log.py
+++ b/tests/test_push_notification_log.py
@@ -39,37 +39,71 @@ def test_send_with_empty_subject_skips_webpush_but_still_logs(tmp_path: Path) ->
     assert manager.count() == 1
 
 
-def test_local_delivery_suppresses_native_fallback(tmp_path: Path, monkeypatch) -> None:
-    """A successful push to a *local* subscription means this machine already
-    got the banner via the PWA, so nothing is logged for the menu bar."""
+def test_local_notification_always_uses_native_banner(tmp_path: Path, monkeypatch) -> None:
+    """The local machine's notification always goes through the menu bar's
+    native banner, never Web Push — the push service's 2xx cannot confirm the
+    browser displayed it, so relying on it silently loses notifications."""
     import pywebpush
 
-    monkeypatch.setattr(pywebpush, "webpush", lambda **kwargs: None)  # succeeds
+    endpoints: list[str] = []
+    monkeypatch.setattr(
+        pywebpush,
+        "webpush",
+        lambda **kwargs: endpoints.append(kwargs["subscription_info"]["endpoint"]),
+    )
     manager = PushManager(tmp_path, subject="mailto:ciaobot@localhost")
     manager.add({"endpoint": "https://push.example/local"}, local=True)
 
     manager.send({"title": "t", "body": "hi", "chat_id": "c1"})
 
-    assert not (tmp_path / "notifications.jsonl").exists()  # no native fallback
+    assert len(_read_log(tmp_path)) == 1  # native banner queued for the menu bar
+    assert endpoints == []  # local subscription is NOT pushed to
 
 
-def test_remote_only_subscription_still_logs_for_local_menu_bar(tmp_path: Path, monkeypatch) -> None:
-    """A subscription on another device (e.g. a phone) must NOT stop this Mac's
-    native banner — the log entry is still written."""
+def test_remote_subscription_is_pushed_and_local_still_logs(tmp_path: Path, monkeypatch) -> None:
+    """A subscription on another device (e.g. a phone) IS delivered via Web
+    Push, while this Mac still gets its native banner via the log."""
     import pywebpush
 
-    monkeypatch.setattr(pywebpush, "webpush", lambda **kwargs: None)  # succeeds
+    endpoints: list[str] = []
+    monkeypatch.setattr(
+        pywebpush,
+        "webpush",
+        lambda **kwargs: endpoints.append(kwargs["subscription_info"]["endpoint"]),
+    )
     manager = PushManager(tmp_path, subject="mailto:ciaobot@localhost")
     manager.add({"endpoint": "https://push.example/phone"}, local=False)
 
     manager.send({"title": "t", "body": "hi", "chat_id": "c1"})
 
-    assert len(_read_log(tmp_path)) == 1  # local machine still gets a fallback
+    assert len(_read_log(tmp_path)) == 1  # local machine still gets a banner
+    assert endpoints == ["https://push.example/phone"]  # remote device pushed
 
 
-def test_failed_local_push_falls_back_to_log(tmp_path: Path, monkeypatch) -> None:
-    """A local subscription that exists but whose delivery fails must not
-    suppress the native fallback — otherwise the notification is lost."""
+def test_send_test_pushes_only_to_local_subscriptions(tmp_path: Path, monkeypatch) -> None:
+    """``send_test`` verifies the local browser displays a push, so it targets
+    local subscriptions (and reports how many the push service accepted)."""
+    import pywebpush
+
+    endpoints: list[str] = []
+    monkeypatch.setattr(
+        pywebpush,
+        "webpush",
+        lambda **kwargs: endpoints.append(kwargs["subscription_info"]["endpoint"]),
+    )
+    manager = PushManager(tmp_path, subject="mailto:ciaobot@localhost")
+    manager.add({"endpoint": "https://push.example/local"}, local=True)
+    manager.add({"endpoint": "https://push.example/phone"}, local=False)
+
+    result = manager.send_test({"title": "t", "body": "hi", "chat_id": ""})
+
+    assert endpoints == ["https://push.example/local"]  # only the local sub
+    assert result == {"local_subscriptions": 1, "accepted": 1}
+
+
+def test_remote_push_failure_does_not_lose_local_notification(tmp_path: Path, monkeypatch) -> None:
+    """A remote push that fails must not affect the local native banner, and a
+    non-404 failure must not prune the subscription."""
     import pywebpush
 
     def boom(**kwargs):
@@ -77,11 +111,11 @@ def test_failed_local_push_falls_back_to_log(tmp_path: Path, monkeypatch) -> Non
 
     monkeypatch.setattr(pywebpush, "webpush", boom)
     manager = PushManager(tmp_path, subject="mailto:ciaobot@localhost")
-    manager.add({"endpoint": "https://push.example/local"}, local=True)
+    manager.add({"endpoint": "https://push.example/phone"}, local=False)
 
     manager.send({"title": "t", "body": "hi", "chat_id": "c1"})
 
-    assert len(_read_log(tmp_path)) == 1  # failed delivery → native fallback
+    assert len(_read_log(tmp_path)) == 1  # local banner unaffected
     assert manager.count() == 1  # non-404 failure does not prune the sub
 
 

--- a/tests/test_transcript_discovery.py
+++ b/tests/test_transcript_discovery.py
@@ -204,6 +204,27 @@ def test_discover_archived_chats_pruning_ignores_active(tmp_path: Path) -> None:
     assert pcm.get_chat(chat.chat_id) is not None
 
 
+def test_new_session_refuses_to_resurrect_archived_chat(tmp_path: Path) -> None:
+    """new_session() on an archived chat must not clear its archived flag or
+    archive_path. Doing so left empty, active chats that reappeared in the
+    sidebar and menu bar tray ("archived chats came back"). Continuing an
+    archived chat is continue_archived_chat()'s job — it spawns a new chat."""
+    pcm = _make_manager(tmp_path)
+    proj = pcm.create_project("Work Project A", workspace="work")
+    chat = pcm.create_chat(proj.project_id, title="Routine Chat")
+    # Simulate the archived state a routine auto-archive leaves behind.
+    chat.archived = True
+    chat.archive_path = "memory-vault/Logs/Chats/chat-x/claude/t.md"
+
+    with pytest.raises(ValueError, match="archived"):
+        pcm.new_session(chat.chat_id)
+
+    same = pcm.get_chat(chat.chat_id)
+    assert same is not None
+    assert same.archived is True  # not resurrected
+    assert same.archive_path == "memory-vault/Logs/Chats/chat-x/claude/t.md"
+
+
 def test_continue_archived_chat(tmp_path: Path) -> None:
     pcm = _make_manager(tmp_path)
     


### PR DESCRIPTION
## Summary
Three related macOS/notification fixes, validated locally with real notifications.

### 1. Reliable local notifications (Option A)
`PushManager.send()` treated a push service's HTTP 2xx as "the user saw it" and suppressed the native menu-bar banner. But 2xx only means *accepted* — a browser with notifications disabled at the OS level (System Settings → Notifications → Chrome) drops the push silently, so **nothing displayed and no fallback fired**.

Now the always-on menu bar owns local notifications: `send()` always queues a native banner for this machine (gated by the menu bar's Notifications toggle) and uses Web Push only for *remote* subscriptions (other devices). Adds `send_test()` to push to local subs so the user can verify the browser actually displays a push — the one thing neither the server nor the Web Notification API can detect.

### 2. Notification icon: Ciaobot, not Python
The launchd menu bar `exec`s the Homebrew python, whose Mach-O lives outside `Ciaobot.app`, so alerts were attributed to "Python" (rocket icon). We now override the running process's main-bundle `CFBundleIdentifier` to Ciaobot's, so Notification Center resolves the installed `Ciaobot.app` and uses its name + icon. Verified on the real keg interpreter.

### 3. Stop `new_session` from resurrecting archived chats
An archived chat receiving `POST /api/chats/{id}/new` was silently un-archived: `new_session()` cleared both `archived` and `archive_path` and started an empty session — an active, transcript-less chat that reappeared in the sidebar and menu bar tray. It now raises `ValueError` (route → 400) on an archived chat, mirroring the existing "Cannot move an archived chat" guard. Continuing an archive remains `continue_archived_chat()`'s job.

## Tests
- Push tests rewritten for local-always / remote-push semantics.
- New guard test for archived-chat resurrection.
- Full backend suite: 1221 passed, 1 skipped.