### PR TITLE
fix(web): stop duplicate user bubble from stranded optimistic send

### DIFF
--- a/ciao/web/static/index.html
+++ b/ciao/web/static/index.html
@@ -13,7 +13,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-180.png" />
     <title>Ciaobot</title>
-    <script type="module" crossorigin src="/assets/index-DyuE9sDl.js"></script>
+    <script type="module" crossorigin src="/assets/index-Cud34QgY.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-bEmbKxes.css">
   </head>
   <body>

--- a/web/src/stores/projects.test.ts
+++ b/web/src/stores/projects.test.ts
@@ -181,6 +181,87 @@ describe('queued message replay handling', () => {
   })
 })
 
+describe('optimistic user bubble reconciliation', () => {
+  test('reconciles a bubble stranded behind a prior turn instead of duplicating it', async () => {
+    // Repro: the user sends while the client thinks it is idle, so an
+    // optimistic bubble (no turn_index) is rendered. The server queues the
+    // send behind a still-running turn whose activity/assistant blocks stream
+    // on top, then records + echoes the turn later with a fresh turn_index.
+    // The echo must reconcile the stranded bubble, not push a second copy.
+    apiGet.mockResolvedValue([])
+    const store = useProjectStore()
+    const chatId = 'chat-strand'
+    store.messages[chatId] = [
+      { role: 'user', content: 'queued question', timestamp: '', turn_index: undefined },
+      { role: 'assistant', content: 'prior turn reply', timestamp: '' },
+    ]
+
+    store.connectWs(chatId)
+    fakeSockets[0].onmessage?.({
+      data: JSON.stringify({
+        type: 'user_echo',
+        text: 'queued question',
+        turn_index: 1,
+        sent_at: '2026-07-16T13:07:59Z',
+      }),
+    })
+
+    const userMsgs = store.messages[chatId].filter(
+      m => m.role === 'user' && m.content === 'queued question',
+    )
+    expect(userMsgs.length).toBe(1)
+    expect(userMsgs[0].turn_index).toBe(1)
+  })
+
+  test('upgrades an optimistic bubble in place when nothing streamed between send and echo', async () => {
+    apiGet.mockResolvedValue([])
+    const store = useProjectStore()
+    const chatId = 'chat-fast'
+    store.messages[chatId] = [
+      { role: 'assistant', content: 'earlier reply', timestamp: '' },
+      { role: 'user', content: 'hello', timestamp: '', turn_index: undefined },
+    ]
+
+    store.connectWs(chatId)
+    fakeSockets[0].onmessage?.({
+      data: JSON.stringify({ type: 'user_echo', text: 'hello', turn_index: 2 }),
+    })
+
+    const userMsgs = store.messages[chatId].filter(
+      m => m.role === 'user' && m.content === 'hello',
+    )
+    expect(userMsgs.length).toBe(1)
+    expect(userMsgs[0].turn_index).toBe(2)
+  })
+
+  test('loadMessages heals an orphaned optimistic bubble the live echo missed', async () => {
+    // Existing chats already carrying the duplicate must self-heal on reload:
+    // the server session holds the turn exactly once, so the shorter server
+    // history would otherwise be blocked by the never-shrink guard.
+    const store = useProjectStore()
+    const chatId = 'chat-heal'
+    store.messages[chatId] = [
+      { role: 'user', content: 'dup question', timestamp: '', turn_index: undefined },
+      { role: 'assistant', content: 'prior reply', timestamp: '' },
+      { role: 'user', content: 'dup question', timestamp: '2026-07-16T13:07:59Z', turn_index: 1 },
+      { role: 'assistant', content: 'answer', timestamp: '' },
+    ]
+    apiGet.mockResolvedValue([
+      { role: 'assistant', content: 'prior reply', sent_at: '' },
+      { role: 'user', content: 'dup question', sent_at: '2026-07-16T13:07:59Z', turn_index: 1 },
+      { role: 'assistant', content: 'answer', sent_at: '' },
+    ])
+
+    await store.loadMessages(chatId)
+
+    const userMsgs = store.messages[chatId].filter(
+      m => m.role === 'user' && m.content === 'dup question',
+    )
+    expect(userMsgs.length).toBe(1)
+    expect(userMsgs[0].turn_index).toBe(1)
+  })
+})
+
 describe('Codex structured questions', () => {
   test('answers a native request inside the active websocket turn', () => {
     const store = useProjectStore()

--- a/web/src/stores/projects.ts
+++ b/web/src/stores/projects.ts
@@ -177,6 +177,37 @@ export const useProjectStore = defineStore('projects', () => {
   }
   const activeQuestions = ref<Record<string, ActiveQuestion[]>>({})
 
+  // Signatures of AskUserQuestion pickers the user has already answered or
+  // dismissed this session, keyed by chat. Clearing `activeQuestions` on send
+  // is only client-side and optimistic; the server clears the persisted
+  // `pending_question` a beat later (native accept, or the next turn). Any
+  // `/api/chats` poll or WS reconnect in that window (`reconcileChatList`
+  // overwrites `chats.value` with the server snapshot, then `loadMessages` runs
+  // `rebuildPendingQuestion`) would otherwise resurrect the answered picker —
+  // and because `rebuildPendingQuestion` bails when a picker is already live, a
+  // later clean snapshot never removes it, so the card sticks. Remembering the
+  // resolved signature lets `rebuildPendingQuestion` refuse the stale rebuild.
+  const resolvedQuestions = ref<Record<string, Set<string>>>({})
+
+  // Stable identity for a picker, computable identically from the live
+  // `activeQuestions` entry (at resolve time) and from a rebuilt `pending_question`
+  // (at rebuild time). Native providers (Codex) carry a `requestId`; Claude's
+  // picker has none, so fall back to the question content.
+  function questionsSignature(qs: ActiveQuestion[] | undefined): string {
+    if (!qs || !qs.length) return ''
+    const rid = qs[0]?.requestId
+    if (rid) return `rid:${rid}`
+    return `q:${qs.map(q => `${q.id}${q.question}`).join('')}`
+  }
+
+  // Record the currently-active picker for `chatId` as resolved. Reads the live
+  // `activeQuestions` entry, so it must run before that entry is deleted.
+  function markResolvedQuestion(chatId: string) {
+    const sig = questionsSignature(activeQuestions.value[chatId])
+    if (!sig) return
+    ;(resolvedQuestions.value[chatId] ||= new Set<string>()).add(sig)
+  }
+
   // Parse the AskUserQuestion tool_input JSON (`{"questions": [...]}`) into the
   // picker's shape. Shared by the live `tool_use` handler and the reload-time
   // rebuild from a chat's persisted `pending_question`. Returns [] on anything
@@ -220,7 +251,11 @@ export const useProjectStore = defineStore('projects', () => {
     if (activeQuestions.value[chatId]?.length) return
     const chat = chats.value.find(c => c.chat_id === chatId)
     const qs = parseQuestions(chat?.pending_question)
-    if (qs.length) activeQuestions.value[chatId] = qs
+    if (!qs.length) return
+    // Don't resurrect a picker the user already answered/dismissed from a
+    // server snapshot that hasn't caught up yet.
+    if (resolvedQuestions.value[chatId]?.has(questionsSignature(qs))) return
+    activeQuestions.value[chatId] = qs
   }
   // Per-chat map from a Task/Agent dispatch's tool_use_id to a short subagent
   // label like "[Explore]". Populated when we see the parent's Task tool_use,
@@ -873,6 +908,9 @@ export const useProjectStore = defineStore('projects', () => {
     for (const key of Object.keys(messages.value)) {
       if (!validIds.has(key)) delete messages.value[key]
     }
+    for (const key of Object.keys(resolvedQuestions.value)) {
+      if (!validIds.has(key)) delete resolvedQuestions.value[key]
+    }
     persistMessages()
 
     // Reconcile overlay: drop entries for deleted chats, and for chats that
@@ -1349,7 +1387,24 @@ export const useProjectStore = defineStore('projects', () => {
         tool: m.tool,
         phase: m.phase,
       })))
-      const normalizedLocal = normalizeMessages(messages.value[chatId] || [])
+      let normalizedLocal = normalizeMessages(messages.value[chatId] || [])
+
+      // Heal orphaned optimistic user bubbles. A send queued behind a still
+      // streaming turn can leave a turn_index-less copy that the live echo
+      // failed to reconcile (see the user_echo handler). The SDK session is
+      // authoritative and holds each turn exactly once, so drop any local
+      // null-turn_index user bubble whose text already appears as a server
+      // user turn before comparing lengths — otherwise the "never shrink
+      // history" guard below would preserve the duplicate forever.
+      const serverUserContent = new Set(
+        normalizedServer.filter(m => m.role === 'user').map(m => m.content),
+      )
+      if (serverUserContent.size) {
+        const pruned = normalizedLocal.filter(
+          m => !(m.role === 'user' && m.turn_index == null && serverUserContent.has(m.content)),
+        )
+        if (pruned.length !== normalizedLocal.length) normalizedLocal = pruned
+      }
 
       if (historySignature(normalizedServer) !== historySignature(normalizedLocal)) {
         // Guard: never replace a longer local history with a shorter server
@@ -2024,6 +2079,7 @@ export const useProjectStore = defineStore('projects', () => {
     // pending_question too, so a loadMessages racing this send (WS reconnect,
     // reconciliation) doesn't rebuild the picker from a now-stale value.
     if (activeQuestions.value[chatId]) {
+      markResolvedQuestion(chatId)
       delete activeQuestions.value[chatId]
     }
     const answeredChat = chats.value.find(c => c.chat_id === chatId)
@@ -2181,6 +2237,7 @@ export const useProjectStore = defineStore('projects', () => {
     requestId: string,
     answers: Record<string, string[]>,
   ) {
+    markResolvedQuestion(chatId)
     delete activeQuestions.value[chatId]
     const chat = chats.value.find(c => c.chat_id === chatId)
     if (chat?.pending_question) chat.pending_question = ''
@@ -2563,19 +2620,37 @@ export const useProjectStore = defineStore('projects', () => {
             break
           }
           // Look for an optimistic user message with matching content but no
-          // assigned turn_index yet — upgrade it in place instead of pushing
-          // a duplicate.
+          // assigned turn_index yet — reconcile it instead of pushing a
+          // duplicate. A hydrated or already-echoed bubble always carries a
+          // turn_index, so a user entry with turn_index == null is necessarily
+          // an un-reconciled optimistic bubble we rendered at send time; that
+          // invariant lets us scan the whole tail safely.
+          //
+          // Two shapes:
+          //  - Fast path: the optimistic bubble is still the last thing in the
+          //    tail (nothing streamed between send and echo). Upgrade it in
+          //    place.
+          //  - Stranded: the send was queued server-side behind a still-running
+          //    turn, so that turn's assistant/activity blocks rendered before
+          //    the echo arrived. The optimistic bubble now sits *above* those
+          //    blocks. Drop the stale copy and fall through to push a fresh
+          //    bubble at the tail, matching the server's turn order. The old
+          //    "stop at the first assistant message" scan bailed here and left
+          //    the bubble orphaned, rendering the turn twice.
           let upgraded = false
+          let sawAssistant = false
           for (let i = msgs.length - 1; i >= 0; i--) {
             const m = msgs[i]
             if (m.role === 'user' && m.turn_index == null && m.content === trimmed) {
+              if (sawAssistant) {
+                msgs.splice(i, 1)
+                break
+              }
               m.turn_index = turnIndex
               upgraded = true
               break
             }
-            // Don't walk past the boundary of this turn — an assistant reply
-            // ends the previous turn, so we only scan back through the tail.
-            if (m.role === 'assistant') break
+            if (m.role === 'assistant') sawAssistant = true
           }
           if (upgraded) {
             if (queuedMessages.value[chatId]?.length) clearQueued(chatId)
@@ -2675,6 +2750,10 @@ export const useProjectStore = defineStore('projects', () => {
         if (event.tool_name === 'AskUserQuestion' && event.tool_input) {
           const qs = parseQuestions(event.tool_input, event.request_id || '')
           if (qs.length) {
+            // A fresh live question supersedes any earlier resolved-picker
+            // memory for this chat (keeps the set from growing and avoids a
+            // reused native request id being wrongly suppressed).
+            delete resolvedQuestions.value[chatId]
             activeQuestions.value[chatId] = qs
             // Nudge the user when the tab is backgrounded so they don't
             // miss a question that the model needs answered.
@@ -3002,7 +3081,7 @@ export const useProjectStore = defineStore('projects', () => {
     setChatRetry, stopChatRetry, tryChatRetryNow,
     switchChat, switchWorkspace, openChatFromDeepLink,
     syncLatest,
-    sendMessage, stopChat, respondPermission, respondQuestion, transcribeVoice, speakMessage, uploadImages, uploadImageRefs, removePendingImage, clearPendingImages,
+    sendMessage, stopChat, respondPermission, respondQuestion, markResolvedQuestion, transcribeVoice, speakMessage, uploadImages, uploadImageRefs, removePendingImage, clearPendingImages,
     addPendingComment, removePendingComment, clearPendingComments,
     addPendingChatComment, removePendingChatComment, clearPendingChatComments, updatePendingChatComment,
     addPendingChatCommentImage, removePendingChatCommentImage,


### PR DESCRIPTION
## Problem

A single user message could render **twice** in the chat transcript — sent once, but shown at (e.g.) 15:02 and again at 15:07 with a fresh "Thinking…" turn after the second copy. Inspecting the SDK session for an affected chat confirmed the turn was recorded **exactly once** (at the later timestamp), so this is a pure frontend rendering bug, not a backend re-submit.

## Root cause

1. When the client believes it is idle, a send renders an optimistic user bubble with `turn_index == null`.
2. The server queues that send behind a still-running turn. That turn's assistant/activity blocks stream on top before the send is recorded and echoed back with a fresh `turn_index`.
3. The `user_echo` reconciliation scanned back only until the first assistant message (`projects.ts`), so it never found the stranded optimistic bubble and pushed a **second** copy.
4. `loadMessages` then froze the duplicate: the server history (one turn) was shorter than local (two bubbles), so the never-shrink-history guard preserved the stale copy on every reload.

## Fix (frontend-only, `web/src/stores/projects.ts`)

- **`user_echo`**: a `turn_index == null` user entry is provably an un-reconciled optimistic bubble, so scan the whole tail. If it is stranded behind streamed content, drop the stale copy and let the echo land in server order; otherwise upgrade in place as before.
- **`loadMessages`**: prune local `turn_index == null` user bubbles whose text already exists as a server user turn before the length comparison, so **already-duplicated chats self-heal on reload**.

## Tests

Added 3 cases to `projects.test.ts` (stranded reconciliation, fast-path in-place upgrade, reload heal). All pass; full store suite green. `npm run build` passes (rebuilt `index.html` included).
