### PR TITLE
fix(web): broadcast chat_archived over /ws/events for cross-tab sync

### DIFF
--- a/PWA_API.md
+++ b/PWA_API.md
@@ -489,7 +489,7 @@ Global `/ws/events` payloads the PWA reacts to:
 - `chat_subagents_ready`: emitted when a background `Agent` (run_in_background) finishes or its count drops. Fields: `{chat_id, project_id, remaining}`.
 - `chat_read`: another client/device marked the chat read.
 - `chat_title`: auto-title finished.
-- `chat_moved` / `chat_deleted`: project changes.
+- `chat_moved` / `chat_archived` / `chat_deleted`: project changes.
 - `server_restarting`: restart drain began (`{message}`). The connect `snapshot` also carries `restarting: true` when drain is already in progress so late clients show the overlay without waiting for a turn rejection.
 
 Per-chat `/ws/chat/{chat_id}` events include text/thinking deltas, `tool_use` (with optional `file_touch` and provider-native `request_id`), `permission_request`, `result`, `user_echo`, `queued`, `queue_state`, `steered`, `status`, `error`, and `server_restarting` (sent instead of `error` when a new turn is rejected because restart drain is in progress). Client messages include normal `message`, `stop`, `permission_response`, and `question_response`; Codex structured questions use `question_response {request_id, answers: {question_id: string[]}}` so the answer resolves inside the still-running app-server turn.

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -3221,6 +3221,12 @@ class ProjectChatManager:
                 chat.archive_path = str(result)
             self._append_subchats_to_transcript(result, chat_id)
         self._save()
+        self._events.publish({
+            "type": "chat_archived",
+            "chat_id": chat_id,
+            "project_id": chat.project_id,
+            "archive_path": chat.archive_path,
+        })
         if result is None:
             return None
         return ArchiveOutcome(

--- a/tests/test_project_chat_moves.py
+++ b/tests/test_project_chat_moves.py
@@ -281,3 +281,17 @@ def test_delete_chat_publishes_event(tmp_path: Path) -> None:
     assert len(deleted) == 1
     assert deleted[0]["chat_id"] == chat.chat_id
     assert deleted[0]["reason"] == "user"
+
+
+def test_archive_chat_publishes_event(tmp_path: Path) -> None:
+    pcm = _make_manager(tmp_path)
+    project = pcm.create_project("2026-q2-archive", workspace="work")
+    chat = pcm.create_chat(project.project_id)
+
+    cap = _EventCapture(pcm)
+    pcm.archive_chat(chat.chat_id)
+
+    archived = [e for e in cap.drain() if e.get("type") == "chat_archived"]
+    assert len(archived) == 1
+    assert archived[0]["chat_id"] == chat.chat_id
+    assert archived[0]["project_id"] == project.project_id

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -272,6 +272,7 @@ export type EventsWsMessage =
   | { type: 'chat_read'; chat_id: string; last_read_at: string }
   | { type: 'chat_title'; chat_id: string; title: string; status?: 'pending' | 'ready' }
   | { type: 'chat_moved'; chat_id: string; project_id: string; old_project_id: string }
+  | { type: 'chat_archived'; chat_id: string; project_id: string; archive_path?: string }
   | { type: 'chat_deleted'; chat_id: string; project_id: string; reason?: string }
   | { type: 'chat_retry'; chat_id: string; project_id: string; status: 'pending' | 'stopped' | ''; next_at?: string; last_error?: string; attempts?: number; interval_seconds?: number }
   | { type: 'project_created'; project: ProjectInfo }

--- a/web/src/stores/projects.test.ts
+++ b/web/src/stores/projects.test.ts
@@ -1104,6 +1104,27 @@ describe('deep-link chat navigation', () => {
     })
     expect(routerPush).toHaveBeenCalledWith('/chat/c2')
   })
+
+  test('chat_archived event over /ws/events marks chat archived and clears active chat', async () => {
+    const store = useProjectStore()
+    store.projects = [
+      { project_id: 'p1', name: 'Proj', workspace: 'personal', context: '', created_at: '', order: 0, vault_folder: '' },
+    ]
+    store.chats = [
+      { chat_id: 'c1', project_id: 'p1', title: 'Chat 1', model: '', provider: 'claude', mode: '', session_id: '', created_at: '', archived: false },
+    ]
+    store.activeChatId = 'c1'
+    store.connectEventsWs()
+    const sock = fakeSockets[fakeSockets.length - 1]
+
+    sock.onmessage?.({
+      data: JSON.stringify({ type: 'chat_archived', chat_id: 'c1', project_id: 'p1', archive_path: 'archive/c1.md' }),
+    })
+
+    expect(store.chats[0].archived).toBe(true)
+    expect(store.chats[0].archive_path).toBe('archive/c1.md')
+    expect(store.activeChatId).toBeNull()
+  })
 })
 
 describe('workspace and chat transitions', () => {

--- a/web/src/stores/projects.ts
+++ b/web/src/stores/projects.ts
@@ -2244,6 +2244,18 @@ export const useProjectStore = defineStore('projects', () => {
         }
         break
       }
+      case 'chat_archived': {
+        disconnectWs(msg.chat_id)
+        const chat = chats.value.find(c => c.chat_id === msg.chat_id)
+        if (chat) {
+          chat.archived = true
+          if (msg.archive_path) chat.archive_path = msg.archive_path
+        }
+        if (activeChatId.value === msg.chat_id) {
+          activeChatId.value = null
+        }
+        break
+      }
       case 'chat_deleted': {
         // Fires when the server prunes an empty chat (user created a "New
         // Chat" and never sent a message, then moved on) or when another


### PR DESCRIPTION
## What

Archiving a chat from one tab/device did not notify other tabs/devices that had the same chat open. They kept showing the chat as live and sendable, and a send from the stale tab ran against an archived chat, raising `ValueError: Cannot send messages to an archived chat`.

## Root cause

`archive_chat()` in `ciao/web/project_chats.py` set `archived=True` but published no event over `/ws/events`, and the global events handler (`web/src/stores/projects.ts::handleEventsMessage`) had no `chat_archived` case. So a stale tab's `chat.archived` never flipped and the composer (disabled on `chat.archived`) stayed enabled.

## Fix

Mirrors the existing cross-device sync for `chat_read` and `chat_moved`.

- **Backend** (`ciao/web/project_chats.py`): publish a `chat_archived` event from `archive_chat()` over the global events hub with `chat_id`, `project_id`, and `archive_path`, placed after `self._save()` so subscribers see the persisted state.
- **Frontend** (`web/src/stores/projects.ts`): handle `chat_archived` in `handleEventsMessage` by flipping `chat.archived = true`, storing `archive_path`, and clearing `activeChatId` when it is the active chat (mirroring local `archiveChat`). The composer on the stale tab then disables itself via the existing `chat.archived` binding in `ChatPanel.vue`.
- **Types/docs**: add the `chat_archived` variant to `EventsWsMessage` (`web/src/lib/types.ts`) and list it in `PWA_API.md`'s `/ws/events` payload table. No new route, so no agent-recipe entry needed.

## Tests

- `tests/test_project_chat_moves.py::test_archive_chat_publishes_event`: asserts `archive_chat()` publishes exactly one `chat_archived` event with the right `chat_id`/`project_id`.
- `web/src/stores/projects.test.ts`: asserts a `chat_archived` `/ws/events` message marks the chat archived, stores `archive_path`, and clears the active chat.

Backend: `uv run pytest tests/test_project_chat_moves.py` (16 passed). Frontend: `npx vitest run src/stores/projects.test.ts` (51 passed) and `npx vue-tsc --noEmit` clean.

The backend send-path guard (`raise ValueError("Cannot send messages to an archived chat")`) already exists in the source tree, so no change there.

Fixes #174