### PR TITLE
Release v0.4.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.4.23 - 2026-07-14
+
+### Added
+- feat(voice): default TTS to a male voice to match the avatar (`a662e33`)
+
+### Changed
+- Merge pull request #107 from raffaelefarinaro/chore/sync-develop-v0.4.22 (`f28bfca`)
+- Merge pull request #108 from raffaelefarinaro/fix/tray-single-window (`ebcf751`)
+- Merge pull request #109 from raffaelefarinaro/feat/male-tts-voice (`92454da`)
+- Merge pull request #110 from raffaelefarinaro/fix/tts-env-doc-comment (`8bf9f75`)
+
+### Fixed
+- fix(menubar): focus the installed PWA instead of spawning a new window (`229b49c`)
+- fix(config): don't trip env-var doc check with a CIAO_TTS_* glob in a comment (`ca452d0`)
+
 ## v0.4.22 - 2026-07-14
 
 ### Added

--- a/ciao/__init__.py
+++ b/ciao/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.22"
+__version__ = "0.4.23"

--- a/ciao/config.py
+++ b/ciao/config.py
@@ -263,7 +263,7 @@ class CiaoConfig:
     # Default to a male voice to match the Ciaobot avatar. OpenAI ``onyx`` and
     # Kokoro ``am_michael`` (``am_`` = American Male) are the male counterparts
     # of the former ``nova`` / ``af_heart`` defaults. Overridable in Settings /
-    # via CIAO_TTS_*_VOICE.
+    # via CIAO_TTS_CLOUD_VOICE and CIAO_TTS_LOCAL_VOICE.
     tts_cloud_voice: str = "onyx"
     tts_local_voice: str = "am_michael"
     claude_models: list[str] = field(default_factory=lambda: ["opus", "sonnet", "haiku"])

--- a/ciao/config.py
+++ b/ciao/config.py
@@ -260,8 +260,12 @@ class CiaoConfig:
     # kokoro-onnx, free/offline). Runtime-overridable from the PWA
     # Settings → Models tab.
     tts_engine: str = "cloud"
-    tts_cloud_voice: str = "nova"
-    tts_local_voice: str = "af_heart"
+    # Default to a male voice to match the Ciaobot avatar. OpenAI ``onyx`` and
+    # Kokoro ``am_michael`` (``am_`` = American Male) are the male counterparts
+    # of the former ``nova`` / ``af_heart`` defaults. Overridable in Settings /
+    # via CIAO_TTS_*_VOICE.
+    tts_cloud_voice: str = "onyx"
+    tts_local_voice: str = "am_michael"
     claude_models: list[str] = field(default_factory=lambda: ["opus", "sonnet", "haiku"])
     claude_default_model: str = "opus"
     # Per-workspace default models. Empty string falls back to
@@ -699,9 +703,9 @@ class CiaoConfig:
                 in {"cloud", "local"}
                 else "cloud"
             ),
-            tts_cloud_voice=source.get("CIAO_TTS_CLOUD_VOICE", "").strip() or "nova",
+            tts_cloud_voice=source.get("CIAO_TTS_CLOUD_VOICE", "").strip() or "onyx",
             tts_local_voice=source.get("CIAO_TTS_LOCAL_VOICE", "").strip()
-            or "af_heart",
+            or "am_michael",
             ollama_local_discovery=source.get(
                 "CIAO_OLLAMA_LOCAL_DISCOVERY", ""
             ).strip().lower()

--- a/ciao/menubar.py
+++ b/ciao/menubar.py
@@ -259,9 +259,34 @@ def remove_browser_pwa_duplicates(app_name: str = "Ciaobot") -> list[Path]:
     return removed
 
 
-def open_command(url: str) -> list[str]:
-    """``open`` argv for a URL in an app-like window when possible."""
+def _installed_ciaobot_pwa() -> Path | None:
+    """Path to a browser-installed Ciaobot PWA app shim, if one exists.
 
+    Excludes our own native launcher bundle. A PWA app shim is single-instance,
+    which is what makes single-window launching possible (see open_command)."""
+
+    if sys.platform != "darwin":
+        return None
+    pwas = browser_pwa_duplicate_paths("Ciaobot")
+    return pwas[0] if pwas else None
+
+
+def open_command(url: str) -> list[str]:
+    """``open`` argv for the Ciaobot UI in an app-like window.
+
+    Prefer an installed Ciaobot PWA: its app shim is single-instance, so
+    ``open``-ing it *focuses the existing window* instead of spawning a new one.
+    That is the fix for "clicking Open Ciaobot opens a new window every time" —
+    ``--app=<url>`` on the raw browser binary always makes a fresh window, even
+    when the PWA is installed. Deep-link navigation (notification → chat) is
+    handled in-app by ``notify_open_chat`` over the WebSocket, so the URL is not
+    needed here while the PWA is running. Fall back to a raw app-mode window,
+    then the default browser, when no PWA is installed.
+    """
+
+    pwa = _installed_ciaobot_pwa()
+    if pwa is not None:
+        return ["open", str(pwa)]
     app_mode = browser_app_mode_command(url)
     if app_mode is not None:
         return app_mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciaobot"
-version = "0.4.22"
+version = "0.4.23"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_menubar.py
+++ b/tests/test_menubar.py
@@ -113,6 +113,7 @@ def test_server_recovery_label_matches_reachability() -> None:
 
 def test_open_url_uses_setup_token(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(menubar, "_installed_browser_app_names", lambda: [])
+    monkeypatch.setattr(menubar, "_installed_ciaobot_pwa", lambda: None)
     token_path = tmp_path / ".runtime" / "setup-token"
     token_path.parent.mkdir(parents=True)
     token_path.write_text("tok123\n", encoding="utf-8")
@@ -128,6 +129,7 @@ def test_open_url_without_token_falls_back_to_plain_url(
     tmp_path: Path, monkeypatch
 ) -> None:
     monkeypatch.setattr(menubar, "_installed_browser_app_names", lambda: [])
+    monkeypatch.setattr(menubar, "_installed_ciaobot_pwa", lambda: None)
 
     url = menubar.open_url(tmp_path, 8443)
     assert menubar.open_command(url) == [
@@ -141,12 +143,25 @@ def test_open_command_uses_browser_binary_for_app_mode(monkeypatch) -> None:
     # `open` drops the args when the browser is already running, so the app
     # window never opens (the "Open Ciaobot only focuses Chrome" bug).
     monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(menubar, "_installed_ciaobot_pwa", lambda: None)
     monkeypatch.setattr(menubar, "_installed_browser_app_names", lambda: ["Google Chrome"])
 
     assert menubar.open_command("http://localhost:8443/") == [
         "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
         "--app=http://localhost:8443/",
     ]
+
+
+def test_open_command_prefers_installed_pwa(tmp_path: Path, monkeypatch) -> None:
+    # An installed PWA app shim is single-instance: opening it focuses the
+    # existing window instead of spawning a new one (the "Open Ciaobot opens a
+    # new window every click" bug). It wins over the raw-browser app-mode path.
+    monkeypatch.setattr(sys, "platform", "darwin")
+    pwa = tmp_path / "Chrome Apps.localized" / "Ciaobot.app"
+    monkeypatch.setattr(menubar, "_installed_ciaobot_pwa", lambda: pwa)
+    monkeypatch.setattr(menubar, "_installed_browser_app_names", lambda: ["Google Chrome"])
+
+    assert menubar.open_command("http://localhost:8443/chat/abc") == ["open", str(pwa)]
 
 
 def test_launch_ui_spawns_detached_browser(monkeypatch) -> None:

--- a/tests/test_settings_routines_route.py
+++ b/tests/test_settings_routines_route.py
@@ -84,8 +84,8 @@ def test_get_returns_effective_models_and_options(monkeypatch, tmp_path):
     assert data["transcription"]["cloud_available"] is True
     assert data["speech"]["engine"] == "cloud"
     assert data["speech"]["cloud_available"] is True
-    assert data["speech"]["cloud_voice"] == "nova"
-    assert data["speech"]["local_voice"] == "af_heart"
+    assert data["speech"]["cloud_voice"] == "onyx"
+    assert data["speech"]["local_voice"] == "am_michael"
 
 
 def test_get_returns_apfel_effective_when_installed(monkeypatch, tmp_path):

--- a/tests/test_tts_engine.py
+++ b/tests/test_tts_engine.py
@@ -45,8 +45,8 @@ def _pcm(tmp_path, **config_overrides):
 def test_tts_engine_defaults_to_cloud(tmp_path):
     config = _config(tmp_path=tmp_path)
     assert config.tts_engine == "cloud"
-    assert config.tts_cloud_voice == "nova"
-    assert config.tts_local_voice == "af_heart"
+    assert config.tts_cloud_voice == "onyx"
+    assert config.tts_local_voice == "am_michael"
 
 
 def test_tts_engine_env_selection(tmp_path):
@@ -150,7 +150,7 @@ async def test_synthesize_speech_local_success(tmp_path, monkeypatch):
         mime_type = "audio/wav"
 
         def __init__(self, voice_id):
-            assert voice_id == "af_heart"
+            assert voice_id == "am_michael"
 
         async def speak(self, text):
             assert "Hello" in text

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-pwa",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-pwa",
-      "version": "0.4.22",
+      "version": "0.4.23",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
         "dompurify": "^3.4.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-pwa",
   "private": true,
-  "version": "0.4.22",
+  "version": "0.4.23",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Release Ciaobot v0.4.23 to `main`
- Update package, PWA, and package-lock versions
- Add changelog notes for the release range

## Release notes
## v0.4.23 - 2026-07-14

### Added
- feat(voice): default TTS to a male voice to match the avatar (`a662e33`)

### Changed
- Merge pull request #107 from raffaelefarinaro/chore/sync-develop-v0.4.22 (`f28bfca`)
- Merge pull request #108 from raffaelefarinaro/fix/tray-single-window (`ebcf751`)
- Merge pull request #109 from raffaelefarinaro/feat/male-tts-voice (`92454da`)
- Merge pull request #110 from raffaelefarinaro/fix/tts-env-doc-comment (`8bf9f75`)

### Fixed
- fix(menubar): focus the installed PWA instead of spawning a new window (`229b49c`)
- fix(config): don't trip env-var doc check with a CIAO_TTS_* glob in a comment (`ca452d0`)

## Testing
- pytest tests/
- cd web && npm run test
- cd web && npm run build
- ciao package-smoke --skip-frontend

## After approval
- Merge this PR into `main`
- GitHub Actions will create tag `v0.4.23`, publish the GitHub release, and sync `develop`
