### PR TITLE
fix(web): pin short chats to bottom — fix empty-gap scroll bug

### DIFF
--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -2943,6 +2943,8 @@ function insertImageRef(n: number) {
    flex-end so short chats sit above the composer without breaking scroll. */
 .messages {
   flex: 1;
+  display: flex;
+  flex-direction: column;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
@@ -2954,8 +2956,12 @@ function insertImageRef(n: number) {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  min-height: 100%;
-  justify-content: flex-end;
+  /* Pin the transcript to the bottom when it's shorter than the viewport, but
+     collapse to 0 and scroll normally when it overflows. `margin-top: auto`
+     is resolution-independent — unlike `min-height: 100%`, which resolved
+     against `.messages` (no explicit height) to 0 in some engines and left
+     short/streaming chats stuck at the top with dead space below. */
+  margin-top: auto;
 }
 
 .message-wrap {


### PR DESCRIPTION
## Problem
The chat transcript rendered at the **top** with a large empty gap down to the input — most visible with few messages while streaming a "Thinking…" bubble. Recurring scroll bug.

## Root cause
`.messages-content { min-height: 100% }` was the only mechanism stretching the wrapper so `justify-content: flex-end` could bottom-align content. But that percentage resolves against `.messages`, which has **no explicit height** (only flex-stretch), so it evaluated to 0 in some engines → wrapper collapsed to content height → short content sat at the top of the block scroller.

## Fix
Make `.messages` a flex column and pin with `margin-top: auto` on `.messages-content` (the idiomatic, resolution-independent chat pattern): bottom-aligned when short, collapses to 0 and scrolls normally (top reachable) when it overflows. No JS change — the existing scroll-to-bottom / stick-to-bottom logic still handles the overflow case. Build clean.

Diagnosed via subagent trace of the container/CSS chain in ChatPanel.vue.