### PR TITLE
feat(voice): default TTS to a male voice (matches the avatar)

### DIFF
--- a/ciao/config.py
+++ b/ciao/config.py
@@ -260,8 +260,12 @@ class CiaoConfig:
     # kokoro-onnx, free/offline). Runtime-overridable from the PWA
     # Settings → Models tab.
     tts_engine: str = "cloud"
-    tts_cloud_voice: str = "nova"
-    tts_local_voice: str = "af_heart"
+    # Default to a male voice to match the Ciaobot avatar. OpenAI ``onyx`` and
+    # Kokoro ``am_michael`` (``am_`` = American Male) are the male counterparts
+    # of the former ``nova`` / ``af_heart`` defaults. Overridable in Settings /
+    # via CIAO_TTS_*_VOICE.
+    tts_cloud_voice: str = "onyx"
+    tts_local_voice: str = "am_michael"
     claude_models: list[str] = field(default_factory=lambda: ["opus", "sonnet", "haiku"])
     claude_default_model: str = "opus"
     # Per-workspace default models. Empty string falls back to
@@ -699,9 +703,9 @@ class CiaoConfig:
                 in {"cloud", "local"}
                 else "cloud"
             ),
-            tts_cloud_voice=source.get("CIAO_TTS_CLOUD_VOICE", "").strip() or "nova",
+            tts_cloud_voice=source.get("CIAO_TTS_CLOUD_VOICE", "").strip() or "onyx",
             tts_local_voice=source.get("CIAO_TTS_LOCAL_VOICE", "").strip()
-            or "af_heart",
+            or "am_michael",
             ollama_local_discovery=source.get(
                 "CIAO_OLLAMA_LOCAL_DISCOVERY", ""
             ).strip().lower()

--- a/tests/test_settings_routines_route.py
+++ b/tests/test_settings_routines_route.py
@@ -84,8 +84,8 @@ def test_get_returns_effective_models_and_options(monkeypatch, tmp_path):
     assert data["transcription"]["cloud_available"] is True
     assert data["speech"]["engine"] == "cloud"
     assert data["speech"]["cloud_available"] is True
-    assert data["speech"]["cloud_voice"] == "nova"
-    assert data["speech"]["local_voice"] == "af_heart"
+    assert data["speech"]["cloud_voice"] == "onyx"
+    assert data["speech"]["local_voice"] == "am_michael"
 
 
 def test_get_returns_apfel_effective_when_installed(monkeypatch, tmp_path):

--- a/tests/test_tts_engine.py
+++ b/tests/test_tts_engine.py
@@ -45,8 +45,8 @@ def _pcm(tmp_path, **config_overrides):
 def test_tts_engine_defaults_to_cloud(tmp_path):
     config = _config(tmp_path=tmp_path)
     assert config.tts_engine == "cloud"
-    assert config.tts_cloud_voice == "nova"
-    assert config.tts_local_voice == "af_heart"
+    assert config.tts_cloud_voice == "onyx"
+    assert config.tts_local_voice == "am_michael"
 
 
 def test_tts_engine_env_selection(tmp_path):
@@ -150,7 +150,7 @@ async def test_synthesize_speech_local_success(tmp_path, monkeypatch):
         mime_type = "audio/wav"
 
         def __init__(self, voice_id):
-            assert voice_id == "af_heart"
+            assert voice_id == "am_michael"
 
         async def speak(self, text):
             assert "Hello" in text


### PR DESCRIPTION
The Ciaobot avatar is male, but both TTS voice defaults were female — OpenAI `nova` and Kokoro `af_heart` (`af_` = American **Female**).

Switch defaults to their male counterparts:
- Cloud (OpenAI `gpt-4o-mini-tts`): `nova` → **`onyx`**
- Local (Kokoro): `af_heart` → **`am_michael`** (`am_` = American Male; language auto-detection keys off the first letter, so `am_` stays en-us)

Still overridable in Settings → Models / via `CIAO_TTS_CLOUD_VOICE` / `CIAO_TTS_LOCAL_VOICE`. Default-assertion tests updated; env-override and lang-detection tests unchanged.