### PR TITLE
fix(oneshot): propagate upstream error detail + bounded retry (#143)

### DIFF
--- a/ciao/providers/oneshot.py
+++ b/ciao/providers/oneshot.py
@@ -23,6 +23,179 @@ from claude_agent_sdk import (
 logger = logging.getLogger(__name__)
 
 
+class OneShotError(RuntimeError):
+    """A one-shot model call failed with whatever detail was available.
+
+    ``detail`` carries the composed upstream error (status / subtype /
+    stop_reason / body) so callers -- the titler, ``job_runs`` -- can
+    surface it instead of a bare "One-shot query failed". ``transient``
+    marks failures worth retrying: empty-body / gateway errors from an
+    Anthropic-compatible backend (e.g. Ollama Cloud intermittently
+    returns contentless ``is_error`` results) succeed on a second try,
+    whereas auth / subscription / bad-model errors will fail again.
+    """
+
+    def __init__(
+        self, detail: str, *, status: int | None = None, transient: bool = False
+    ) -> None:
+        super().__init__(detail or "one-shot query failed")
+        self.detail = detail or "one-shot query failed"
+        self.status = status
+        self.transient = transient
+
+
+# HTTP statuses / message markers that mean "this will fail again" -- do not
+# retry these. Everything else (empty body, 5xx, unexpected EOF, timeouts on
+# the upstream copy) is treated as transient.
+_NON_TRANSIENT_STATUSES = frozenset({400, 401, 402, 403, 404, 405, 422})
+_NON_TRANSIENT_MARKERS = (
+    "authentication",
+    "unauthorized",
+    "invalid api key",
+    "invalid_api_key",
+    "x-api-key",
+    "subscription",
+    "credit balance",
+    "insufficient",
+    "quota",
+    "permission",
+    "forbidden",
+    "not found",
+    "issue with the selected model",
+    "invalid model",
+    "does not exist",
+    "unsupported",
+)
+
+
+def _result_error_detail(msg: ResultMessage) -> tuple[str, int | None]:
+    """Compose a human-readable detail string from an error ResultMessage.
+
+    Ollama Cloud's known failure mode is a contentless ``is_error`` result
+    (empty body, no status), so the parts are all best-effort and we fall
+    back to an explicit "empty error result" marker when nothing is set.
+    """
+    status = getattr(msg, "api_error_status", None)
+    parts: list[str] = []
+    subtype = getattr(msg, "subtype", None)
+    if subtype and subtype not in ("success", ""):
+        parts.append(f"subtype={subtype}")
+    if status:
+        parts.append(f"status={status}")
+    stop_reason = getattr(msg, "stop_reason", None)
+    if stop_reason:
+        parts.append(f"stop_reason={stop_reason}")
+    result = (getattr(msg, "result", None) or "").strip()
+    if result:
+        parts.append(result)
+    for err in getattr(msg, "errors", None) or []:
+        text = str(err).strip()
+        if text and text not in parts:
+            parts.append(text)
+    detail = "; ".join(parts) if parts else "empty error result (no status or body)"
+    return detail, status
+
+
+def _is_transient(detail: str, status: int | None) -> bool:
+    if status is not None and status in _NON_TRANSIENT_STATUSES:
+        return False
+    low = detail.lower()
+    if any(marker in low for marker in _NON_TRANSIENT_MARKERS):
+        return False
+    return True
+
+
+async def _run_claude_oneshot(
+    prompt: str,
+    *,
+    system_prompt: str,
+    model: str,
+    env: dict[str, str] | None,
+) -> str:
+    options = ClaudeAgentOptions(
+        model=model,
+        system_prompt=system_prompt,
+        setting_sources=[],
+        skills=[],
+        max_turns=1,
+        env=env or {},
+    )
+    parts: list[str] = []
+    agen = query(prompt=prompt, options=options)
+    try:
+        async for msg in agen:
+            if isinstance(msg, AssistantMessage):
+                if getattr(msg, "error", None):
+                    error_text = "".join(
+                        block.text for block in msg.content
+                        if isinstance(block, TextBlock)
+                    ).strip()
+                    detail = error_text or f"assistant error: {msg.error}"
+                    raise OneShotError(detail, transient=_is_transient(detail, None))
+                for block in msg.content:
+                    if isinstance(block, TextBlock):
+                        parts.append(block.text)
+            elif isinstance(msg, ResultMessage):
+                if msg.is_error:
+                    detail, status = _result_error_detail(msg)
+                    raise OneShotError(
+                        detail, status=status,
+                        transient=_is_transient(detail, status),
+                    )
+    finally:
+        # Close the SDK generator deterministically. When the loop
+        # raises (model error, subprocess exit 1) or wait_for cancels
+        # us on timeout, the generator is otherwise left for GC to
+        # close in a fire-and-forget task; the SDK's teardown then
+        # re-surfaces the ProcessError as a "Task exception was never
+        # retrieved" log entry. aclose() is a no-op on an exhausted
+        # generator, so the normal path is unaffected.
+        try:
+            await agen.aclose()
+        except Exception:  # noqa: BLE001
+            logger.debug("oneshot query generator cleanup raised; already handled")
+    return "".join(parts).strip()
+
+
+async def _run_codex_oneshot(
+    prompt: str,
+    *,
+    system_prompt: str,
+    model: str,
+    env: dict[str, str] | None,
+    cwd: Path | None,
+) -> str:
+    from ciao.models import AgentRequest, ResultEvent
+    from ciao.providers.codex import CodexProvider
+
+    codex = CodexProvider(
+        (cwd or Path.cwd()).resolve(),
+        developer_instructions=system_prompt,
+        ephemeral=True,
+    )
+    try:
+        async for event in codex.run_streaming(
+            AgentRequest(
+                prompt=prompt,
+                model=model,
+                mode="plan",
+                provider="codex",
+                extra_env=env or {},
+            ),
+            lambda _handle: None,
+        ):
+            if isinstance(event, ResultEvent):
+                if event.is_error:
+                    detail = (event.result or "").strip() or "codex one-shot failed"
+                    # Codex surfaces its own retriable errors internally; treat
+                    # a returned error as terminal here so we don't double-retry.
+                    raise OneShotError(detail, transient=False)
+                return event.result
+        return ""
+    finally:
+        await codex.disconnect()
+
+
 async def run_oneshot(
     prompt: str,
     *,
@@ -32,12 +205,21 @@ async def run_oneshot(
     timeout_s: float = 120.0,
     provider: str = "claude",
     cwd: Path | None = None,
+    max_retries: int = 1,
+    retry_backoff_s: float = 0.5,
 ) -> str:
     """Run a single-turn model call and return the assistant's text.
 
     Empty string is a valid return (the model had nothing to say); the
-    caller decides how to handle it. ``timeout_s`` wraps the whole call
-    via :func:`asyncio.wait_for`.
+    caller decides how to handle it. ``timeout_s`` wraps each attempt via
+    :func:`asyncio.wait_for`.
+
+    On a transient failure (an empty-body / ``is_error`` result, the known
+    Ollama Cloud gateway flake) the call is retried up to ``max_retries``
+    times with exponential backoff; non-transient failures (auth /
+    subscription / bad-model) and timeouts are raised immediately. On
+    failure an :class:`OneShotError` carrying the upstream ``detail`` is
+    raised so callers can log the real cause instead of a generic string.
     """
     # Chats can run with Claude Code's fast-mode suffix ("[1m]"), but the
     # one-shot API path rejects annotated model ids ("There's an issue with
@@ -45,79 +227,43 @@ async def run_oneshot(
     # need fast mode; use the base model.
     if model.endswith("[1m]"):
         model = model[: -len("[1m]")]
+
     if provider == "codex":
-        from ciao.models import AgentRequest, ResultEvent
-        from ciao.providers.codex import CodexProvider
-
-        codex = CodexProvider(
-            (cwd or Path.cwd()).resolve(),
-            developer_instructions=system_prompt,
-            ephemeral=True,
-        )
-
-        async def _collect_codex() -> str:
-            try:
-                async for event in codex.run_streaming(
-                    AgentRequest(
-                        prompt=prompt,
-                        model=model,
-                        mode="plan",
-                        provider="codex",
-                        extra_env=env or {},
-                    ),
-                    lambda _handle: None,
-                ):
-                    if isinstance(event, ResultEvent):
-                        if event.is_error:
-                            raise RuntimeError(event.result or "Codex one-shot failed")
-                        return event.result
-                return ""
-            finally:
-                await codex.disconnect()
-
-        return await asyncio.wait_for(_collect_codex(), timeout=timeout_s)
-    if provider != "claude":
+        async def _attempt() -> str:
+            return await _run_codex_oneshot(
+                prompt,
+                system_prompt=system_prompt,
+                model=model,
+                env=env,
+                cwd=cwd,
+            )
+    elif provider == "claude":
+        async def _attempt() -> str:
+            return await _run_claude_oneshot(
+                prompt,
+                system_prompt=system_prompt,
+                model=model,
+                env=env,
+            )
+    else:
         raise ValueError(f"Unknown one-shot provider '{provider}'")
 
-    options = ClaudeAgentOptions(
-        model=model,
-        system_prompt=system_prompt,
-        setting_sources=[],
-        skills=[],
-        max_turns=1,
-        env=env or {},
-    )
-
-    async def _collect() -> str:
-        parts: list[str] = []
-        agen = query(prompt=prompt, options=options)
+    attempts = max(0, int(max_retries)) + 1
+    last_exc: OneShotError | None = None
+    for attempt_no in range(attempts):
         try:
-            async for msg in agen:
-                if isinstance(msg, AssistantMessage):
-                    if getattr(msg, "error", None):
-                        error_text = "".join(
-                            block.text for block in msg.content
-                            if isinstance(block, TextBlock)
-                        ).strip()
-                        raise RuntimeError(error_text or f"Assistant error: {msg.error}")
-                    for block in msg.content:
-                        if isinstance(block, TextBlock):
-                            parts.append(block.text)
-                elif isinstance(msg, ResultMessage):
-                    if msg.is_error:
-                        raise RuntimeError(msg.result or "One-shot query failed")
-        finally:
-            # Close the SDK generator deterministically. When the loop
-            # raises (model error, subprocess exit 1) or wait_for cancels
-            # us on timeout, the generator is otherwise left for GC to
-            # close in a fire-and-forget task; the SDK's teardown then
-            # re-surfaces the ProcessError as a "Task exception was never
-            # retrieved" log entry. aclose() is a no-op on an exhausted
-            # generator, so the normal path is unaffected.
-            try:
-                await agen.aclose()
-            except Exception:  # noqa: BLE001
-                logger.debug("oneshot query generator cleanup raised; already handled")
-        return "".join(parts).strip()
-
-    return await asyncio.wait_for(_collect(), timeout=timeout_s)
+            return await asyncio.wait_for(_attempt(), timeout=timeout_s)
+        except OneShotError as exc:
+            last_exc = exc
+            if not exc.transient or attempt_no >= attempts - 1:
+                raise
+            delay = retry_backoff_s * (2 ** attempt_no)
+            logger.info(
+                "one-shot %s (model=%s) attempt %d/%d failed transiently (%s); "
+                "retrying in %.1fs",
+                provider, model, attempt_no + 1, attempts, exc.detail, delay,
+            )
+            await asyncio.sleep(delay)
+    # Loop only exits via return or raise; this satisfies type-checkers.
+    assert last_exc is not None
+    raise last_exc

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -429,7 +429,7 @@ async def _generate_chat_title(
     provider: str = "claude",
 ) -> str | None:
     """Back-compat wrapper around :func:`_generate_chat_title_with_engine`."""
-    title, _engine = await _generate_chat_title_with_engine(
+    title, _engine, _detail = await _generate_chat_title_with_engine(
         user_text,
         assistant_text,
         model=model,
@@ -450,7 +450,7 @@ async def _generate_chat_title_with_engine(
     env: dict[str, str] | None = None,
     timeout_s: float = 15.0,
     provider: str = "claude",
-) -> tuple[str | None, str]:
+) -> tuple[str | None, str, str | None]:
     """Summarize the first user message into a short chat title.
 
     Prefers the local Apple Intelligence CLI (`apfel`) when available,
@@ -463,23 +463,25 @@ async def _generate_chat_title_with_engine(
     Falls back to a deterministic truncation when both paths fail so the
     sidebar never gets stuck on "New Chat".
 
-    Returns ``(title, engine)`` where engine names what actually produced
-    the title: ``"apfel"``, ``"<provider>:<model>"``, or ``"fallback"``
-    for the deterministic truncation (including reply-shaped model output
-    that _clean_title rejected).
+    Returns ``(title, engine, detail)`` where engine names what actually
+    produced the title: ``"apfel"``, ``"<provider>:<model>"``, or
+    ``"fallback"`` for the deterministic truncation (including reply-shaped
+    model output that _clean_title rejected). ``detail`` carries the
+    upstream error text when the engine failed outright (so ``job_runs``
+    can record the real cause instead of a generic string), else ``None``.
     """
     from ciao.providers.oneshot import run_oneshot
 
     user_snippet = (user_text or "").strip()[:1000]
     if not user_snippet:
-        return None, "fallback"
+        return None, "fallback", None
 
     # A bare "continue"/"ok"/"go on" as the first message gives the titler
     # nothing to summarize; asking a model to title it invites a
     # conversational reply that then sticks as the title. Skip straight to
     # the deterministic fallback (which just truncates the user text).
     if _is_contentless_prompt(user_snippet):
-        return _fallback_title(user_snippet), "fallback"
+        return _fallback_title(user_snippet), "fallback", None
 
     assistant_snippet = (assistant_text or "").strip()[:1000]
     if assistant_snippet:
@@ -516,7 +518,8 @@ async def _generate_chat_title_with_engine(
             if proc.returncode == 0:
                 text = stdout.decode().strip()
                 if text:
-                    return _titled(text, user_snippet, "apfel")
+                    title, engine = _titled(text, user_snippet, "apfel")
+                    return title, engine, None
             else:
                 logger.info(
                     "apfel title generation exited with %d: %s",
@@ -543,17 +546,23 @@ async def _generate_chat_title_with_engine(
             cwd=cwd,
         )
         if text:
-            return _titled(text, user_snippet, f"{provider}:{fallback_model}")
+            title, engine = _titled(text, user_snippet, f"{provider}:{fallback_model}")
+            return title, engine, None
     except Exception as exc:
+        # OneShotError carries a composed upstream detail (status / body /
+        # subtype); fall back to str(exc) for anything else. Surfacing it
+        # lets the titler / job_runs record the real cause instead of the
+        # opaque "One-shot query failed".
+        detail = (getattr(exc, "detail", None) or str(exc) or "").strip()
         logger.info(
             "Title generation via %s %s failed: %s",
             provider,
             fallback_model or "account default",
-            exc,
+            detail or exc,
         )
-        return _fallback_title(user_snippet), "fallback"
+        return _fallback_title(user_snippet), "fallback", (detail[:500] or None)
 
-    return _fallback_title(user_snippet), "fallback"
+    return _fallback_title(user_snippet), "fallback", None
 
 
 def _titled(raw: str, user_snippet: str, engine: str) -> tuple[str | None, str]:
@@ -5428,21 +5437,31 @@ class ProjectChatManager:
             # provider that needs an explicit dispatch hint here.
             if chat.provider == "codex" or codex_override:
                 title_kwargs["provider"] = "codex"
-            title, engine = await _generate_chat_title_with_engine(
+            title, engine, detail = await _generate_chat_title_with_engine(
                 user_text,
                 assistant_text,
                 **title_kwargs,
             )
             run.extra["engine"] = engine
+            if detail:
+                # Upstream failure text (status / body / subtype) — the
+                # "model vs. subscription vs. transient?" signal that was
+                # previously collapsed into a generic string.
+                run.extra["error_detail"] = detail
             if not title:
                 run.status = "error"
                 run.error = "title model returned no title (timeout/failure)"
                 return None
             if engine == "fallback":
                 # A title was set, but the selected engine did not produce
-                # it — surface the degradation instead of reporting ok.
+                # it — surface the degradation (with the upstream detail when
+                # available) instead of reporting ok.
                 run.status = "error"
-                run.error = "title engine failed; used deterministic fallback"
+                run.error = (
+                    f"title engine failed ({detail}); used deterministic fallback"
+                    if detail
+                    else "title engine failed; used deterministic fallback"
+                )
             elif title_model == "apfel" and engine != "apfel":
                 run.extra["note"] = f"apfel not installed; used {engine}"
 

--- a/tests/test_auto_title.py
+++ b/tests/test_auto_title.py
@@ -220,10 +220,12 @@ async def test_generate_title_skips_model_for_contentless_prompt(
         return "I don't have any prior context to continue from."
 
     monkeypatch.setattr("ciao.providers.oneshot.run_oneshot", spy_oneshot)
-    title, engine = await _generate_chat_title_with_engine("continue", model="haiku")
+    title, engine, detail = await _generate_chat_title_with_engine("continue", model="haiku")
     assert called is False
     assert engine == "fallback"
     assert title == "continue"
+    # A contentless prompt is skipped, not a failure — no upstream detail.
+    assert detail is None
 
 
 @pytest.mark.asyncio
@@ -236,27 +238,31 @@ async def test_generate_title_reports_engine(monkeypatch: pytest.MonkeyPatch) ->
         return "Wedding Task Planning"
 
     monkeypatch.setattr("ciao.providers.oneshot.run_oneshot", good_oneshot)
-    title, engine = await _generate_chat_title_with_engine(
+    title, engine, detail = await _generate_chat_title_with_engine(
         "Create google tasks for my wedding", model="haiku"
     )
-    assert (title, engine) == ("Wedding Task Planning", "claude:haiku")
+    assert (title, engine, detail) == ("Wedding Task Planning", "claude:haiku", None)
 
     async def reply_shaped_oneshot(*args, **kwargs):
         return "I'd be happy to help you create Google Tasks, but I need more info."
 
     monkeypatch.setattr("ciao.providers.oneshot.run_oneshot", reply_shaped_oneshot)
-    title, engine = await _generate_chat_title_with_engine(
+    title, engine, detail = await _generate_chat_title_with_engine(
         "Create google tasks for my wedding", model="haiku"
     )
     assert engine == "fallback"
     assert title == "Create google tasks for my wedding"
+    # Reply-shaped output is a soft fallback, not an upstream failure.
+    assert detail is None
 
     async def failing_oneshot(*args, **kwargs):
         raise RuntimeError("provider unavailable")
 
     monkeypatch.setattr("ciao.providers.oneshot.run_oneshot", failing_oneshot)
-    title, engine = await _generate_chat_title_with_engine(
+    title, engine, detail = await _generate_chat_title_with_engine(
         "Create google tasks for my wedding", model="haiku"
     )
     assert engine == "fallback"
     assert title == "Create google tasks for my wedding"
+    # A hard failure surfaces the upstream error text for job_runs.
+    assert detail == "provider unavailable"

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import pytest
 
+from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+
 import ciao.providers.oneshot as oneshot
 
 
@@ -11,6 +13,39 @@ def _fake_query(captured: dict):
         captured["prompt"] = prompt
         if False:  # pragma: no cover - make this an async generator
             yield None
+
+    return fake_query
+
+
+def _result(**kwargs) -> ResultMessage:
+    """Build a minimal ResultMessage; callers override the error fields."""
+    base = dict(
+        subtype="success",
+        duration_ms=10,
+        duration_api_ms=5,
+        is_error=False,
+        num_turns=1,
+        session_id="s",
+        result=None,
+    )
+    base.update(kwargs)
+    return ResultMessage(**base)
+
+
+def _text_result(text: str) -> AssistantMessage:
+    return AssistantMessage(content=[TextBlock(text=text)], model="haiku")
+
+
+def _script_query(scripts: list[list[object]], calls: list[int]):
+    """Return a fake ``query`` that yields the next scripted message list on
+    each call. ``calls`` records how many times query was invoked."""
+
+    async def fake_query(*, prompt: str, options):
+        idx = calls[0]
+        calls[0] += 1
+        messages = scripts[min(idx, len(scripts) - 1)]
+        for msg in messages:
+            yield msg
 
     return fake_query
 
@@ -33,3 +68,115 @@ async def test_run_oneshot_passes_plain_models_through(monkeypatch) -> None:
 
     await oneshot.run_oneshot("hello", system_prompt="sys", model="haiku")
     assert captured["model"] == "haiku"
+
+
+def test_result_error_detail_composes_available_fields() -> None:
+    msg = _result(
+        subtype="error_during_execution",
+        is_error=True,
+        api_error_status=502,
+        stop_reason="error",
+        result="upstream exploded",
+    )
+    detail, status = oneshot._result_error_detail(msg)
+    assert status == 502
+    assert "subtype=error_during_execution" in detail
+    assert "status=502" in detail
+    assert "stop_reason=error" in detail
+    assert "upstream exploded" in detail
+
+
+def test_result_error_detail_marks_empty_body() -> None:
+    # The Ollama Cloud flake: is_error with no status, body, or reason.
+    detail, status = oneshot._result_error_detail(
+        _result(subtype="", is_error=True)
+    )
+    assert status is None
+    assert "empty error result" in detail
+
+
+def test_is_transient_classification() -> None:
+    # Empty body / gateway flake -> retry.
+    assert oneshot._is_transient("empty error result (no status or body)", None)
+    assert oneshot._is_transient("status=502; unexpected EOF", 502)
+    # Auth / subscription / bad-model -> do not retry.
+    assert not oneshot._is_transient("authentication_error: invalid x-api-key", 401)
+    assert not oneshot._is_transient("credit balance too low", None)
+    assert not oneshot._is_transient(
+        "There's an issue with the selected model (apfel)", None
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_oneshot_raises_oneshot_error_with_detail(monkeypatch) -> None:
+    calls = [0]
+    err = _result(subtype="error", is_error=True, api_error_status=401,
+                  result="authentication_error")
+    monkeypatch.setattr(oneshot, "query", _script_query([[err]], calls))
+
+    with pytest.raises(oneshot.OneShotError) as excinfo:
+        await oneshot.run_oneshot("hi", system_prompt="s", model="haiku")
+    exc = excinfo.value
+    assert exc.status == 401
+    assert "authentication_error" in exc.detail
+    assert exc.transient is False
+    # Non-transient: only one attempt, no retry.
+    assert calls[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_run_oneshot_retries_transient_empty_body(monkeypatch) -> None:
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(oneshot.asyncio, "sleep", fake_sleep)
+
+    calls = [0]
+    # First attempt: contentless is_error (the Ollama Cloud flake).
+    # Retry: a real assistant answer.
+    scripts = [
+        [_result(subtype="error", is_error=True)],
+        [_text_result("Recovered Title"), _result(is_error=False)],
+    ]
+    monkeypatch.setattr(oneshot, "query", _script_query(scripts, calls))
+
+    out = await oneshot.run_oneshot(
+        "hi", system_prompt="s", model="haiku", retry_backoff_s=0.1
+    )
+    assert out == "Recovered Title"
+    assert calls[0] == 2  # one retry
+    assert sleeps == [0.1]  # backoff applied once
+
+
+@pytest.mark.asyncio
+async def test_run_oneshot_exhausts_retries_then_raises(monkeypatch) -> None:
+    async def fake_sleep(delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(oneshot.asyncio, "sleep", fake_sleep)
+
+    calls = [0]
+    scripts = [[_result(subtype="error", is_error=True)]]  # always empty-body error
+    monkeypatch.setattr(oneshot, "query", _script_query(scripts, calls))
+
+    with pytest.raises(oneshot.OneShotError) as excinfo:
+        await oneshot.run_oneshot(
+            "hi", system_prompt="s", model="haiku", max_retries=2
+        )
+    assert excinfo.value.transient is True
+    assert calls[0] == 3  # initial + 2 retries
+
+
+@pytest.mark.asyncio
+async def test_run_oneshot_no_retry_when_disabled(monkeypatch) -> None:
+    calls = [0]
+    scripts = [[_result(subtype="error", is_error=True)]]
+    monkeypatch.setattr(oneshot, "query", _script_query(scripts, calls))
+
+    with pytest.raises(oneshot.OneShotError):
+        await oneshot.run_oneshot(
+            "hi", system_prompt="s", model="haiku", max_retries=0
+        )
+    assert calls[0] == 1

--- a/tests/test_providers_ollama.py
+++ b/tests/test_providers_ollama.py
@@ -305,7 +305,7 @@ async def test_auto_title_uses_workspace_haiku_model(
     async def fake_generate(user, assistant, *, model, cwd, env=None, pi_settings=None, timeout_s=15.0):
         captured["model"] = model
         captured["env"] = env
-        return "ollama-titled", "test"
+        return "ollama-titled", "test", None
 
     monkeypatch.setattr(
         "ciao.web.project_chats._generate_chat_title_with_engine", fake_generate
@@ -805,7 +805,7 @@ async def test_auto_title_honours_title_model_override(
     async def fake_generate(user, assistant, *, model, cwd, env=None, pi_settings=None, timeout_s=15.0):
         captured["model"] = model
         captured["env"] = env
-        return "ok", "test"
+        return "ok", "test", None
 
     monkeypatch.setattr("ciao.web.project_chats._generate_chat_title_with_engine", fake_generate)
     await pcm.auto_title_if_default(chat.chat_id, "hi", "hello")
@@ -828,7 +828,7 @@ async def test_auto_title_uses_workspace_haiku_for_anthropic_bucket(
     async def fake_generate(user, assistant, *, model, cwd, env=None, pi_settings=None, timeout_s=15.0):
         captured["model"] = model
         captured["env"] = env
-        return "haiku-titled", "test"
+        return "haiku-titled", "test", None
 
     monkeypatch.setattr(
         "ciao.web.project_chats._generate_chat_title_with_engine", fake_generate
@@ -856,7 +856,7 @@ async def test_auto_title_falls_back_to_haiku_when_ollama_disabled(
     async def fake_generate(user, assistant, *, model, cwd, env=None, pi_settings=None, timeout_s=15.0):
         captured["model"] = model
         captured["env"] = env
-        return "haiku-titled", "test"
+        return "haiku-titled", "test", None
 
     monkeypatch.setattr(
         "ciao.web.project_chats._generate_chat_title_with_engine", fake_generate
@@ -884,7 +884,7 @@ async def test_auto_title_works_with_user_text_only(
     async def fake_generate(user, assistant, *, model, cwd, env=None, pi_settings=None, timeout_s=15.0):
         captured["user"] = user
         captured["assistant"] = assistant
-        return "early-titled", "test"
+        return "early-titled", "test", None
 
     monkeypatch.setattr(
         "ciao.web.project_chats._generate_chat_title_with_engine", fake_generate


### PR DESCRIPTION
Closes #143.

## Problem
Background one-shot model calls (chat title generation and other routines) route through `ciao/providers/oneshot.py` `run_oneshot()`. On an error `ResultMessage` with no message it raised the generic `RuntimeError("One-shot query failed")`, and the titler stored `title engine failed; used deterministic fallback`. When Ollama Cloud intermittently returns empty-body errors there was no status/body detail, so model vs. subscription vs. transient error were indistinguishable.

## Changes
- **Propagate upstream error detail** (`oneshot.py`): errors now raise a new `OneShotError` carrying a composed detail string built from the SDK `ResultMessage` fields (`subtype`, `api_error_status`, `stop_reason`, `result`, `errors`), or an explicit `empty error result (no status or body)` marker for the contentless Ollama Cloud case.
- **Bounded retry with backoff** (`oneshot.py`): transient failures (empty-body / 5xx / gateway flakes) are retried up to `max_retries` (default 1) with exponential backoff; each attempt is timeout-wrapped and logged. Non-transient failures (auth / subscription / bad-model, detected by HTTP status and message markers) and timeouts raise immediately — no wasted retries.
- **Surface detail through the titler / job_runs** (`ciao/web/project_chats.py`): `_generate_chat_title_with_engine` now returns `(title, engine, detail)`; the title job records the real upstream detail in `run.error` and `run.extra["error_detail"]` instead of the opaque generic string.
- **Tests**: `tests/test_oneshot.py` covers detail composition, transient classification, retry-then-success, retry exhaustion, and non-transient no-retry. `tests/test_auto_title.py` asserts the detail is surfaced on hard failure and `None` on soft fallbacks. Updated `tests/test_providers_ollama.py` fakes to the 3-tuple return.

## Deferred
Improvement #3 (alternate-model fallback on repeated empty-body failures) — skipped to keep the change low-risk; the bounded retry already handles the observed single-occurrence flake.

## Tests
`.venv/bin/python -m pytest tests/` → 1315 passed, 1 skipped.