### PR TITLE
fix(web): make bare-URL frontmatter values clickable in file viewers

### DIFF
--- a/web/src/components/FileViewerModal.vue
+++ b/web/src/components/FileViewerModal.vue
@@ -244,7 +244,15 @@
               <dl v-if="fmExtraEntries.length" class="fv-meta-extra">
                 <template v-for="entry in fmExtraEntries" :key="entry.key">
                   <dt>{{ entry.key }}</dt>
-                  <dd>{{ entry.value }}</dd>
+                  <dd>
+                    <a
+                      v-if="isUrl(entry.value)"
+                      :href="entry.value"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >{{ entry.value }}</a>
+                    <template v-else>{{ entry.value }}</template>
+                  </dd>
                 </template>
               </dl>
             </div>
@@ -512,6 +520,12 @@ function fmList(key: string): string[] {
   const v = frontmatter.value?.[key]
   if (v == null) return []
   return Array.isArray(v) ? v : [String(v)]
+}
+// A frontmatter value that is a bare http(s) URL (e.g. `url:`) renders as a
+// clickable link rather than plain text. Only http/https so the href can't be
+// a javascript:/data: scheme.
+function isUrl(value: string): boolean {
+  return /^https?:\/\/\S+$/.test(value.trim())
 }
 // Keep `fmTitle` in scope (read by linters as referenced for completeness
 // even though the chip itself uses fmName / basename for the heading).

--- a/web/src/components/PinnedFilePanel.vue
+++ b/web/src/components/PinnedFilePanel.vue
@@ -116,7 +116,15 @@
             <dl v-if="fmExtraEntries.length" class="pfp-meta-extra">
               <template v-for="entry in fmExtraEntries" :key="entry.key">
                 <dt>{{ entry.key }}</dt>
-                <dd>{{ entry.value }}</dd>
+                <dd>
+                  <a
+                    v-if="isUrl(entry.value)"
+                    :href="entry.value"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >{{ entry.value }}</a>
+                  <template v-else>{{ entry.value }}</template>
+                </dd>
               </template>
             </dl>
           </div>
@@ -429,6 +437,11 @@ function fmString(key: string): string {
   const v = frontmatter.value?.[key]
   if (v == null) return ''
   return Array.isArray(v) ? v.join(', ') : String(v)
+}
+// Render a bare http(s) frontmatter value (e.g. `url:`) as a clickable link.
+// Only http/https so the href can't be a javascript:/data: scheme.
+function isUrl(value: string): boolean {
+  return /^https?:\/\/\S+$/.test(value.trim())
 }
 function fmList(key: string): string[] {
   const v = frontmatter.value?.[key]


### PR DESCRIPTION
A frontmatter `url: https://…` field rendered as plain text in the metadata card (e.g. a Confluence link wasn't clickable — reported with a screenshot). Render a bare http(s) value as an anchor (`target=_blank`, `rel=noopener noreferrer`) in both FileViewerModal and PinnedFilePanel. Restricted to http/https so the href can't be a javascript:/data: scheme. vue-tsc + vite build clean.