### PR TITLE
fix(auth): proxy-aware WebSocket origin check (#115)

### DIFF
--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -173,6 +173,7 @@ Runtime config for the Ciaobot server itself (PWA, schedules, deploy).
 
 - `CLAUDE_EXECUTION_MODE`: `normal`, `plan`, `auto`, `bypass`. Legacy `CLAUDE_PERMISSION_MODE` still accepted.
 - `PWA_AUTH_REQUIRED`: set to `true` to require password protection for the PWA dashboard. Disabled by default.
+- `CIAO_ALLOWED_ORIGINS`: comma-separated extra hostnames/origins accepted for state-changing HTTP and WebSocket handshakes when the app is reached under a host it doesn't bind to (reverse proxy, tunnel, or host alias). Without it, such setups get their `/ws/*` upgrades rejected (403) and live updates stall. A proxy-supplied `X-Forwarded-Host` is honored automatically. Example: `app.example.com,ciao.tailnet.ts.net`.
 - `CIAO_DEV_MODE`: set to `true` to enable developer mode controls in the PWA dashboard (like the Deploy button).
 - `CIAO_VAULT_MODE`: onboarding mode for memory-vault folders. Either `scratch` (create folders and documentation from scratch) or `existing` (connect and adapt existing markdown folders).
 - `CIAO_BOOTSTRAP_WORKSPACE`: temp workspace root used when `PWA_AUTH_TOKEN` is absent. Defaults to `~/.ciao/bootstrap`; Ciaobot persists the generated bootstrap auth token under its `.runtime/` so first-run setup survives a restart.

--- a/ciao/config.py
+++ b/ciao/config.py
@@ -236,6 +236,12 @@ class CiaoConfig:
     state_path: Path
     media_root: Path
     pwa_auth_required: bool = False
+    # Extra origins accepted for state-changing HTTP + WebSocket handshakes when
+    # the app is reached under a host it doesn't bind to (reverse proxy / tunnel
+    # / host alias). Bare hostnames or full origins; from CIAO_ALLOWED_ORIGINS.
+    # A proxy-supplied X-Forwarded-Host is honored too (browsers can't forge it
+    # on a handshake, so it's safe against cross-site WS hijacking).
+    pwa_allowed_origins: tuple[str, ...] = ()
     dev_mode: bool = False
     vault_mode: str = "scratch"
     bootstrap_mode: bool = False
@@ -502,6 +508,12 @@ class CiaoConfig:
         pwa_auth_required_raw = source.get("PWA_AUTH_REQUIRED", "").strip().lower()
         pwa_auth_required = pwa_auth_required_raw in {"true", "1", "yes", "y"}
 
+        pwa_allowed_origins = tuple(
+            o.strip()
+            for o in source.get("CIAO_ALLOWED_ORIGINS", "").split(",")
+            if o.strip()
+        )
+
         pwa_auth_token = source.get("PWA_AUTH_TOKEN", "").strip()
         bootstrap_mode = not (
             (bool(pwa_auth_token) or not pwa_auth_required)
@@ -671,6 +683,7 @@ class CiaoConfig:
             state_path=state_path,
             media_root=media_root,
             pwa_auth_required=pwa_auth_required,
+            pwa_allowed_origins=pwa_allowed_origins,
             dev_mode=dev_mode,
             vault_mode=vault_mode,
             bootstrap_mode=bootstrap_mode,

--- a/ciao/web/auth.py
+++ b/ciao/web/auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hmac
+import logging
 from pathlib import Path
 
 from itsdangerous import URLSafeTimedSerializer, BadSignature
@@ -10,6 +11,8 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, RedirectResponse
 from starlette.websockets import WebSocket
+
+logger = logging.getLogger(__name__)
 
 SESSION_COOKIE = "ciao_session"
 SESSION_MAX_AGE = 60 * 60 * 24 * 30  # 30 days
@@ -65,6 +68,35 @@ def _split_host(value: str) -> tuple[str, int | None]:
         return host, None
 
 
+def _allowed_origin_hosts(request: Request | WebSocket) -> set[str]:
+    """Hostnames — beyond the bound ``Host`` — an origin may legitimately match.
+
+    Covers the reverse-proxy / tunnel / host-alias case where the browser
+    reaches the app under a public hostname while the server binds to (and sees
+    ``Host``) something else:
+
+    - ``X-Forwarded-Host``: the original host a proxy declares. Browsers cannot
+      set this on a WebSocket/fetch handshake, so it can't be forged by a
+      cross-site page — only a fronting proxy sets it.
+    - ``CIAO_ALLOWED_ORIGINS``: an explicit operator allowlist of hosts/origins.
+    """
+    from urllib.parse import urlsplit
+
+    hosts: set[str] = set()
+    forwarded = request.headers.get("x-forwarded-host", "")
+    for part in forwarded.split(","):
+        host, _port = _split_host(part.strip())
+        if host:
+            hosts.add(host.lower().rstrip("."))
+    state = getattr(getattr(request, "app", None), "state", None)
+    cfg = getattr(state, "config", None)
+    for entry in getattr(cfg, "pwa_allowed_origins", ()) or ():
+        host = urlsplit(entry).hostname if "//" in entry else _split_host(entry)[0]
+        if host:
+            hosts.add(host.lower().rstrip("."))
+    return hosts
+
+
 def _same_origin(request: Request | WebSocket, origin: str) -> bool:
     from urllib.parse import urlsplit
 
@@ -82,11 +114,13 @@ def _same_origin(request: Request | WebSocket, origin: str) -> bool:
 
     origin_host = parsed.hostname.lower()
     origin_port = parsed.port
-    if origin_host != request_host:
-        return False
-    if origin_port is not None and request_port is not None and origin_port != request_port:
-        return False
-    return True
+    if origin_host == request_host:
+        if origin_port is not None and request_port is not None and origin_port != request_port:
+            return False
+        return True
+    # Reached under a proxy-declared or operator-allowed host (port may differ
+    # across the proxy hop, so it isn't compared here).
+    return origin_host in _allowed_origin_hosts(request)
 
 
 def _state_change_origin_allowed(request: Request) -> bool:
@@ -111,6 +145,13 @@ async def authorize_websocket(websocket: WebSocket) -> bool:
     """
     origin = websocket.headers.get("origin")
     if origin and not _same_origin(websocket, origin):
+        logger.warning(
+            "WebSocket origin rejected: origin=%s host=%s x-forwarded-host=%s "
+            "(set CIAO_ALLOWED_ORIGINS if reaching Ciaobot under a proxy host)",
+            origin,
+            websocket.headers.get("host", ""),
+            websocket.headers.get("x-forwarded-host", ""),
+        )
         await websocket.close(code=4003, reason="forbidden origin")
         return False
     config = getattr(websocket.app.state, "config", None)

--- a/tests/test_auth_security.py
+++ b/tests/test_auth_security.py
@@ -61,6 +61,48 @@ def test_safe_request_does_not_require_origin() -> None:
     assert resp.status_code == 200
 
 
+def _origin_req(headers: dict[str, str], allowed: tuple[str, ...] = ()) -> object:
+    cfg = SimpleNamespace(pwa_allowed_origins=allowed)
+    return SimpleNamespace(
+        headers={k.lower(): v for k, v in headers.items()},
+        url=SimpleNamespace(hostname=None, port=None),
+        app=SimpleNamespace(state=SimpleNamespace(config=cfg)),
+    )
+
+
+def test_same_origin_accepts_matching_host() -> None:
+    from ciao.web.auth import _same_origin
+
+    req = _origin_req({"host": "ciao.example"})
+    assert _same_origin(req, "https://ciao.example") is True
+
+
+def test_same_origin_rejects_cross_origin() -> None:
+    from ciao.web.auth import _same_origin
+
+    req = _origin_req({"host": "ciao.example"})
+    assert _same_origin(req, "https://evil.example") is False
+
+
+def test_same_origin_accepts_proxy_forwarded_host() -> None:
+    """Behind a proxy the bound Host differs from the browser origin; the
+    proxy-declared X-Forwarded-Host makes the WS/state-change handshake pass."""
+    from ciao.web.auth import _same_origin
+
+    req = _origin_req({"host": "localhost:8765", "x-forwarded-host": "app.example"})
+    assert _same_origin(req, "https://app.example") is True
+    # A genuine cross-origin still fails even with the forwarded host present.
+    assert _same_origin(req, "https://evil.example") is False
+
+
+def test_same_origin_accepts_configured_allowlist() -> None:
+    from ciao.web.auth import _same_origin
+
+    req = _origin_req({"host": "localhost"}, allowed=("app.example",))
+    assert _same_origin(req, "https://app.example") is True
+    assert _same_origin(req, "https://other.example") is False
+
+
 def _auth_client() -> TestClient:
     serializer = URLSafeTimedSerializer("test-secret")
     app = Starlette(


### PR DESCRIPTION
Fixes #115. The WS origin check 403'd every upgrade behind a reverse proxy / tunnel / host alias (browser origin host != bound `Host`), silently killing live updates. Now accepts an origin whose host matches a proxy-declared `X-Forwarded-Host` (unforgeable by a cross-site browser handshake) or an operator allowlist `CIAO_ALLOWED_ORIGINS`; genuine cross-origin still rejected. Logs rejected origin/host at WARNING; documented in INTEGRATIONS.md. Tests: matching / cross-origin / forwarded-host / allowlist. Full suite 1233 passed.