### PR TITLE
fix(gws): require confirmation before GWS health re-authenticate push

### DIFF
--- a/ciao/gws_auth.py
+++ b/ciao/gws_auth.py
@@ -406,6 +406,17 @@ class GwsHealthMonitor:
         events_hub=None,
         runtime_root: Path | None = None,
         status_fn: Callable[..., dict[str, Any]] = auth_status,
+        # When ``auth status`` reports the token invalid (but the probe itself
+        # ran), re-probe once after this delay before believing it. A single
+        # ``token_valid: false`` reading can be a transient Google API hiccup
+        # (momentary 401/500/rate-limit) or a startup refresh race that
+        # recovers on its own; see issue #173.
+        retry_delay: float = 8.0,
+        # Only surface the "re-authenticate" notification after this many
+        # consecutive invalid readings across separate ``check_once`` runs,
+        # so one transient reading (even after the in-process retry) cannot
+        # false-alarm the user. Reset to 0 on the first valid reading.
+        notify_threshold: int = 2,
     ) -> None:
         self._config = config
         self._push = push_manager
@@ -416,6 +427,8 @@ class GwsHealthMonitor:
             else Path(config.state_path).parent
         )
         self._status_fn = status_fn
+        self._retry_delay = max(0.0, retry_delay)
+        self._notify_threshold = max(1, int(notify_threshold))
         self._lock = threading.Lock()
 
     def _cache_path(self) -> Path:
@@ -449,6 +462,13 @@ class GwsHealthMonitor:
 
         Serialized with a lock so overlapping periodic + on-demand runs cannot
         interleave their read-modify-write of the cache.
+
+        A single ``token_valid: false`` reading does not notify on its own.
+        The monitor first re-probes in-process (``retry_delay``) to ride out
+        transient Google API errors or startup refresh races, and then requires
+        ``notify_threshold`` consecutive invalid readings across separate runs
+        before alerting the user (issue #173). The counter and the
+        ``notified_invalid`` flag both reset on the first valid reading.
         """
         with self._lock:
             state = self._load()
@@ -464,21 +484,49 @@ class GwsHealthMonitor:
                     continue
                 token_valid = bool(status.get("token_valid"))
                 token_error = status.get("token_error", "")
+                if not token_valid:
+                    # Re-probe once: a single invalid reading may be a transient
+                    # false negative (momentary 401/500/rate-limit, or a startup
+                    # race where the first refresh fails and a later one
+                    # succeeds). Only treat the token as invalid if the retry
+                    # agrees. If the retry itself goes unavailable, treat the
+                    # whole probe as inconclusive and skip, like an
+                    # unavailable first probe.
+                    if self._retry_delay > 0:
+                        time.sleep(self._retry_delay)
+                    retry = self._status_fn(self._config, profile)
+                    if not retry.get("available"):
+                        continue
+                    if retry.get("token_valid"):
+                        token_valid = True
+                    else:
+                        # Prefer the most recent error text if non-empty.
+                        retry_error = retry.get("token_error", "")
+                        if retry_error:
+                            token_error = retry_error
+                consecutive_invalid = int(prior.get("consecutive_invalid", 0))
                 entry = {
                     "token_valid": token_valid,
                     "token_error": token_error,
                     "has_refresh_token": bool(status.get("has_refresh_token")),
                     "checked_at": time.time(),
                     "notified_invalid": bool(prior.get("notified_invalid")),
+                    "consecutive_invalid": consecutive_invalid,
                 }
                 if not token_valid:
                     summary["invalid"].append(profile)
-                    if not prior.get("notified_invalid"):
+                    consecutive_invalid += 1
+                    entry["consecutive_invalid"] = consecutive_invalid
+                    if (
+                        consecutive_invalid >= self._notify_threshold
+                        and not prior.get("notified_invalid")
+                    ):
                         self._notify(profile, token_error)
                         entry["notified_invalid"] = True
                         summary["notified"].append(profile)
                 else:
                     entry["notified_invalid"] = False
+                    entry["consecutive_invalid"] = 0
                 state[profile] = entry
             try:
                 self._save(state)
@@ -489,7 +537,7 @@ class GwsHealthMonitor:
     def _notify(self, profile: str, token_error: str) -> None:
         title = "Google Workspace login needs attention"
         body = (
-            f"The '{profile}' Google login has expired or been revoked. "
+            f"The '{profile}' Google login may have expired or been revoked. "
             "Re-authenticate in Settings → Integrations to restore Gmail, "
             "Calendar, Drive, and scheduled Google tasks."
         )

--- a/tests/test_gws_auth.py
+++ b/tests/test_gws_auth.py
@@ -244,35 +244,168 @@ def test_health_monitor_debounces_and_rearms(tmp_path: Path) -> None:
         events_hub=events,
         runtime_root=runtime,
         status_fn=lambda config, profile: state["value"],
+        retry_delay=0,  # skip the in-process backoff in tests
+        notify_threshold=2,
     )
 
-    # First invalid check → one notification for the affected profile.
+    # First invalid check → counted but not yet notified (needs 2 consecutive).
     s1 = monitor.check_once()
     assert s1["invalid"] == ["personal"]
-    assert s1["notified"] == ["personal"]
+    assert s1["notified"] == []
+    assert push.sent == []
+    cache = gws_auth.read_health_cache(runtime)
+    assert cache["personal"]["consecutive_invalid"] == 1
+    assert cache["personal"]["notified_invalid"] is False
+
+    # Second consecutive invalid → now notify.
+    s2 = monitor.check_once()
+    assert s2["notified"] == ["personal"]
     assert len(push.sent) == 1
     assert push.sent[0]["profile"] == "personal"
     assert "personal" in push.sent[0]["body"]
+    assert "may have expired or been revoked" in push.sent[0]["body"]
     assert len(events.published) == 1
     assert events.published[0]["type"] == "gws_health"
+    cache = gws_auth.read_health_cache(runtime)
+    assert cache["personal"]["consecutive_invalid"] == 2
+    assert cache["personal"]["notified_invalid"] is True
 
     # Still invalid → debounced, no new notification.
-    s2 = monitor.check_once()
-    assert s2["notified"] == []
+    s3 = monitor.check_once()
+    assert s3["notified"] == []
     assert len(push.sent) == 1
 
-    # Recovered → clears the alert (re-arms).
+    # Recovered → clears the alert (re-arms) and resets the counter.
     state["value"] = valid
     monitor.check_once()
     cache = gws_auth.read_health_cache(runtime)
     assert cache["personal"]["token_valid"] is True
     assert cache["personal"]["notified_invalid"] is False
+    assert cache["personal"]["consecutive_invalid"] == 0
 
-    # Breaks again → re-notifies.
+    # Breaks again → needs 2 consecutive again before re-notifying.
     state["value"] = invalid
     s4 = monitor.check_once()
-    assert s4["notified"] == ["personal"]
+    assert s4["notified"] == []
+    assert len(push.sent) == 1
+    s5 = monitor.check_once()
+    assert s5["notified"] == ["personal"]
     assert len(push.sent) == 2
+
+
+def test_health_monitor_in_process_retry_suppresses_transient_invalid(tmp_path: Path) -> None:
+    """A single transient token_valid=false that recovers on retry must not
+    advance the consecutive-failure counter or notify (issue #173)."""
+    cfg = _config(tmp_path)
+    config_dir = gws_auth.profile_config_dir(cfg, "personal")
+    config_dir.mkdir(parents=True)
+    (config_dir / "credentials.json").write_text("{}", encoding="utf-8")
+
+    calls: list[str] = []
+    valid = {"available": True, "token_valid": True, "token_error": "", "has_refresh_token": True}
+    invalid = {
+        "available": True,
+        "token_valid": False,
+        "token_error": "Token has been expired or revoked.",
+        "has_refresh_token": True,
+    }
+    seq = {"i": 0}
+
+    def status_fn(config, profile):
+        calls.append("call")
+        seq["i"] += 1
+        # First probe invalid, retry (same run) valid.
+        return invalid if seq["i"] == 1 else valid
+
+    push = _FakePush()
+    monitor = gws_auth.GwsHealthMonitor(
+        cfg,
+        push_manager=push,
+        runtime_root=tmp_path / ".runtime",
+        status_fn=status_fn,
+        retry_delay=0,
+        notify_threshold=2,
+    )
+    summary = monitor.check_once()
+    # The retry recovered, so the run reports a valid token and no notify.
+    assert summary["invalid"] == []
+    assert summary["notified"] == []
+    assert push.sent == []
+    cache = gws_auth.read_health_cache(tmp_path / ".runtime")
+    assert cache["personal"]["token_valid"] is True
+    assert cache["personal"]["consecutive_invalid"] == 0
+    # status_fn was invoked twice: initial probe + in-process retry.
+    assert len(calls) == 2
+
+
+def test_health_monitor_retry_unavailable_skips(tmp_path: Path) -> None:
+    """If the in-process retry itself becomes unavailable, treat the run as
+    inconclusive: leave prior state untouched (no counter bump, no notify)."""
+    cfg = _config(tmp_path)
+    config_dir = gws_auth.profile_config_dir(cfg, "personal")
+    config_dir.mkdir(parents=True)
+    (config_dir / "credentials.json").write_text("{}", encoding="utf-8")
+
+    invalid = {
+        "available": True,
+        "token_valid": False,
+        "token_error": "Token has been expired or revoked.",
+        "has_refresh_token": True,
+    }
+    unavailable = {"available": False, "reason": "gws missing"}
+    seq = {"i": 0}
+
+    def status_fn(config, profile):
+        seq["i"] += 1
+        return invalid if seq["i"] == 1 else unavailable
+
+    push = _FakePush()
+    monitor = gws_auth.GwsHealthMonitor(
+        cfg,
+        push_manager=push,
+        runtime_root=tmp_path / ".runtime",
+        status_fn=status_fn,
+        retry_delay=0,
+        notify_threshold=2,
+    )
+    summary = monitor.check_once()
+    assert summary["invalid"] == []
+    assert summary["notified"] == []
+    assert push.sent == []
+    # No state persisted for the profile on an inconclusive run.
+    assert gws_auth.read_health_cache(tmp_path / ".runtime") == {}
+
+
+def test_health_monitor_single_invalid_does_not_notify_with_default_threshold(
+    tmp_path: Path,
+) -> None:
+    """Default threshold (2) holds even when retry_delay is disabled: one
+    invalid run alone never fires a notification."""
+    cfg = _config(tmp_path)
+    config_dir = gws_auth.profile_config_dir(cfg, "personal")
+    config_dir.mkdir(parents=True)
+    (config_dir / "credentials.json").write_text("{}", encoding="utf-8")
+
+    invalid = {
+        "available": True,
+        "token_valid": False,
+        "token_error": "Token has been expired or revoked.",
+        "has_refresh_token": True,
+    }
+    push = _FakePush()
+    monitor = gws_auth.GwsHealthMonitor(
+        cfg,
+        push_manager=push,
+        runtime_root=tmp_path / ".runtime",
+        status_fn=lambda config, profile: invalid,
+        retry_delay=0,
+    )
+    s1 = monitor.check_once()
+    assert s1["invalid"] == ["personal"]
+    assert s1["notified"] == []
+    assert push.sent == []
+    cache = gws_auth.read_health_cache(tmp_path / ".runtime")
+    assert cache["personal"]["consecutive_invalid"] == 1
 
 
 def test_health_monitor_skips_unavailable(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #173.

## Problem

The GWS health monitor fired a user-facing "re-authenticate" push notification based on a single `token_valid: false` reading from `gws auth status`. When that reading was transient (observed at server startup, recovered ~90s later with no re-auth), the user still received a scary, actionable push ("...has expired or been revoked. Re-authenticate in Settings -> Integrations...") even though the token was fine.

The existing flaky-probe guard in `GwsHealthMonitor.check_once()` only covered `available=false` (subprocess-level failure). It did **not** cover the case where `gws auth status` runs successfully but returns `token_valid=false` due to a transient Google API error (momentary 401/500/rate-limit, or a startup race where the first refresh attempt fails and a later one succeeds).

## Fix

Combined confirmation approach in `ciao/gws_auth.py`:

1. **In-process retry** — when `auth_status` returns `available=true & token_valid=false`, re-probe once after a short backoff (default 8s, configurable via the new `retry_delay` constructor param). Only treat the token as invalid if the retry agrees. If the retry itself goes unavailable, treat the whole probe as inconclusive and skip (leave prior state untouched), mirroring the existing unavailable-first-probe behavior.
2. **Consecutive-failure counter** — persist `consecutive_invalid` in `.runtime/gws_health.json`; only call `_notify()` after `notify_threshold` (default 2) consecutive invalid readings across separate `check_once` runs. Reset to 0 on the first valid reading. `notified_invalid` semantics are unchanged (set on notify, cleared on recovery).
3. **Softer wording** — notification body now says "may have expired or been revoked" to acknowledge the remaining transience possibility.

## Cache compatibility

`consecutive_invalid` is added alongside existing keys. The writer already `sort_keys`, and the only route consumer (`_gws_profile_payload` in `routes_api.py`) reads `token_valid` / `token_error` only, so existing entries load without migration.

## Tests

`tests/test_gws_auth.py` (network never hit; `status_fn` is faked):
- 2-consecutive threshold + debounce + rearm, including the softened body wording.
- In-process retry suppresses a transient invalid (first probe invalid, retry valid -> no notify, counter stays 0, `status_fn` called twice).
- Unavailable retry skips the run as inconclusive (no state persisted, no notify).
- A single invalid run does not notify under the default threshold.

All 19 tests in `tests/test_gws_auth.py` pass. No docs updated (no layout, endpoint, env-var, or capability changes).

## Notes

- The default `retry_delay=8s` runs inside the monitor's existing lock, consistent with the existing 30s `auth status` subprocess timeout already held under the same lock. Both `retry_delay` and `notify_threshold` are constructor params for testability/tunability.
- Did not touch the running server or PWA build, per instructions. No `.env`/secrets touched.