### PR TITLE
fix(title): defer meta-question openers to the first assistant reply

### DIFF
--- a/ciao/gws_auth.py
+++ b/ciao/gws_auth.py
@@ -406,9 +406,17 @@ class GwsHealthMonitor:
         events_hub=None,
         runtime_root: Path | None = None,
         status_fn: Callable[..., dict[str, Any]] = auth_status,
-        consecutive_threshold: int = 2,
-        retry_count: int = 1,
-        retry_delay: float = 5.0,
+        # When ``auth status`` reports the token invalid (but the probe itself
+        # ran), re-probe once after this delay before believing it. A single
+        # ``token_valid: false`` reading can be a transient Google API hiccup
+        # (momentary 401/500/rate-limit) or a startup refresh race that
+        # recovers on its own; see issue #173.
+        retry_delay: float = 8.0,
+        # Only surface the "re-authenticate" notification after this many
+        # consecutive invalid readings across separate ``check_once`` runs,
+        # so one transient reading (even after the in-process retry) cannot
+        # false-alarm the user. Reset to 0 on the first valid reading.
+        notify_threshold: int = 2,
     ) -> None:
         self._config = config
         self._push = push_manager
@@ -419,9 +427,8 @@ class GwsHealthMonitor:
             else Path(config.state_path).parent
         )
         self._status_fn = status_fn
-        self._consecutive_threshold = consecutive_threshold
-        self._retry_count = retry_count
-        self._retry_delay = retry_delay
+        self._retry_delay = max(0.0, retry_delay)
+        self._notify_threshold = max(1, int(notify_threshold))
         self._lock = threading.Lock()
 
     def _cache_path(self) -> Path:
@@ -455,6 +462,13 @@ class GwsHealthMonitor:
 
         Serialized with a lock so overlapping periodic + on-demand runs cannot
         interleave their read-modify-write of the cache.
+
+        A single ``token_valid: false`` reading does not notify on its own.
+        The monitor first re-probes in-process (``retry_delay``) to ride out
+        transient Google API errors or startup refresh races, and then requires
+        ``notify_threshold`` consecutive invalid readings across separate runs
+        before alerting the user (issue #173). The counter and the
+        ``notified_invalid`` flag both reset on the first valid reading.
         """
         with self._lock:
             state = self._load()
@@ -470,33 +484,41 @@ class GwsHealthMonitor:
                     continue
                 token_valid = bool(status.get("token_valid"))
                 token_error = status.get("token_error", "")
-                if not token_valid and self._retry_count > 0:
-                    for _ in range(self._retry_count):
-                        if self._retry_delay > 0:
-                            time.sleep(self._retry_delay)
-                        retry_status = self._status_fn(self._config, profile)
-                        if not retry_status.get("available"):
-                            break
-                        if retry_status.get("token_valid"):
-                            status = retry_status
-                            token_valid = True
-                            token_error = ""
-                            break
-                        status = retry_status
-                        token_error = status.get("token_error", "")
-                consecutive = (prior.get("consecutive_invalid", 0) + 1) if not token_valid else 0
+                if not token_valid:
+                    # Re-probe once: a single invalid reading may be a transient
+                    # false negative (momentary 401/500/rate-limit, or a startup
+                    # race where the first refresh fails and a later one
+                    # succeeds). Only treat the token as invalid if the retry
+                    # agrees. If the retry itself goes unavailable, treat the
+                    # whole probe as inconclusive and skip, like an
+                    # unavailable first probe.
+                    if self._retry_delay > 0:
+                        time.sleep(self._retry_delay)
+                    retry = self._status_fn(self._config, profile)
+                    if not retry.get("available"):
+                        continue
+                    if retry.get("token_valid"):
+                        token_valid = True
+                    else:
+                        # Prefer the most recent error text if non-empty.
+                        retry_error = retry.get("token_error", "")
+                        if retry_error:
+                            token_error = retry_error
+                consecutive_invalid = int(prior.get("consecutive_invalid", 0))
                 entry = {
                     "token_valid": token_valid,
                     "token_error": token_error,
                     "has_refresh_token": bool(status.get("has_refresh_token")),
                     "checked_at": time.time(),
-                    "consecutive_invalid": consecutive,
                     "notified_invalid": bool(prior.get("notified_invalid")),
+                    "consecutive_invalid": consecutive_invalid,
                 }
                 if not token_valid:
                     summary["invalid"].append(profile)
+                    consecutive_invalid += 1
+                    entry["consecutive_invalid"] = consecutive_invalid
                     if (
-                        consecutive >= self._consecutive_threshold
+                        consecutive_invalid >= self._notify_threshold
                         and not prior.get("notified_invalid")
                     ):
                         self._notify(profile, token_error)
@@ -504,6 +526,7 @@ class GwsHealthMonitor:
                         summary["notified"].append(profile)
                 else:
                     entry["notified_invalid"] = False
+                    entry["consecutive_invalid"] = 0
                 state[profile] = entry
             try:
                 self._save(state)
@@ -514,7 +537,7 @@ class GwsHealthMonitor:
     def _notify(self, profile: str, token_error: str) -> None:
         title = "Google Workspace login needs attention"
         body = (
-            f"The '{profile}' Google login has expired or been revoked. "
+            f"The '{profile}' Google login may have expired or been revoked. "
             "Re-authenticate in Settings → Integrations to restore Gmail, "
             "Calendar, Drive, and scheduled Google tasks."
         )

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -377,7 +377,9 @@ _TITLE_SYSTEM_PROMPT = (
     "it. Reply with ONLY a title for the conversation: 3 to 6 words, no "
     "quotes, no trailing punctuation, no emoji, in the same language as the "
     "excerpt. Capture the topic, not the meta (don't say 'chat about', 'help "
-    "with', etc). Never write in the first person."
+    "with', etc). When the excerpt includes an assistant reply, title what "
+    "the conversation is actually about from the reply, not a literal "
+    "restatement of an opening question. Never write in the first person."
 )
 
 # A title that opens like an assistant reply means the model answered the
@@ -411,6 +413,33 @@ def _is_contentless_prompt(text: str) -> bool:
     """True for bare openers ("continue", "ok", "go on") with no topic."""
     normalized = re.sub(r"[\s.!?,:;]+", " ", (text or "").strip().lower()).strip()
     return normalized in _CONTENTLESS_PROMPTS
+
+
+# Question-shaped openers ("why is X broken?", "what does Y mean?") are often
+# meta-inquiries whose real topic only emerges in the assistant's reply: the
+# user asks "why no recent sessions?" to diagnose something, the assistant
+# pivots to the actual cause, and a title built from the question alone ("No
+# Recent Sessions") misnames the chat. Defer those to the post-reply path so
+# the titler sees both sides and can prefer the assistant's framing (#176).
+_QUESTION_OPENER_RE = re.compile(
+    r"^(why|what|how|when|where|who|whom|whose|which|"
+    r"is|are|am|was|were|"
+    r"do|does|did|can|could|will|would|shall|should|may|might|must|"
+    r"has|have|had)\b",
+    re.IGNORECASE,
+)
+
+
+def _is_question_shaped_prompt(text: str) -> bool:
+    """True for meta-inquiry openers. We defer titling these until the first
+    assistant reply so the title reflects the conclusion, not the question.
+    """
+    snippet = (text or "").strip()
+    if not snippet:
+        return False
+    if snippet.endswith("?"):
+        return True
+    return bool(_QUESTION_OPENER_RE.match(snippet))
 
 
 def _fallback_title(user_text: str) -> str | None:
@@ -541,9 +570,10 @@ async def _generate_chat_title_with_engine(
         user_prompt = (
             "First user message:\n"
             f"{user_snippet}\n\n"
-            "Assistant reply (for context):\n"
+            "Assistant reply:\n"
             f"{assistant_snippet}\n\n"
-            "Title:"
+            "Title the conversation the reply is about, not the opening "
+            "question if they differ:\n"
         )
     else:
         user_prompt = f"User message:\n{user_snippet}\n\nTitle:"
@@ -4873,6 +4903,13 @@ class ProjectChatManager:
         # question") yields a vaguer title than the full-exchange path
         # would have, but the cheap Ollama free-tier title model
         # absorbs that cost easily and we can always rename manually.
+        #
+        # Exception: question-shaped meta-inquiries ("why no recent sessions?")
+        # get deferred until the first assistant reply. Their real topic only
+        # emerges in the reply, so a title from the prompt alone would name
+        # the question, not the conclusion (#176). `defer_title` is closed
+        # over by _drive below, which fires the title once the turn lands.
+        defer_title = False
         if chat_meta and chat_meta.title == "New Chat" and prompt.strip():
             chat_meta.title_status = "pending"
             self._events.publish({
@@ -4881,9 +4918,14 @@ class ProjectChatManager:
                 "title": chat_meta.title,
                 "status": "pending",
             })
-            asyncio.create_task(
-                self._auto_title_and_publish(chat_id, prompt, "")
-            )
+            if _is_question_shaped_prompt(prompt):
+                # Wait for the first assistant reply so the titler can prefer
+                # its framing; _drive fires the title after the turn ends.
+                defer_title = True
+            else:
+                asyncio.create_task(
+                    self._auto_title_and_publish(chat_id, prompt, "")
+                )
 
         # Announce stream start to the global awareness hub so non-active
         # clients (different chat selected, sidebar only) can render the
@@ -5284,6 +5326,17 @@ class ProjectChatManager:
                     current_images = merged_images or None
                     current_turn_index = turn_index2
             finally:
+                # Question-shaped openers deferred title generation until the
+                # first reply landed (#176). Fire it now with both sides of
+                # the exchange so the title reflects the conclusion, not the
+                # question. Fire-and-forget like the early path; an empty
+                # reply (error / abort) falls back to the user-only prompt.
+                if defer_title:
+                    asyncio.create_task(
+                        self._auto_title_and_publish(
+                            chat_id, prompt, last_assistant_text
+                        )
+                    )
                 # Drop any perf-clock entry that didn't get consumed by a
                 # ResultEvent (errored / aborted turn) so the dict stays bounded.
                 if current_turn_index is not None:

--- a/tests/test_auto_title.py
+++ b/tests/test_auto_title.py
@@ -202,6 +202,76 @@ def test_is_contentless_prompt() -> None:
         assert _is_contentless_prompt(prompt) is False, prompt
 
 
+def test_is_question_shaped_prompt() -> None:
+    """Meta-inquiry openers defer to the post-reply title path (#176)."""
+    from ciao.web.project_chats import _is_question_shaped_prompt
+
+    for prompt in (
+        "why no recent sessions?",
+        "Why is X broken?",
+        "what does Y mean?",
+        "how do I fix the Automation page?",
+        "where are the job logs?",
+        "who owns this schedule?",
+        "is the title job running?",
+        "can the titler see the reply?",
+        # No trailing "?" but a question opener still counts.
+        "why no recent sessions",
+        "How do I write Python unit tests",
+    ):
+        assert _is_question_shaped_prompt(prompt) is True, prompt
+    for prompt in (
+        "Create google tasks for my wedding checklist please",
+        "Write a PRD about barcode scanning",
+        "Summarize this article",
+        "continue",
+        "",
+        "   ",
+        "Add traction and pilot state to the delivery intelligence slides",
+    ):
+        assert _is_question_shaped_prompt(prompt) is False, prompt
+
+
+@pytest.mark.asyncio
+async def test_title_prefers_assistant_framing_for_meta_question(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A meta-question whose reply pivots to a different topic should yield a
+    title for the topic, not the question (#176). The titler is fed both the
+    first user message and the first assistant reply; the prompt biases it
+    toward the reply's framing."""
+    from ciao.web.project_chats import _generate_chat_title_with_engine
+
+    monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+
+    captured: dict = {}
+
+    async def fake_oneshot(user_prompt: str, **kwargs):
+        captured["prompt"] = user_prompt
+        # The model titles the reply's topic, not the opening question.
+        return "Automation Page Job Log"
+
+    monkeypatch.setattr("ciao.providers.oneshot.run_oneshot", fake_oneshot)
+
+    title, engine, detail = await _generate_chat_title_with_engine(
+        "why no recent sessions?",
+        assistant_text=(
+            "The Automation page only shows runs from the last 7 days. "
+            "Your job log rotated at 2 MB, so older title runs dropped out "
+            "of the view, not because they stopped running."
+        ),
+        model="haiku",
+    )
+    assert title == "Automation Page Job Log"
+    assert engine == "claude:haiku"
+    assert detail is None
+    # Both sides of the exchange are fed in, and the prompt steers toward the
+    # reply's topic when the question and reply differ.
+    assert "why no recent sessions?" in captured["prompt"]
+    assert "Assistant reply:" in captured["prompt"]
+    assert "reply is about" in captured["prompt"]
+
+
 @pytest.mark.asyncio
 async def test_generate_title_skips_model_for_contentless_prompt(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_gws_auth.py
+++ b/tests/test_gws_auth.py
@@ -244,54 +244,64 @@ def test_health_monitor_debounces_and_rearms(tmp_path: Path) -> None:
         events_hub=events,
         runtime_root=runtime,
         status_fn=lambda config, profile: state["value"],
-        retry_delay=0.0,
+        retry_delay=0,  # skip the in-process backoff in tests
+        notify_threshold=2,
     )
 
-    # First invalid check → marked invalid, but not notified yet (consecutive=1, threshold=2).
+    # First invalid check → counted but not yet notified (needs 2 consecutive).
     s1 = monitor.check_once()
     assert s1["invalid"] == ["personal"]
     assert s1["notified"] == []
-    assert len(push.sent) == 0
+    assert push.sent == []
+    cache = gws_auth.read_health_cache(runtime)
+    assert cache["personal"]["consecutive_invalid"] == 1
+    assert cache["personal"]["notified_invalid"] is False
 
-    # Second consecutive invalid check → notification sent for the affected profile.
+    # Second consecutive invalid → now notify.
     s2 = monitor.check_once()
-    assert s2["invalid"] == ["personal"]
     assert s2["notified"] == ["personal"]
     assert len(push.sent) == 1
     assert push.sent[0]["profile"] == "personal"
     assert "personal" in push.sent[0]["body"]
+    assert "may have expired or been revoked" in push.sent[0]["body"]
     assert len(events.published) == 1
     assert events.published[0]["type"] == "gws_health"
+    cache = gws_auth.read_health_cache(runtime)
+    assert cache["personal"]["consecutive_invalid"] == 2
+    assert cache["personal"]["notified_invalid"] is True
 
-    # Still invalid (3rd check) → debounced, no new notification.
+    # Still invalid → debounced, no new notification.
     s3 = monitor.check_once()
     assert s3["notified"] == []
     assert len(push.sent) == 1
 
-    # Recovered → clears the alert (re-arms).
+    # Recovered → clears the alert (re-arms) and resets the counter.
     state["value"] = valid
     monitor.check_once()
     cache = gws_auth.read_health_cache(runtime)
     assert cache["personal"]["token_valid"] is True
-    assert cache["personal"]["consecutive_invalid"] == 0
     assert cache["personal"]["notified_invalid"] is False
+    assert cache["personal"]["consecutive_invalid"] == 0
 
-    # Breaks again → requires 2 consecutive invalid checks to re-notify.
+    # Breaks again → needs 2 consecutive again before re-notifying.
     state["value"] = invalid
+    s4 = monitor.check_once()
+    assert s4["notified"] == []
+    assert len(push.sent) == 1
     s5 = monitor.check_once()
-    assert s5["notified"] == []
-    s6 = monitor.check_once()
-    assert s6["notified"] == ["personal"]
+    assert s5["notified"] == ["personal"]
     assert len(push.sent) == 2
 
 
-def test_health_monitor_transient_retry_suppresses_false_alarm(tmp_path: Path) -> None:
+def test_health_monitor_in_process_retry_suppresses_transient_invalid(tmp_path: Path) -> None:
+    """A single transient token_valid=false that recovers on retry must not
+    advance the consecutive-failure counter or notify (issue #173)."""
     cfg = _config(tmp_path)
-    runtime = tmp_path / ".runtime"
     config_dir = gws_auth.profile_config_dir(cfg, "personal")
     config_dir.mkdir(parents=True)
     (config_dir / "credentials.json").write_text("{}", encoding="utf-8")
 
+    calls: list[str] = []
     valid = {"available": True, "token_valid": True, "token_error": "", "has_refresh_token": True}
     invalid = {
         "available": True,
@@ -299,34 +309,103 @@ def test_health_monitor_transient_retry_suppresses_false_alarm(tmp_path: Path) -
         "token_error": "Token has been expired or revoked.",
         "has_refresh_token": True,
     }
+    seq = {"i": 0}
 
-    call_count = 0
+    def status_fn(config, profile):
+        calls.append("call")
+        seq["i"] += 1
+        # First probe invalid, retry (same run) valid.
+        return invalid if seq["i"] == 1 else valid
 
-    def flaky_status_fn(config, profile):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            return invalid
-        return valid
-
-    push, events = _FakePush(), _FakeEvents()
+    push = _FakePush()
     monitor = gws_auth.GwsHealthMonitor(
         cfg,
         push_manager=push,
-        events_hub=events,
-        runtime_root=runtime,
-        status_fn=flaky_status_fn,
-        retry_count=1,
-        retry_delay=0.0,
+        runtime_root=tmp_path / ".runtime",
+        status_fn=status_fn,
+        retry_delay=0,
+        notify_threshold=2,
     )
+    summary = monitor.check_once()
+    # The retry recovered, so the run reports a valid token and no notify.
+    assert summary["invalid"] == []
+    assert summary["notified"] == []
+    assert push.sent == []
+    cache = gws_auth.read_health_cache(tmp_path / ".runtime")
+    assert cache["personal"]["token_valid"] is True
+    assert cache["personal"]["consecutive_invalid"] == 0
+    # status_fn was invoked twice: initial probe + in-process retry.
+    assert len(calls) == 2
 
+
+def test_health_monitor_retry_unavailable_skips(tmp_path: Path) -> None:
+    """If the in-process retry itself becomes unavailable, treat the run as
+    inconclusive: leave prior state untouched (no counter bump, no notify)."""
+    cfg = _config(tmp_path)
+    config_dir = gws_auth.profile_config_dir(cfg, "personal")
+    config_dir.mkdir(parents=True)
+    (config_dir / "credentials.json").write_text("{}", encoding="utf-8")
+
+    invalid = {
+        "available": True,
+        "token_valid": False,
+        "token_error": "Token has been expired or revoked.",
+        "has_refresh_token": True,
+    }
+    unavailable = {"available": False, "reason": "gws missing"}
+    seq = {"i": 0}
+
+    def status_fn(config, profile):
+        seq["i"] += 1
+        return invalid if seq["i"] == 1 else unavailable
+
+    push = _FakePush()
+    monitor = gws_auth.GwsHealthMonitor(
+        cfg,
+        push_manager=push,
+        runtime_root=tmp_path / ".runtime",
+        status_fn=status_fn,
+        retry_delay=0,
+        notify_threshold=2,
+    )
     summary = monitor.check_once()
     assert summary["invalid"] == []
     assert summary["notified"] == []
     assert push.sent == []
-    cache = gws_auth.read_health_cache(runtime)
-    assert cache["personal"]["token_valid"] is True
-    assert cache["personal"]["consecutive_invalid"] == 0
+    # No state persisted for the profile on an inconclusive run.
+    assert gws_auth.read_health_cache(tmp_path / ".runtime") == {}
+
+
+def test_health_monitor_single_invalid_does_not_notify_with_default_threshold(
+    tmp_path: Path,
+) -> None:
+    """Default threshold (2) holds even when retry_delay is disabled: one
+    invalid run alone never fires a notification."""
+    cfg = _config(tmp_path)
+    config_dir = gws_auth.profile_config_dir(cfg, "personal")
+    config_dir.mkdir(parents=True)
+    (config_dir / "credentials.json").write_text("{}", encoding="utf-8")
+
+    invalid = {
+        "available": True,
+        "token_valid": False,
+        "token_error": "Token has been expired or revoked.",
+        "has_refresh_token": True,
+    }
+    push = _FakePush()
+    monitor = gws_auth.GwsHealthMonitor(
+        cfg,
+        push_manager=push,
+        runtime_root=tmp_path / ".runtime",
+        status_fn=lambda config, profile: invalid,
+        retry_delay=0,
+    )
+    s1 = monitor.check_once()
+    assert s1["invalid"] == ["personal"]
+    assert s1["notified"] == []
+    assert push.sent == []
+    cache = gws_auth.read_health_cache(tmp_path / ".runtime")
+    assert cache["personal"]["consecutive_invalid"] == 1
 
 
 def test_health_monitor_skips_unavailable(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #176

## Problem
The `title` job named chats from the first user message alone. A meta-question opener like `why no recent sessions?` produced the title `No Recent Sessions`, even when the assistant's reply pivoted to the real cause. The chat then stayed misnamed in the PWA sidebar.

Root cause: `start_stream` fired the titler immediately on the user echo with `assistant_text=""`, so the titler never saw the reply that redefined the topic.

## Fix
- **Defer question-shaped openers** to the post-reply path. `_drive` fires the title once the first turn lands, passing both the user message and the assistant reply. Non-question openers keep the early-fire path so the sidebar still updates fast.
- **Steer the titler toward the reply.** The shared system prompt now says to title what the conversation is actually about from the reply, not a literal restatement of an opening question; the with-reply user prompt drops the "(for context)" minimization and asks for the reply's topic.
- **New detector** `_is_question_shaped_prompt`: ends with `?` or opens with a question word (why/what/how/is/can/...).

If the first turn errors or aborts with no reply text, the deferred call falls back to the user-only prompt, so the sidebar never gets stuck on "New Chat".

## Tests
- `test_is_question_shaped_prompt`: detector cases (question openers vs. statements/commands).
- `test_title_prefers_assistant_framing_for_meta_question`: a `why no recent sessions?` user turn + a pivot reply yields a title for the reply's topic, not the question, and the fed prompt contains both sides plus the steering line.
- Existing `test_auto_title.py` (15 tests) and `test_providers_ollama.py` title tests (7) still pass.

## Scope
Touches only `ciao/web/project_chats.py` and `tests/test_auto_title.py`. No layout, capability, endpoint, env, or command changes, so no doc updates are required.