### PR TITLE
chore: sync develop with main after v0.4.23 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.4.23 - 2026-07-14
+
+### Added
+- feat(voice): default TTS to a male voice to match the avatar (`a662e33`)
+
+### Changed
+- Merge pull request #107 from raffaelefarinaro/chore/sync-develop-v0.4.22 (`f28bfca`)
+- Merge pull request #108 from raffaelefarinaro/fix/tray-single-window (`ebcf751`)
+- Merge pull request #109 from raffaelefarinaro/feat/male-tts-voice (`92454da`)
+- Merge pull request #110 from raffaelefarinaro/fix/tts-env-doc-comment (`8bf9f75`)
+
+### Fixed
+- fix(menubar): focus the installed PWA instead of spawning a new window (`229b49c`)
+- fix(config): don't trip env-var doc check with a CIAO_TTS_* glob in a comment (`ca452d0`)
+
 ## v0.4.22 - 2026-07-14
 
 ### Added

--- a/ciao/__init__.py
+++ b/ciao/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.22"
+__version__ = "0.4.23"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciaobot"
-version = "0.4.22"
+version = "0.4.23"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-pwa",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-pwa",
-      "version": "0.4.22",
+      "version": "0.4.23",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
         "dompurify": "^3.4.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-pwa",
   "private": true,
-  "version": "0.4.22",
+  "version": "0.4.23",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
The automated sync-develop job was skipped because the release workflow hit a transient GitHub API 500 creating the release (then the re-run's tag-guard skipped it). This brings develop up to main (version bump to 0.4.23 + CHANGELOG), so the next release cuts 0.4.24 cleanly.