### PR TITLE
fix(settings): show model tier on Chat titles row under Automatic

### DIFF
--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -341,10 +341,10 @@
                   <option v-if="routineProviderValue('title_model') === 'custom'" value="custom">Custom model</option>
                 </select>
                 <select
-                  v-if="routineTierSelectable('title_model')"
+                  v-if="routineProviderValue('title_model') !== 'apple'"
                   class="routine-select routine-select--tier"
                   :value="routineTierValue('title_model')"
-                  :disabled="routinesSaving"
+                  :disabled="routinesSaving || !routineTierSelectable('title_model')"
                   @change="saveRoutineTier('title_model', ($event.target as HTMLSelectElement).value)"
                 >
                   <option v-for="tier in modelTiers" :key="`title-${tier.key}`" :value="tier.key">


### PR DESCRIPTION
## What

Aligns the **Chat titles** routine row with the **Session insights** row so both show the model tier dropdown.

Previously the Chat titles row removed its tier dropdown entirely under the `Automatic` provider (`v-if="routineTierSelectable('title_model')"`), while Session insights kept it visible-but-disabled. Under Automatic the Chat titles row showed only "Automatic" with no indication of which tier was in use, even though the resolved model was displayed in the hint.

## Change

`web/src/components/SettingsView.vue` — the title-row tier `<select>`:
- `v-if` now renders whenever the provider is not `apple` (the "Local (free)" mode uses the single-control layout and has no tier concept), instead of only when selectable.
- `:disabled` gates on `!routineTierSelectable('title_model')`, matching the insights row.

## Result

Under **Automatic**, the Chat titles row now shows the implied tier (**Haiku** — `deepseek-v4-flash:cloud` infers to the haiku tier) as a disabled dropdown, alongside the existing "Automatic: <model>" hint. Real providers (Claude/OpenRouter/Ollama/Codex) remain enabled/selectable; "Local (free)"/apple still hides the tier.

## Verification

- `cd web && npm run build` passes.
- Behavior verified against the tier-resolution helpers: `routineTierValue('title_model')` returns `haiku` under Automatic.

Context: noticed while investigating why the Chat titles routine showed an error badge and no visible tier (that error was a transient Ollama Cloud backend failure, tracked separately in #143).