### PR TITLE
fix(web): stop answered AskUserQuestion picker from sticking on screen

### DIFF
--- a/ciao/web/static/index.html
+++ b/ciao/web/static/index.html
@@ -13,7 +13,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-180.png" />
     <title>Ciaobot</title>
-    <script type="module" crossorigin src="/assets/index-DyuE9sDl.js"></script>
+    <script type="module" crossorigin src="/assets/index-BldSb9-Z.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-bEmbKxes.css">
   </head>
   <body>

--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -1239,7 +1239,12 @@ function dismissQuestions() {
   if (!id) return
   const requestId = activeQuestions.value[0]?.requestId || ''
   if (requestId) {
+    // respondQuestion records the resolution itself before clearing.
     store.respondQuestion(id, requestId, {})
+  } else {
+    // Claude picker has no round-trip; remember it as resolved so a stale
+    // server snapshot can't rebuild it after dismissal.
+    store.markResolvedQuestion(id)
   }
   delete store.activeQuestions[id]
   questionAnswers.value = {}

--- a/web/src/stores/projects.test.ts
+++ b/web/src/stores/projects.test.ts
@@ -233,6 +233,103 @@ describe('Codex structured questions', () => {
     }))
   })
 
+  test('does not resurrect an answered picker from a stale server snapshot', async () => {
+    apiGet.mockResolvedValue([])
+    const store = useProjectStore()
+    const chatId = 'codex-stale'
+    // The persisted payload carries the request id, exactly as the backend
+    // embeds it into pending_question for native providers.
+    const pending = JSON.stringify({
+      request_id: 'codex-1',
+      questions: [{
+        id: 'choice',
+        header: 'Choice',
+        question: 'Pick one',
+        isOther: false,
+        options: [{ label: 'A', description: 'first' }],
+      }],
+    })
+    store.chats = [{
+      chat_id: chatId,
+      project_id: 'p1',
+      title: 'Codex',
+      model: 'gpt-test',
+      provider: 'codex',
+      mode: 'auto',
+      session_id: 'thread-1',
+      created_at: '',
+      archived: false,
+      pending_question: pending,
+    }]
+    store.activeChatId = chatId
+    store.connectWs(chatId)
+    fakeSockets[0].onmessage?.({
+      data: JSON.stringify({
+        type: 'tool_use',
+        tool_name: 'AskUserQuestion',
+        request_id: 'codex-1',
+        tool_input: JSON.stringify({
+          questions: [{
+            id: 'choice',
+            header: 'Choice',
+            question: 'Pick one',
+            isOther: false,
+            options: [{ label: 'A', description: 'first' }],
+          }],
+        }),
+      }),
+    })
+    expect(store.activeQuestions[chatId]).toHaveLength(1)
+
+    store.respondQuestion(chatId, 'codex-1', { choice: ['A'] })
+    expect(store.activeQuestions[chatId]).toBeUndefined()
+
+    // A poll/reconnect races the server clear: the snapshot still carries the
+    // now-answered pending_question. loadMessages runs rebuildPendingQuestion,
+    // which must refuse to bring the picker back.
+    store.chats[0].pending_question = pending
+    await store.loadMessages(chatId)
+    expect(store.activeQuestions[chatId]).toBeUndefined()
+  })
+
+  test('rebuilds a genuinely new question after an earlier one was answered', async () => {
+    apiGet.mockResolvedValue([])
+    const store = useProjectStore()
+    const chatId = 'codex-next'
+    const mkPayload = (rid: string) => JSON.stringify({
+      request_id: rid,
+      questions: [{ id: 'choice', header: 'Choice', question: 'Pick one', options: [{ label: 'A' }] }],
+    })
+    store.chats = [{
+      chat_id: chatId,
+      project_id: 'p1',
+      title: 'Codex',
+      model: 'gpt-test',
+      provider: 'codex',
+      mode: 'auto',
+      session_id: 'thread-1',
+      created_at: '',
+      archived: false,
+    }]
+    store.activeChatId = chatId
+    store.connectWs(chatId)
+    fakeSockets[0].onmessage?.({
+      data: JSON.stringify({
+        type: 'tool_use',
+        tool_name: 'AskUserQuestion',
+        request_id: 'codex-1',
+        tool_input: mkPayload('codex-1'),
+      }),
+    })
+    store.respondQuestion(chatId, 'codex-1', { choice: ['A'] })
+    expect(store.activeQuestions[chatId]).toBeUndefined()
+
+    // A distinct later question (new request id) must still surface on rebuild.
+    store.chats[0].pending_question = mkPayload('codex-2')
+    await store.loadMessages(chatId)
+    expect(store.activeQuestions[chatId]?.[0]).toMatchObject({ requestId: 'codex-2' })
+  })
+
   test('chatNeedsInput reflects live and persisted AskUserQuestion state', () => {
     const store = useProjectStore()
     const chatId = 'question-chat'

--- a/web/src/stores/projects.ts
+++ b/web/src/stores/projects.ts
@@ -177,6 +177,37 @@ export const useProjectStore = defineStore('projects', () => {
   }
   const activeQuestions = ref<Record<string, ActiveQuestion[]>>({})
 
+  // Signatures of AskUserQuestion pickers the user has already answered or
+  // dismissed this session, keyed by chat. Clearing `activeQuestions` on send
+  // is only client-side and optimistic; the server clears the persisted
+  // `pending_question` a beat later (native accept, or the next turn). Any
+  // `/api/chats` poll or WS reconnect in that window (`reconcileChatList`
+  // overwrites `chats.value` with the server snapshot, then `loadMessages` runs
+  // `rebuildPendingQuestion`) would otherwise resurrect the answered picker —
+  // and because `rebuildPendingQuestion` bails when a picker is already live, a
+  // later clean snapshot never removes it, so the card sticks. Remembering the
+  // resolved signature lets `rebuildPendingQuestion` refuse the stale rebuild.
+  const resolvedQuestions = ref<Record<string, Set<string>>>({})
+
+  // Stable identity for a picker, computable identically from the live
+  // `activeQuestions` entry (at resolve time) and from a rebuilt `pending_question`
+  // (at rebuild time). Native providers (Codex) carry a `requestId`; Claude's
+  // picker has none, so fall back to the question content.
+  function questionsSignature(qs: ActiveQuestion[] | undefined): string {
+    if (!qs || !qs.length) return ''
+    const rid = qs[0]?.requestId
+    if (rid) return `rid:${rid}`
+    return `q:${qs.map(q => `${q.id}${q.question}`).join('')}`
+  }
+
+  // Record the currently-active picker for `chatId` as resolved. Reads the live
+  // `activeQuestions` entry, so it must run before that entry is deleted.
+  function markResolvedQuestion(chatId: string) {
+    const sig = questionsSignature(activeQuestions.value[chatId])
+    if (!sig) return
+    ;(resolvedQuestions.value[chatId] ||= new Set<string>()).add(sig)
+  }
+
   // Parse the AskUserQuestion tool_input JSON (`{"questions": [...]}`) into the
   // picker's shape. Shared by the live `tool_use` handler and the reload-time
   // rebuild from a chat's persisted `pending_question`. Returns [] on anything
@@ -220,7 +251,11 @@ export const useProjectStore = defineStore('projects', () => {
     if (activeQuestions.value[chatId]?.length) return
     const chat = chats.value.find(c => c.chat_id === chatId)
     const qs = parseQuestions(chat?.pending_question)
-    if (qs.length) activeQuestions.value[chatId] = qs
+    if (!qs.length) return
+    // Don't resurrect a picker the user already answered/dismissed from a
+    // server snapshot that hasn't caught up yet.
+    if (resolvedQuestions.value[chatId]?.has(questionsSignature(qs))) return
+    activeQuestions.value[chatId] = qs
   }
   // Per-chat map from a Task/Agent dispatch's tool_use_id to a short subagent
   // label like "[Explore]". Populated when we see the parent's Task tool_use,
@@ -872,6 +907,9 @@ export const useProjectStore = defineStore('projects', () => {
     const validIds = new Set(nextChats.map(ch => ch.chat_id))
     for (const key of Object.keys(messages.value)) {
       if (!validIds.has(key)) delete messages.value[key]
+    }
+    for (const key of Object.keys(resolvedQuestions.value)) {
+      if (!validIds.has(key)) delete resolvedQuestions.value[key]
     }
     persistMessages()
 
@@ -2024,6 +2062,7 @@ export const useProjectStore = defineStore('projects', () => {
     // pending_question too, so a loadMessages racing this send (WS reconnect,
     // reconciliation) doesn't rebuild the picker from a now-stale value.
     if (activeQuestions.value[chatId]) {
+      markResolvedQuestion(chatId)
       delete activeQuestions.value[chatId]
     }
     const answeredChat = chats.value.find(c => c.chat_id === chatId)
@@ -2181,6 +2220,7 @@ export const useProjectStore = defineStore('projects', () => {
     requestId: string,
     answers: Record<string, string[]>,
   ) {
+    markResolvedQuestion(chatId)
     delete activeQuestions.value[chatId]
     const chat = chats.value.find(c => c.chat_id === chatId)
     if (chat?.pending_question) chat.pending_question = ''
@@ -2675,6 +2715,10 @@ export const useProjectStore = defineStore('projects', () => {
         if (event.tool_name === 'AskUserQuestion' && event.tool_input) {
           const qs = parseQuestions(event.tool_input, event.request_id || '')
           if (qs.length) {
+            // A fresh live question supersedes any earlier resolved-picker
+            // memory for this chat (keeps the set from growing and avoids a
+            // reused native request id being wrongly suppressed).
+            delete resolvedQuestions.value[chatId]
             activeQuestions.value[chatId] = qs
             // Nudge the user when the tab is backgrounded so they don't
             // miss a question that the model needs answered.
@@ -3002,7 +3046,7 @@ export const useProjectStore = defineStore('projects', () => {
     setChatRetry, stopChatRetry, tryChatRetryNow,
     switchChat, switchWorkspace, openChatFromDeepLink,
     syncLatest,
-    sendMessage, stopChat, respondPermission, respondQuestion, transcribeVoice, speakMessage, uploadImages, uploadImageRefs, removePendingImage, clearPendingImages,
+    sendMessage, stopChat, respondPermission, respondQuestion, markResolvedQuestion, transcribeVoice, speakMessage, uploadImages, uploadImageRefs, removePendingImage, clearPendingImages,
     addPendingComment, removePendingComment, clearPendingComments,
     addPendingChatComment, removePendingChatComment, clearPendingChatComments, updatePendingChatComment,
     addPendingChatCommentImage, removePendingChatCommentImage,


### PR DESCRIPTION
## Problem

After sending an answer (or hitting Cancel) on a structured **AskUserQuestion** picker, the question cards stayed on screen while the assistant kept "thinking" — see the reported repro (Codex chat, two-question picker, "Send answer" clicked, cards remained).

## Root cause

Clearing `activeQuestions` on send is **client-side and optimistic**. The server clears the persisted `pending_question` a beat later (native accept in `respond_question`, or the next user turn). Any `/api/chats` poll (`syncLatest`, every 15s) or WS reconnect in that window runs:

`reconcileChatList` → `chats.value = <server snapshot>` (restores the stale `pending_question`) → `loadMessages` → `rebuildPendingQuestion` → re-adds the picker.

Worse, `rebuildPendingQuestion` early-returns when a picker is already live, so once resurrected, **no later clean snapshot ever removes it** — the card sticks. The rebuild path was purely additive with no "already answered" memory.

## Fix

Remember, per chat, a signature of pickers the user has already **answered or dismissed**, and have `rebuildPendingQuestion` refuse to resurrect one.

- The signature is computed **identically** from the live `activeQuestions` entry (at resolve time) and from a rebuilt `pending_question` (at rebuild time): the native `request_id` for Codex, the question content for Claude (no round-trip id).
- Marked from all resolution paths: `respondQuestion` (native), `sendMessage` (Claude/interrupt), and the Cancel/dismiss handler.
- A fresh live question clears the memory for that chat — bounds growth and avoids suppressing a reused native request id across sessions.
- Deleted chats are pruned in `reconcileChatList`.

## Tests

- New: an answered picker is **not** resurrected from a stale server snapshot on `loadMessages`.
- New: a genuinely new question (different `request_id`) **still** surfaces on rebuild.
- Full web suite green (`npx vitest run`), `npm run build` clean.

## Notes

Branched off `develop`. The `projects.ts` change was originally drafted while a concurrent job was committing in the shared checkout; this PR isolates only the AskUserQuestion fix.