### PR TITLE
Release v0.4.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.4.27 - 2026-07-15
+
+### Added
+- feat(web): pulse the active-work dot on a running loop (`a7c1eff`)
+
+### Changed
+- Merge pull request #128 from raffaelefarinaro/chore/sync-develop-v0.4.26 (`ead9055`)
+
+### Fixed
+- fix(pwa): service worker falls back to the app shell on navigation (`5c83cb3`)
+- fix(web): remount the chat view when switching chats (`ecfcee7`)
+
 ## v0.4.26 - 2026-07-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 - fix(pwa): service worker falls back to the app shell on navigation (`5c83cb3`)
 - fix(web): remount the chat view when switching chats (`ecfcee7`)
+- fix(vault-lint): cut false positives — code spans, escaped brackets, templates, same-stem duplicates, .venv (#129) (`68d8be5`)
 
 ## v0.4.26 - 2026-07-15
 

--- a/ciao/__init__.py
+++ b/ciao/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.26"
+__version__ = "0.4.27"

--- a/ciao/vault_lint.py
+++ b/ciao/vault_lint.py
@@ -8,6 +8,38 @@ from pathlib import Path
 # Match [[Target]], ignoring optional #anchors and |labels
 WIKILINK_RE = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|[^\]]*)?\]\]")
 
+# Fenced code blocks and inline code spans are prose *about* wikilinks, not
+# real links — guides and changelogs routinely document `[[wikilink]]` syntax.
+# Strip them before extracting links so documented syntax isn't flagged.
+_FENCE_RE = re.compile(r"(?ms)^[ \t]*(`{3,}|~{3,}).*?^[ \t]*\1[ \t]*$")
+_INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
+
+# Common structural filenames that legitimately recur across folders (one
+# README/log/etc. per project). Same stem across folders is not a duplicate.
+_COMMON_STEMS = {
+    "readme", "index", "log", "notes", "general", "overview",
+    "changelog", "todo", "template",
+}
+
+
+def _links_in(text: str):
+    """Yield wikilink targets in ``text``, skipping code spans/fences,
+    backslash-escaped brackets, and ``<placeholder>`` template syntax — none
+    of which are real links."""
+    stripped = _INLINE_CODE_RE.sub("", _FENCE_RE.sub("", text))
+    for m in WIKILINK_RE.finditer(stripped):
+        if m.start() > 0 and stripped[m.start() - 1] == "\\":
+            continue  # escaped \[[...]] — documenting the syntax
+        target = m.group(1).strip()
+        if "<" in target or ">" in target:
+            continue  # placeholder like [[projects/active/<folder>/<folder>]]
+        yield target
+
+
+def _is_template(stem: str) -> bool:
+    return "template" in stem.lower()
+
+
 def run_validation(vault_root: Path) -> dict:
     """Scan the vault directory and find broken wikilinks, orphans, and duplicates."""
     issues = {
@@ -15,52 +47,64 @@ def run_validation(vault_root: Path) -> dict:
         "orphans": [],
         "duplicates": []
     }
-    
+
     valid_targets = set()
     files_to_scan = []
     incoming_links = {}
-    
-    # Exclude directories
-    exclude_dirs = {"Logs", "Templates", ".obsidian"}
+
+    # Exclude directories that aren't vault content: app state, generated
+    # projections, tool caches, and any venv/node_modules checked out inside
+    # the vault root (see issue #129).
+    exclude_dirs = {
+        "Logs", "Templates", ".obsidian",
+        ".venv", "venv", "node_modules", ".git",
+        ".claude", ".agents", ".codex", "__pycache__",
+    }
     exclude_files = {"INDEX.md", "MEMORY.md"}
-    
+
     normalized_names = {}
-    
+
     for path in vault_root.rglob("*.md"):
         try:
             rel = path.relative_to(vault_root)
         except ValueError:
             continue
-            
+
         if any(p in exclude_dirs for p in rel.parts):
             continue
         if rel.name in exclude_files:
             continue
-            
+
         target_stem = path.stem
         target_rel = str(rel.with_suffix(""))
         valid_targets.add(target_stem)
         valid_targets.add(target_rel)
-        files_to_scan.append((path, str(rel)))
-        
+
+        # Template files contain placeholder links by design; keep them as
+        # valid link targets but don't scan them as a source of broken links.
+        if not _is_template(target_stem):
+            files_to_scan.append((path, str(rel)))
+
         incoming_links[target_stem] = []
         incoming_links[target_rel] = []
-        
-        norm = target_stem.lower().replace("-", "").replace("_", "")
-        normalized_names.setdefault(norm, []).append(str(rel))
+
+        # Duplicate detection: skip common structural stems (README/log/etc.)
+        # that legitimately repeat per folder, and template files.
+        if target_stem.lower() not in _COMMON_STEMS and not _is_template(target_stem):
+            norm = target_stem.lower().replace("-", "").replace("_", "")
+            normalized_names.setdefault(norm, []).append(str(rel))
 
     for norm, paths in normalized_names.items():
         if len(paths) > 1:
             issues["duplicates"].append(paths)
-        
+
     for path, rel_str in files_to_scan:
         try:
             content = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
-            
-        for match in WIKILINK_RE.finditer(content):
-            target = match.group(1).strip()
+
+        for target in _links_in(content):
             if target in valid_targets:
                 incoming_links.setdefault(target, []).append(rel_str)
             else:
@@ -68,7 +112,7 @@ def run_validation(vault_root: Path) -> dict:
                     "source": rel_str,
                     "target": target
                 })
-                
+
     # Check for memory files links (roots)
     memory_md = vault_root / "personal" / "MEMORY.md"
     memory_work_md = vault_root / "work" / "MEMORY.md"
@@ -77,8 +121,8 @@ def run_validation(vault_root: Path) -> dict:
         if mem_file.exists():
             try:
                 mem_content = mem_file.read_text(encoding="utf-8")
-                for match in WIKILINK_RE.finditer(mem_content):
-                    memory_links.add(match.group(1).strip())
+                for target in _links_in(mem_content):
+                    memory_links.add(target)
             except OSError:
                 pass
 
@@ -88,17 +132,17 @@ def run_validation(vault_root: Path) -> dict:
         stem = path.stem
         rel_path = Path(rel_str)
         rel_no_sfx = str(rel_path.with_suffix(""))
-        
+
         if not any(part in orphan_candidate_dirs for part in rel_path.parts):
             continue
-            
+
         has_incoming = False
         if incoming_links.get(stem) or incoming_links.get(rel_no_sfx):
             has_incoming = True
         if stem in memory_links or rel_no_sfx in memory_links:
             has_incoming = True
-            
+
         if not has_incoming:
             issues["orphans"].append(rel_str)
-            
+
     return issues

--- a/ciao/web/static/index.html
+++ b/ciao/web/static/index.html
@@ -13,7 +13,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-180.png" />
     <title>Ciaobot</title>
-    <script type="module" crossorigin src="/assets/index-DoaE1F_L.js"></script>
+    <script type="module" crossorigin src="/assets/index-CXH9DJmA.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-bEmbKxes.css">
   </head>
   <body>

--- a/ciao/web/static/index.html
+++ b/ciao/web/static/index.html
@@ -13,7 +13,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-180.png" />
     <title>Ciaobot</title>
-    <script type="module" crossorigin src="/assets/index-DhkhEuGs.js"></script>
+    <script type="module" crossorigin src="/assets/index-DoaE1F_L.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-bEmbKxes.css">
   </head>
   <body>

--- a/ciao/web/static/sw.js
+++ b/ciao/web/static/sw.js
@@ -244,6 +244,19 @@ self.addEventListener('fetch', (event) => {
         }
         return response
       })
-      .catch(() => caches.match(event.request).then((cached) => cached || Response.error()))
+      .catch(async () => {
+        // SPA navigations (e.g. /chat/<id>) aren't cached under their own URL
+        // — only the app shell is. When the network is momentarily
+        // unavailable (server restart, flaky connection), fall back to the
+        // cached shell so client-side routing still loads the page, instead
+        // of returning a hard network error (blank/broken chat).
+        if (event.request.mode === 'navigate') {
+          const shell =
+            (await caches.match('/index.html')) || (await caches.match('/'))
+          if (shell) return shell
+        }
+        const cached = await caches.match(event.request)
+        return cached || Response.error()
+      })
   )
 })

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciaobot"
-version = "0.4.26"
+version = "0.4.27"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_vault_lint.py
+++ b/tests/test_vault_lint.py
@@ -42,3 +42,41 @@ def test_duplicate_detection(temp_vault):
     assert len(issues["duplicates"]) == 1
     assert "People/Alice-Smith.md" in issues["duplicates"][0]
     assert "People/AliceSmith.md" in issues["duplicates"][0]
+
+
+def test_ignores_wikilinks_in_code_and_escaped(temp_vault):
+    """Wikilink syntax inside code spans/fences or backslash-escaped is
+    documentation, not a real link, and must not be flagged (issue #129)."""
+    (temp_vault / "People" / "Guide.md").write_text(
+        "Use `[[Nonexistent]]` in prose.\n\n"
+        "```\n[[AlsoNonexistent]]\n```\n\n"
+        "Escaped: \\[[EscapedTarget]]\n"
+        "Placeholder: [[projects/active/<folder>/<folder>]]\n",
+        encoding="utf-8",
+    )
+    issues = vault_lint.run_validation(temp_vault)
+    bad = {b["target"] for b in issues["broken_links"]}
+    assert "Nonexistent" not in bad
+    assert "AlsoNonexistent" not in bad
+    assert "EscapedTarget" not in bad
+    assert not any("<folder>" in t for t in bad)
+
+
+def test_common_stems_not_flagged_as_duplicates(temp_vault):
+    """One README/log per project is normal, not a duplicate page (#129)."""
+    projects = temp_vault / "projects"
+    (projects / "a").mkdir(parents=True)
+    (projects / "b").mkdir(parents=True)
+    (projects / "a" / "README.md").write_text("A", encoding="utf-8")
+    (projects / "b" / "README.md").write_text("B", encoding="utf-8")
+    issues = vault_lint.run_validation(temp_vault)
+    assert all("README.md" not in "".join(dup) for dup in issues["duplicates"])
+
+
+def test_excludes_venv_and_tool_dirs(temp_vault):
+    """A venv/node_modules checked out in the vault must not be scanned (#129)."""
+    venv = temp_vault / "work" / "automations" / ".venv" / "lib"
+    venv.mkdir(parents=True)
+    (venv / "doc.md").write_text("[[NopeTarget]]", encoding="utf-8")
+    issues = vault_lint.run_validation(temp_vault)
+    assert not any(b["target"] == "NopeTarget" for b in issues["broken_links"])

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-pwa",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-pwa",
-      "version": "0.4.26",
+      "version": "0.4.27",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
         "dompurify": "^3.4.11",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-pwa",
   "private": true,
-  "version": "0.4.26",
+  "version": "0.4.27",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -244,6 +244,19 @@ self.addEventListener('fetch', (event) => {
         }
         return response
       })
-      .catch(() => caches.match(event.request).then((cached) => cached || Response.error()))
+      .catch(async () => {
+        // SPA navigations (e.g. /chat/<id>) aren't cached under their own URL
+        // — only the app shell is. When the network is momentarily
+        // unavailable (server restart, flaky connection), fall back to the
+        // cached shell so client-side routing still loads the page, instead
+        // of returning a hard network error (blank/broken chat).
+        if (event.request.mode === 'navigate') {
+          const shell =
+            (await caches.match('/index.html')) || (await caches.match('/'))
+          if (shell) return shell
+        }
+        const cached = await caches.match(event.request)
+        return cached || Response.error()
+      })
   )
 })

--- a/web/src/components/ChatLayout.vue
+++ b/web/src/components/ChatLayout.vue
@@ -37,7 +37,7 @@
             @close="closeProject"
             @open-sidebar="sidebarCollapsed = false"
           />
-          <ChatPanel v-else-if="store.activeChat" @close="closeChat" @open-sidebar="sidebarCollapsed = false" />
+          <ChatPanel v-else-if="store.activeChat" :key="store.activeChat.chat_id" @close="closeChat" @open-sidebar="sidebarCollapsed = false" />
           <div v-else-if="!store.bootstrapped" class="empty-shell home-boot" aria-busy="true">
             <PaneHeader title="ciaobot" @open-sidebar="sidebarCollapsed = false" />
           </div>
@@ -113,7 +113,7 @@
           @close="closeProject"
           @open-sidebar="sidebarCollapsed = false"
         />
-        <ChatPanel v-else-if="store.activeChat" @close="closeChat" @open-sidebar="sidebarCollapsed = false" />
+        <ChatPanel v-else-if="store.activeChat" :key="store.activeChat.chat_id" @close="closeChat" @open-sidebar="sidebarCollapsed = false" />
         <div v-else-if="!store.bootstrapped" class="empty-shell home-boot" aria-busy="true">
           <PaneHeader title="ciaobot" @open-sidebar="sidebarCollapsed = false" />
         </div>

--- a/web/src/components/ProjectSidebar.vue
+++ b/web/src/components/ProjectSidebar.vue
@@ -155,6 +155,11 @@
               >
                 <span class="schedule-time">{{ l.running ? `${l.interval_minutes}m` : 'off' }}</span>
                 <span class="schedule-label">{{ l.title || promptTitle(l.prompt) }}</span>
+                <span
+                  v-if="l.running && l.web_chat_id && store.isChatStreaming(l.web_chat_id)"
+                  class="spinner-dot"
+                  title="This loop is working"
+                />
               </router-link>
             </div>
           </div>
@@ -200,6 +205,11 @@
               >
                 <span class="schedule-time">{{ l.running ? `${l.interval_minutes}m` : 'off' }}</span>
                 <span class="schedule-label">{{ l.title || promptTitle(l.prompt) }}</span>
+                <span
+                  v-if="l.running && l.web_chat_id && store.isChatStreaming(l.web_chat_id)"
+                  class="spinner-dot"
+                  title="This loop is working"
+                />
               </router-link>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Release Ciaobot v0.4.27 to `main`
- Update package, PWA, and package-lock versions
- Add changelog notes for the release range

## Release notes
## v0.4.27 - 2026-07-15

### Added
- feat(web): pulse the active-work dot on a running loop (`a7c1eff`)

### Changed
- Merge pull request #128 from raffaelefarinaro/chore/sync-develop-v0.4.26 (`ead9055`)

### Fixed
- fix(pwa): service worker falls back to the app shell on navigation (`5c83cb3`)
- fix(web): remount the chat view when switching chats (`ecfcee7`)

## Testing
- pytest tests/
- cd web && npm run test
- cd web && npm run build
- ciao package-smoke --skip-frontend

## After approval
- Merge this PR into `main`
- GitHub Actions will create tag `v0.4.27`, publish the GitHub release, and sync `develop`
