### PR TITLE
fix(web): auto-reconnect active chat WebSocket on unexpected drop (stale-message fix)

### DIFF
--- a/web/src/stores/projects.test.ts
+++ b/web/src/stores/projects.test.ts
@@ -90,6 +90,63 @@ describe('streaming started reconnect guard', () => {
   })
 })
 
+describe('per-chat WS auto-reconnect', () => {
+  test('reconnects the active chat after an unexpected drop', async () => {
+    apiGet.mockResolvedValue([])
+    const store = useProjectStore()
+    const chatId = 'c-drop'
+    store.activeChatId = chatId
+    store.connectWs(chatId)
+    expect(fakeSockets.length).toBe(1)
+
+    vi.useFakeTimers()
+    try {
+      fakeSockets[0].close() // simulate an unexpected server-side close
+      expect(fakeSockets.length).toBe(1) // reconnect is scheduled, not immediate
+      await vi.advanceTimersByTimeAsync(1200) // > 1s backoff
+    } finally {
+      vi.useRealTimers()
+    }
+
+    expect(fakeSockets.length).toBe(2) // fresh socket opened (resync + reconnect)
+  })
+
+  test('does not reconnect after an intentional disconnect', async () => {
+    apiGet.mockResolvedValue([])
+    const store = useProjectStore()
+    const chatId = 'c-intentional'
+    store.activeChatId = chatId
+    store.connectWs(chatId)
+
+    vi.useFakeTimers()
+    try {
+      store.disconnectWs(chatId) // e.g. switching chats
+      await vi.advanceTimersByTimeAsync(2000)
+    } finally {
+      vi.useRealTimers()
+    }
+
+    expect(fakeSockets.length).toBe(1) // no auto-reconnect
+  })
+
+  test('does not reconnect a chat the user is not viewing', async () => {
+    apiGet.mockResolvedValue([])
+    const store = useProjectStore()
+    store.activeChatId = 'other'
+    store.connectWs('c-background')
+
+    vi.useFakeTimers()
+    try {
+      fakeSockets[0].close()
+      await vi.advanceTimersByTimeAsync(2000)
+    } finally {
+      vi.useRealTimers()
+    }
+
+    expect(fakeSockets.length).toBe(1) // background chat's socket stays closed
+  })
+})
+
 describe('queued message replay handling', () => {
   test('clears local queued chips when server history contains the flushed user turn', async () => {
     const store = useProjectStore()

--- a/web/src/stores/projects.ts
+++ b/web/src/stores/projects.ts
@@ -248,6 +248,16 @@ export const useProjectStore = defineStore('projects', () => {
   let lastEventsFrameAt = 0
   const lastChatFrameAt: Record<string, number> = {}
   const nowMs = () => (typeof performance !== 'undefined' ? performance.now() : Date.now())
+  // Per-chat WS auto-reconnect bookkeeping. A dropped per-chat socket used to
+  // recover only via the 15s syncLatest poll (up to 15s of stale messages /
+  // missed turn result). We now reconnect the *active* chat immediately on an
+  // unexpected close, with backoff. `intentionalCloses` marks a close made by
+  // disconnectWs so it is NOT auto-reconnected; `chatReconnectTimers` lets a
+  // pending reconnect be cancelled; attempts drive the backoff and reset once
+  // the socket proves live (first frame received).
+  const intentionalCloses = new Set<string>()
+  const chatReconnectTimers: Record<string, number> = {}
+  const chatReconnectAttempts: Record<string, number> = {}
 
   // ── Computed ─────────────────────────────────────────────────────────
 
@@ -1460,6 +1470,9 @@ export const useProjectStore = defineStore('projects', () => {
     ws.onmessage = (ev) => {
       // Any frame (including the server keepalive) proves the socket is live.
       lastChatFrameAt[chatId] = nowMs()
+      // A working socket clears the reconnect backoff so a later drop starts
+      // from a fast first retry again.
+      chatReconnectAttempts[chatId] = 0
       const event: WsEvent = JSON.parse(ev.data)
       handleEvent(chatId, event)
     }
@@ -1475,6 +1488,25 @@ export const useProjectStore = defineStore('projects', () => {
       streamingThinking.value[chatId] = ''
       streamingTimeline.value[chatId] = []
       delete streamingTextPhase.value[chatId]
+
+      // Auto-reconnect the chat the user is actually viewing when the socket
+      // drops unexpectedly (server per-turn churn, transient network blip),
+      // so live deltas and the final result resume within ~1s instead of
+      // waiting for the 15s poll or a manual reload. Intentional closes
+      // (disconnectWs, e.g. switching chats) are skipped.
+      if (intentionalCloses.delete(chatId)) return
+      if (typeof window === 'undefined' || typeof WebSocket === 'undefined') return
+      if (activeChatId.value !== chatId) return
+      const attempt = (chatReconnectAttempts[chatId] = (chatReconnectAttempts[chatId] || 0) + 1)
+      const delay = Math.min(1000 * attempt, 5000)
+      if (chatReconnectTimers[chatId]) window.clearTimeout(chatReconnectTimers[chatId])
+      chatReconnectTimers[chatId] = window.setTimeout(() => {
+        delete chatReconnectTimers[chatId]
+        // Only if still the viewed chat and not reconnected in the meantime.
+        if (activeChatId.value === chatId && !sockets.value[chatId]) {
+          void reloadAndReconnectChat(chatId)
+        }
+      }, delay)
     }
   }
 
@@ -1590,8 +1622,15 @@ export const useProjectStore = defineStore('projects', () => {
   }
 
   function disconnectWs(chatId: string) {
+    // Cancel any pending auto-reconnect and mark this as an intentional close
+    // so onclose does not schedule a new one.
+    if (chatReconnectTimers[chatId]) {
+      window.clearTimeout(chatReconnectTimers[chatId])
+      delete chatReconnectTimers[chatId]
+    }
     const ws = sockets.value[chatId]
     if (ws) {
+      intentionalCloses.add(chatId)
       ws.close()
       delete sockets.value[chatId]
     }
@@ -1633,9 +1672,11 @@ export const useProjectStore = defineStore('projects', () => {
         eventsWsFailureStreak = 0
       } else {
         eventsWsFailureStreak += 1
-        if (eventsWsFailureStreak === 5) {
+        if (eventsWsFailureStreak >= 5) {
           // Likely an auth rejection: probe the HTTP API so its 401
-          // handling can redirect this stale tab to /login.
+          // handling can redirect this stale tab to /login. Re-probe on every
+          // failure past the threshold (not just the 5th) so a tab that keeps
+          // flapping still gets redirected.
           void api.get('/api/projects').catch(() => {})
         }
       }


### PR DESCRIPTION
## Problem
A chat's new messages or a finished turn's **result** could stay stale until the user manually reloaded the chat — the top pain point reported.

## Root cause
The per-chat `/ws/chat/<id>` socket had **no reconnect**: `onclose` only tore down local state. A dropped socket (server per-turn churn, transient blip) recovered only via the **15s `syncLatest` poll** — up to 15s of missing deltas — and a socket reconnecting just after a turn finished got no replay (broker cleared on `finish()`). (Investigation also found a latent WS **origin-check 403** bug for proxy/remote deploys — filed separately; NOT the local cause here, since local WS connections are all accepted.)

## Fix
`onclose` now auto-reconnects the **active** chat with backoff (1s→5s cap) via `reloadAndReconnectChat` (refetch `/messages`, then reconnect so the broker replays anything still buffered). Skips intentional closes (`disconnectWs`, e.g. switching chats) and non-active chats; a live frame resets the backoff. Also: the events-WS auth-probe now fires on every failure past the threshold (`>= 5`), not just the 5th.

## Tests
`projects.test.ts`: reconnect-on-drop, no-reconnect-on-intentional-close, no-reconnect-for-non-active-chat. Full store suite: **25 passing**. vue-tsc + vite build clean.