### PR TITLE
Release v0.4.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.4.22 - 2026-07-14
+
+### Added
+- feat(settings): add an Install button for apfel (`c5e1408`)
+
+### Changed
+- Merge pull request #104 from raffaelefarinaro/chore/sync-develop-v0.4.21 (`21d24fa`)
+- perf(ollama): disable attribution header on local-daemon routes (#98) (`afd92fb`)
+- Merge pull request #105 from raffaelefarinaro/feat/notify-archive-apfel-perf (`d195bff`)
+
+### Fixed
+- fix(notify): suppress the push when a chat auto-archives on completion (`1e1ccb7`)
+
 ## v0.4.21 - 2026-07-14
 
 ### Changed

--- a/PWA_API.md
+++ b/PWA_API.md
@@ -54,6 +54,7 @@ The route source of truth is `ciao/web/app.py`. This file is kept in sync by `te
 | GET | `/api/workspace-binary` | Read allowed binary file |
 | GET | `/api/libreoffice-status` | Whether LibreOffice (`soffice`) is available to render `.pptx` previews |
 | POST | `/api/libreoffice-install` | Install LibreOffice via Homebrew Cask (macOS); no restart needed |
+| POST | `/api/apfel/install` | Install apfel (Apple Intelligence CLI) via Homebrew (macOS); no restart needed |
 | POST | `/api/workspace-open` | Open a workspace file with the OS default app on the machine running Ciao |
 | GET | `/api/file-history` | List snapshots for a `(chat_id, file_path)` |
 | GET | `/api/file-content` | Read one snapshot's content |

--- a/ciao/__init__.py
+++ b/ciao/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.21"
+__version__ = "0.4.22"

--- a/ciao/providers/ollama.py
+++ b/ciao/providers/ollama.py
@@ -123,6 +123,24 @@ def _env_overrides(base_url: str, api_key: str) -> dict[str, str]:
     }
 
 
+def _local_daemon_env_overrides(base_url: str, api_key: str) -> dict[str, str]:
+    """Env overrides for a *local* inference server (Ollama daemon).
+
+    The claude CLI prepends a changing attribution header to every request,
+    which invalidates a local server's KV cache and slows inference by up to
+    ~90% (Unsloth write-up: https://unsloth.ai/docs/basics/claude-code). Disable
+    that header plus telemetry / non-essential traffic on local-daemon routes
+    only. No effect on cloud relays (ollama.com, OpenRouter), where there is no
+    local KV cache to preserve.
+    """
+    return {
+        **_env_overrides(base_url, api_key),
+        "CLAUDE_CODE_ATTRIBUTION_HEADER": "0",
+        "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+    }
+
+
 def _tier_remap_env(
     settings: OllamaSettings,
     *,
@@ -181,7 +199,7 @@ def ollama_env_for_model(model: str, settings: OllamaSettings) -> dict[str, str]
         # model for the CLI's internal tier/control-plane slots so Task
         # subagents and auto-mode classifier calls stay on the daemon.
         return {
-            **_env_overrides(settings.local_url, "ollama"),
+            **_local_daemon_env_overrides(settings.local_url, "ollama"),
             **_tier_remap_env(
                 settings,
                 haiku_model=model,
@@ -217,7 +235,7 @@ def routine_env_for_model(model: str, settings: OllamaSettings) -> dict[str, str
     if not model or model in _ANTHROPIC_ALIASES or model.startswith("claude-"):
         return {}
     if is_local_ollama_model(model, settings):
-        return _env_overrides(settings.local_url, "ollama")
+        return _local_daemon_env_overrides(settings.local_url, "ollama")
     if _looks_like_ollama_id(model):
         return _env_overrides(settings.base_url, settings.api_key)
     return {}

--- a/ciao/web/app.py
+++ b/ciao/web/app.py
@@ -93,6 +93,7 @@ from ciao.web.routes_api import (
     voice_install_local_endpoint,
     libreoffice_status_endpoint,
     libreoffice_install_endpoint,
+    apfel_install_endpoint,
     project_restore,
     project_files_list,
     project_files_upload,
@@ -192,6 +193,7 @@ def create_app(config, app_settings=None) -> Starlette:
         Route("/api/workspace-open", workspace_open, methods=["POST"]),
         Route("/api/libreoffice-status", libreoffice_status_endpoint, methods=["GET"]),
         Route("/api/libreoffice-install", libreoffice_install_endpoint, methods=["POST"]),
+        Route("/api/apfel/install", apfel_install_endpoint, methods=["POST"]),
         # File snapshots — History and Diff tabs in the file viewer.
         Route("/api/file-history", file_history, methods=["GET"]),
         Route("/api/file-content", file_content, methods=["GET"]),

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -4072,6 +4072,16 @@ class ProjectChatManager:
             # Chat deleted during the window, or already read on some device.
             if chat is None:
                 return
+            if chat.archived:
+                # The chat was archived during the delay window — e.g. an
+                # auto-archive schedule whose run needed no user action. Nothing
+                # is left to open, so don't notify. archive_chat() also cancels
+                # the pending task; this guard makes suppression deterministic
+                # regardless of cancel/fire timing.
+                logger.debug(
+                    "Skipping push for %s: chat archived (auto-archived run)", chat_id
+                )
+                return
             if (chat.last_read_at or "") >= (chat.last_activity_at or ""):
                 logger.debug(
                     "Skipping push for %s: already read in window", chat_id

--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -2836,6 +2836,19 @@ async def libreoffice_install_endpoint(request: Request) -> JSONResponse:
     return JSONResponse({"ok": True, "output": result.stdout})
 
 
+async def apfel_install_endpoint(request: Request) -> JSONResponse:
+    """Install apfel (Apple Intelligence CLI) via Homebrew. No server restart
+    needed — routines probe for the apfel binary fresh on each run, so titles
+    switch from the cloud fallback to on-device on the next run."""
+    from ciao.upgrade import upgrade_apfel
+
+    result = await upgrade_apfel()
+    if not result.success:
+        error = result.stderr.strip() or "Install failed."
+        return JSONResponse({"ok": False, "error": error}, status_code=500)
+    return JSONResponse({"ok": True, "output": result.stdout})
+
+
 async def workspace_binary(request: Request) -> Response:
     """Serve a read-only binary file (PDF, ZIP, office doc) from the workspace."""
     config = request.app.state.config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciaobot"
-version = "0.4.21"
+version = "0.4.22"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_ollama_local.py
+++ b/tests/test_ollama_local.py
@@ -68,6 +68,35 @@ def test_routine_env_prefers_local():
     assert env["ANTHROPIC_AUTH_TOKEN"] == "ollama"
 
 
+# ── KV-cache / telemetry env (local daemon only) ───────────────────────────
+
+_KV_CACHE_VARS = {
+    "CLAUDE_CODE_ATTRIBUTION_HEADER": "0",
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+}
+
+
+def test_local_daemon_gets_kv_cache_env():
+    """The changing attribution header invalidates the local server KV cache;
+    disable it (+ telemetry) on local-daemon routes so inference stays fast."""
+    chat = ollama_env_for_model("gemma4:12b-it-qat", CLOUD)
+    routine = routine_env_for_model("gemma4:12b-it-qat", CLOUD)
+    for key, value in _KV_CACHE_VARS.items():
+        assert chat[key] == value
+        assert routine[key] == value
+
+
+def test_cloud_models_do_not_get_kv_cache_env():
+    """Cloud relays (ollama.com) have no local KV cache — the vars are a no-op
+    and must not be set, keeping the cloud path unchanged."""
+    chat = ollama_env_for_model("kimi-k2.7-code:cloud", CLOUD)
+    routine = routine_env_for_model("kimi-k2.7-code:cloud", CLOUD)
+    for key in _KV_CACHE_VARS:
+        assert key not in chat
+        assert key not in routine
+
+
 # ── Discovery ────────────────────────────────────────────────────────────
 
 

--- a/tests/test_permission_push.py
+++ b/tests/test_permission_push.py
@@ -103,3 +103,39 @@ def test_notify_permission_swallows_callback_errors(tmp_path: Path) -> None:
     )
     # Must not raise.
     pcm._notify_permission(chat.chat_id, event)
+
+
+async def test_delayed_push_suppressed_when_chat_archived(tmp_path: Path) -> None:
+    """An auto-archive schedule that archives on completion must not notify:
+    _delayed_push skips a chat archived during the delay window (the run needed
+    no user action, so there's nothing to open)."""
+    pcm = _make_manager(tmp_path)
+    pcm._push_delay_seconds = 0
+    project = pcm.create_project("General", workspace="personal")
+    chat = pcm.create_chat(project.project_id, title="Morning briefing")
+    chat.last_activity_at = "2026-07-14T09:00:00Z"
+    chat.last_read_at = ""
+    chat.archived = True  # auto-archived on completion
+
+    calls: list[tuple[str, str, str]] = []
+    pcm.notify_result_cb = lambda cid, title, snippet: calls.append((cid, title, snippet))
+
+    await pcm._delayed_push(chat.chat_id, "Morning briefing", "done")
+    assert calls == []  # archived → no notification
+
+
+async def test_delayed_push_fires_for_active_unread_chat(tmp_path: Path) -> None:
+    """Control: a still-active, unread chat gets its push as before."""
+    pcm = _make_manager(tmp_path)
+    pcm._push_delay_seconds = 0
+    project = pcm.create_project("General", workspace="personal")
+    chat = pcm.create_chat(project.project_id, title="Live chat")
+    chat.last_activity_at = "2026-07-14T09:00:00Z"
+    chat.last_read_at = ""
+    chat.archived = False
+
+    calls: list[tuple[str, str, str]] = []
+    pcm.notify_result_cb = lambda cid, title, snippet: calls.append((cid, title, snippet))
+
+    await pcm._delayed_push(chat.chat_id, "Live chat", "reply")
+    assert calls == [(chat.chat_id, "Live chat", "reply")]

--- a/tests/test_pwa_api_docs.py
+++ b/tests/test_pwa_api_docs.py
@@ -29,6 +29,7 @@ BROWSER_OR_INTERNAL_ROUTES: dict[str, str] = {
     "/api/workspace-health/fix": "browser Settings health Fix button; creates missing scaffold files and re-links skills",
     "/api/tts/install-local": "browser speech local engine installation; installs kokoro-onnx and restarts",
     "/api/libreoffice-install": "browser file-viewer Install LibreOffice button; runs brew install --cask libreoffice, no restart needed",
+    "/api/apfel/install": "Settings Install apfel button; runs brew install apfel, no restart needed",
     "/api/workspace-open": "browser file-viewer Open-in-default-app button; only meaningful when the PWA talks to a local Ciao instance",
     "/api/workspaces": "browser workspaces list config",
     "/api/workspaces/{name}": "browser workspaces management endpoint",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-pwa",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-pwa",
-      "version": "0.4.21",
+      "version": "0.4.22",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
         "dompurify": "^3.4.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-pwa",
   "private": true,
-  "version": "0.4.21",
+  "version": "0.4.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -339,9 +339,18 @@
                 <span class="routine-model-hint">
                   <template v-if="routineProviderValue('title_model') === 'apple'">
                     Runs on-device for free via <a :href="APFEL_REPO_URL" target="_blank" rel="noopener">apfel</a> (Apple Intelligence CLI).
-                    <span v-if="routines && routines.apfel_available === false" class="hint--warn">
-                      apfel is not installed on this machine — titles currently fall back to a cloud model.
-                    </span>
+                    <template v-if="routines && routines.apfel_available === false">
+                      <span class="hint--warn">
+                        apfel is not installed on this machine — titles currently fall back to a cloud model.
+                      </span>
+                      <button
+                        class="btn-primary btn-small voice-install-btn"
+                        :disabled="apfelInstalling"
+                        @click="installApfel"
+                      >
+                        {{ apfelInstalling ? 'Installing…' : 'Install apfel' }}
+                      </button>
+                    </template>
                   </template>
                   <template v-else>{{ routineModelSummary('title_model') }}</template>
                 </span>
@@ -2483,6 +2492,28 @@ async function installLocalVoice() {
     routinesResult.value = `Error installing engine: ${e?.message || e}`
   } finally {
     voiceInstalling.value = false
+  }
+}
+
+const apfelInstalling = ref(false)
+
+async function installApfel() {
+  apfelInstalling.value = true
+  routinesResult.value = 'Installing apfel (Apple Intelligence CLI)…'
+  try {
+    const res = await api.post<{ ok: boolean; output?: string; error?: string }>('/api/apfel/install', {})
+    if (res.ok) {
+      routinesResult.value = 'apfel installed — on-device titles apply from the next run.'
+      // No restart needed: routines probe for the apfel binary per run.
+      // Refresh so the "not installed" hint clears immediately.
+      await fetchRoutines()
+    } else {
+      routinesResult.value = `apfel install failed: ${res.error || 'unknown error'}`
+    }
+  } catch (e: any) {
+    routinesResult.value = `Error installing apfel: ${e?.message || e}`
+  } finally {
+    apfelInstalling.value = false
   }
 }
 


### PR DESCRIPTION
## Summary
- Release Ciaobot v0.4.22 to `main`
- Update package, PWA, and package-lock versions
- Add changelog notes for the release range

## Release notes
## v0.4.22 - 2026-07-14

### Added
- feat(settings): add an Install button for apfel (`c5e1408`)

### Changed
- Merge pull request #104 from raffaelefarinaro/chore/sync-develop-v0.4.21 (`21d24fa`)
- perf(ollama): disable attribution header on local-daemon routes (#98) (`afd92fb`)
- Merge pull request #105 from raffaelefarinaro/feat/notify-archive-apfel-perf (`d195bff`)

### Fixed
- fix(notify): suppress the push when a chat auto-archives on completion (`1e1ccb7`)

## Testing
- pytest tests/
- cd web && npm run test
- cd web && npm run build
- ciao package-smoke --skip-frontend

## After approval
- Merge this PR into `main`
- GitHub Actions will create tag `v0.4.22`, publish the GitHub release, and sync `develop`
