### PR TITLE
fix(menubar): focus installed PWA instead of spawning a new window

### DIFF
--- a/ciao/menubar.py
+++ b/ciao/menubar.py
@@ -259,9 +259,34 @@ def remove_browser_pwa_duplicates(app_name: str = "Ciaobot") -> list[Path]:
     return removed
 
 
-def open_command(url: str) -> list[str]:
-    """``open`` argv for a URL in an app-like window when possible."""
+def _installed_ciaobot_pwa() -> Path | None:
+    """Path to a browser-installed Ciaobot PWA app shim, if one exists.
 
+    Excludes our own native launcher bundle. A PWA app shim is single-instance,
+    which is what makes single-window launching possible (see open_command)."""
+
+    if sys.platform != "darwin":
+        return None
+    pwas = browser_pwa_duplicate_paths("Ciaobot")
+    return pwas[0] if pwas else None
+
+
+def open_command(url: str) -> list[str]:
+    """``open`` argv for the Ciaobot UI in an app-like window.
+
+    Prefer an installed Ciaobot PWA: its app shim is single-instance, so
+    ``open``-ing it *focuses the existing window* instead of spawning a new one.
+    That is the fix for "clicking Open Ciaobot opens a new window every time" —
+    ``--app=<url>`` on the raw browser binary always makes a fresh window, even
+    when the PWA is installed. Deep-link navigation (notification → chat) is
+    handled in-app by ``notify_open_chat`` over the WebSocket, so the URL is not
+    needed here while the PWA is running. Fall back to a raw app-mode window,
+    then the default browser, when no PWA is installed.
+    """
+
+    pwa = _installed_ciaobot_pwa()
+    if pwa is not None:
+        return ["open", str(pwa)]
     app_mode = browser_app_mode_command(url)
     if app_mode is not None:
         return app_mode

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -113,6 +113,7 @@ def test_server_recovery_label_matches_reachability() -> None:
 
 def test_open_url_uses_setup_token(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(menubar, "_installed_browser_app_names", lambda: [])
+    monkeypatch.setattr(menubar, "_installed_ciaobot_pwa", lambda: None)
     token_path = tmp_path / ".runtime" / "setup-token"
     token_path.parent.mkdir(parents=True)
     token_path.write_text("tok123\n", encoding="utf-8")
@@ -128,6 +129,7 @@ def test_open_url_without_token_falls_back_to_plain_url(
     tmp_path: Path, monkeypatch
 ) -> None:
     monkeypatch.setattr(menubar, "_installed_browser_app_names", lambda: [])
+    monkeypatch.setattr(menubar, "_installed_ciaobot_pwa", lambda: None)
 
     url = menubar.open_url(tmp_path, 8443)
     assert menubar.open_command(url) == [
@@ -141,12 +143,25 @@ def test_open_command_uses_browser_binary_for_app_mode(monkeypatch) -> None:
     # `open` drops the args when the browser is already running, so the app
     # window never opens (the "Open Ciaobot only focuses Chrome" bug).
     monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(menubar, "_installed_ciaobot_pwa", lambda: None)
     monkeypatch.setattr(menubar, "_installed_browser_app_names", lambda: ["Google Chrome"])
 
     assert menubar.open_command("http://localhost:8443/") == [
         "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
         "--app=http://localhost:8443/",
     ]
+
+
+def test_open_command_prefers_installed_pwa(tmp_path: Path, monkeypatch) -> None:
+    # An installed PWA app shim is single-instance: opening it focuses the
+    # existing window instead of spawning a new one (the "Open Ciaobot opens a
+    # new window every click" bug). It wins over the raw-browser app-mode path.
+    monkeypatch.setattr(sys, "platform", "darwin")
+    pwa = tmp_path / "Chrome Apps.localized" / "Ciaobot.app"
+    monkeypatch.setattr(menubar, "_installed_ciaobot_pwa", lambda: pwa)
+    monkeypatch.setattr(menubar, "_installed_browser_app_names", lambda: ["Google Chrome"])
+
+    assert menubar.open_command("http://localhost:8443/chat/abc") == ["open", str(pwa)]
 
 
 def test_launch_ui_spawns_detached_browser(monkeypatch) -> None:


### PR DESCRIPTION
## Problem
Clicking **Open Ciaobot** (or a notification) opened a brand-new window every time — even with the PWA installed. `open_command` always invoked the raw browser binary with `--app=<url>`, which spawns a fresh app-mode window on every call. Installing the PWA didn't help because the launcher bypassed it.

## Fix
Prefer an installed Ciaobot PWA app shim. A PWA shim is **single-instance**, so `open`-ing it *focuses the existing window* (or launches it once) instead of spawning a new one. Chat routing on notification-click is already handled in-app by `notify_open_chat` over the WebSocket, so the deep-link URL isn't needed here while the PWA is running.

Falls back to the raw app-mode window (`--app=<url>`), then the default browser, when no PWA is installed — unchanged behavior for non-PWA users.

## Tests
- New `test_open_command_prefers_installed_pwa`.
- Existing `open_command` tests made deterministic (mock `_installed_ciaobot_pwa`).
- `tests/test_menubar.py`: 57 passed.