### PR TITLE
perf(menubar): poll tray status every 2s instead of 10s

### DIFF
--- a/ciao/menubar.py
+++ b/ciao/menubar.py
@@ -35,7 +35,7 @@ from ciao.package_version import _github_repo, make_cached_package_status, updat
 SERVER_LAUNCHD_LABEL = "com.ciao.server"
 MENUBAR_LAUNCHD_LABEL = "com.ciao.menubar"
 LAUNCHD_LABELS = (SERVER_LAUNCHD_LABEL, MENUBAR_LAUNCHD_LABEL)
-POLL_SECONDS = 10.0
+POLL_SECONDS = 2.0
 
 # Spinning-head animation played while a chat is working. Frame count matches
 # the PNGs emitted by scripts/make_menubar_template_icons.py.


### PR DESCRIPTION
## What

Lower `POLL_SECONDS` in `ciao/menubar.py` from `10.0` to `2.0`.

## Why

The main tray refresh — badge count, unread/attention counts, fallback notifications, server-status and update checks — was on a 10s cadence, so those updates felt laggy. This drops it to 2s, matching `WORKING_POLL_SECONDS` (already 2s), which drives the "chat is working" spinner on a separate thread.

## Cost

Each tick is one `localhost` HTTP call to `/api/startup-status` plus a few workspace file reads, and the existing fingerprint diff still rebuilds the dropdown only when content changed (no added flicker). Negligible on a local machine.

## Notes

- Single-line change; no tests pin the constant.
- Takes effect when the menu bar app relaunches.