### PR TITLE
fix(providers): name host and error category on connection failures (#178)

### DIFF
--- a/ciao/providers/claude.py
+++ b/ciao/providers/claude.py
@@ -127,19 +127,16 @@ def _is_connection_drop_text(text: str) -> bool:
 
 
 # A name-resolution / connect failure surfaces from the Claude CLI as a generic
-# "API Error: Unable to connect to API (ENOTFOUND)" with no host, so an operator
-# reading a failed schedule can't tell which endpoint failed to resolve (the
-# Anthropic API, an OpenRouter/Ollama gateway, a custom ANTHROPIC_BASE_URL...).
-# We know the endpoint the turn was pointed at, so annotate the error with it.
-# See issue #162.
-_HOSTLESS_CONNECT_MARKERS = (
-    "unable to connect",
-    "enotfound",
-    "econnrefused",
-    "etimedout",
-    "getaddrinfo",
-    "name resolution",
-    "failed to fetch",
+# "API Error: Unable to connect to API (ENOTFOUND)" with no host and no error
+# category, so an operator reading a failed schedule can't tell which endpoint
+# failed to resolve (the Anthropic API, an OpenRouter/Ollama gateway, a custom
+# ANTHROPIC_BASE_URL...) or whether it was DNS, a refused connection, a timeout,
+# or auth. We know the endpoint the turn was pointed at, so annotate the error
+# with it and classify the failure. See issues #162 and #178. The annotation
+# helpers are shared with the Codex provider in ``ciao.providers.connect_errors``
+# so every provider a schedule can dispatch through surfaces the same context.
+from ciao.providers.connect_errors import (  # noqa: E402
+    annotate_connection_host as _annotate_connection_host,
 )
 
 
@@ -158,23 +155,6 @@ def _resolve_api_host(env: dict[str, str]) -> str:
         return urlsplit(base).hostname or ""
     except ValueError:
         return ""
-
-
-def _annotate_connection_host(text: str, host: str) -> str:
-    """Append ``host`` to a hostless connection-error result string.
-
-    No-op unless the text reads as a DNS/connect failure and doesn't already
-    name the host, so ordinary errors and already-annotated ones pass through
-    untouched.
-    """
-    if not host or not text:
-        return text
-    low = text.lower()
-    if not any(marker in low for marker in _HOSTLESS_CONNECT_MARKERS):
-        return text
-    if host.lower() in low:
-        return text
-    return f"{text} (host: {host})"
 
 # The claude-agent-sdk reads the CLI subprocess stdout into a bounded decode
 # buffer (default 1 MiB, ``_DEFAULT_MAX_BUFFER_SIZE``) and raises a fatal,

--- a/ciao/providers/codex.py
+++ b/ciao/providers/codex.py
@@ -36,6 +36,7 @@ from ciao.providers.base import (
     ProviderCapabilities,
     build_prompt,
 )
+from ciao.providers.connect_errors import annotate_connection_host
 from ciao.providers.stdio_rpc import RpcError, RpcProcessError, StdioJsonRpcPeer
 from ciao.tool_path import resolve_tool
 
@@ -300,6 +301,35 @@ def _codex_path_env(binary: str) -> dict[str, str]:
     if node_bin.is_dir():
         paths.append(str(node_bin))
     return {"PATH": os.pathsep.join(paths)}
+
+
+def _resolve_codex_host(env: Mapping[str, str] | None = None) -> str:
+    """Endpoint label to annotate a Codex connection error with.
+
+    Codex doesn't expose its upstream API base through Ciaobot config: the
+    app-server resolves the OpenAI/ChatGPT endpoint itself, honouring an
+    ``OPENAI_BASE_URL`` override when present. Prefer that hostname when set;
+    otherwise fall back to the resolved Codex binary path (the local endpoint
+    a "codex not in PATH" / app-server start failure is about), then to a
+    fixed label. The result is paired with an error category by
+    :func:`annotate_connection_host` so a failed schedule names the failing
+    endpoint and the failure class. See issue #178.
+    """
+    source = env if env is not None else os.environ
+    base = str(source.get("OPENAI_BASE_URL") or source.get("OPENAI_API_BASE") or "").strip()
+    if base:
+        try:
+            from urllib.parse import urlsplit
+
+            host = urlsplit(base).hostname
+            if host:
+                return host
+        except ValueError:
+            pass
+    binary = resolve_codex_binary(source)
+    if binary:
+        return binary
+    return "codex app-server"
 
 
 def codex_login_status(
@@ -1143,6 +1173,15 @@ class CodexProvider(BaseSDKProvider):
         result_text = error_text if is_error else "\n\n".join(
             part for part in final_parts if part
         )
+        if is_error and result_text:
+            # Annotate connection/auth errors with the failing Codex endpoint
+            # and a category, so a failed schedule identifies the host (the
+            # OpenAI/ChatGPT API when OPENAI_BASE_URL is set, otherwise the
+            # Codex binary path) and whether it was DNS, refused, timeout, or
+            # auth. No-op for ordinary errors and already-annotated strings.
+            result_text = annotate_connection_host(
+                result_text, _resolve_codex_host(request.extra_env or {})
+            )
         if terminal_status == "interrupted" and not result_text:
             result_text = "Interrupted by user"
         yield ResultEvent(

--- a/ciao/providers/connect_errors.py
+++ b/ciao/providers/connect_errors.py
@@ -1,0 +1,131 @@
+"""Shared connection-error annotation for provider result strings.
+
+Schedule dispatches surface a provider error as the turn's result text, and
+that text is what the operator sees in a failed ``schedule_dispatch`` job run.
+A name-resolution or connect failure arrives as a generic string like
+``API Error: Unable to connect to API (ENOTFOUND)`` with no host and no error
+category, so the operator can't tell which endpoint failed to resolve (the
+Anthropic API, an OpenRouter/Ollama gateway, a custom base URL, the Codex
+binary) or whether it was DNS, a refused connection, a timeout, or auth.
+
+The helpers here annotate the string with both the failing host and a short
+category, so the recorded error identifies the endpoint and the failure
+class. Shared across providers (Claude CLI routing covers Anthropic /
+OpenRouter / Ollama; the Codex provider annotates its own results) so every
+provider a schedule can dispatch through surfaces the same context. See
+issue #178 (extending the Claude-only fix from #162 to all schedule
+providers and adding error classification).
+"""
+
+# Markers that flag a result string as a hostless connection/DNS failure
+# worth annotating. Kept in sync with the retryable-error classifier in
+# ``ciao/web/project_chats.py::_is_retryable_connection_error``.
+_HOSTLESS_CONNECT_MARKERS = (
+    "unable to connect",
+    "enotfound",
+    "econnrefused",
+    "etimedout",
+    "getaddrinfo",
+    "name resolution",
+    "temporary failure in name resolution",
+    "dns resolution failed",
+    "failed to fetch",
+    "network request failed",
+    "connection refused",
+    "connection reset",
+    "connection closed",
+    "connection timed out",
+    "socket timeout",
+    "connect timeout",
+)
+
+# Auth/credential failures are NOT connection errors. Label them distinctly so
+# the operator doesn't chase a DNS or firewall fix for a missing API key. The
+# numeric status codes are paired with their reason phrase to avoid matching
+# the bare digits inside unrelated error text (e.g. "generated 401 tokens").
+_AUTH_MARKERS = (
+    "invalid api key",
+    "incorrect api key",
+    "authentication",
+    "unauthorized",
+    "permission denied",
+    "401 unauthorized",
+    "403 forbidden",
+)
+
+_DNS_MARKERS = (
+    "enotfound",
+    "getaddrinfo",
+    "name resolution",
+    "temporary failure in name resolution",
+    "dns resolution failed",
+)
+
+_REFUSED_MARKERS = (
+    "econnrefused",
+    "connection refused",
+)
+
+_TIMEOUT_MARKERS = (
+    "etimedout",
+    "timed out",
+    "socket timeout",
+    "connect timeout",
+    "connection timed out",
+)
+
+
+def classify_connection_error(text: str) -> str | None:
+    """Return a short category for a connection-error string, or ``None``.
+
+    Categories: ``dns``, ``refused``, ``timeout``, ``auth``, ``connect``
+    (a connection error we couldn't classify further), or ``None`` (not a
+    recognised connection/auth error). DNS resolution failures, refused
+    connections, and timeouts are network-side; auth failures are
+    credential-side. Distinguishing them lets the operator pick the right
+    remediation instead of guessing.
+    """
+    low = (text or "").lower()
+    if not low:
+        return None
+    if any(marker in low for marker in _AUTH_MARKERS):
+        return "auth"
+    if any(marker in low for marker in _DNS_MARKERS):
+        return "dns"
+    if any(marker in low for marker in _REFUSED_MARKERS):
+        return "refused"
+    if any(marker in low for marker in _TIMEOUT_MARKERS):
+        return "timeout"
+    if any(marker in low for marker in _HOSTLESS_CONNECT_MARKERS):
+        return "connect"
+    return None
+
+
+def _looks_like_connection_error(text_lower: str) -> bool:
+    return any(marker in text_lower for marker in _HOSTLESS_CONNECT_MARKERS)
+
+
+def annotate_connection_host(text: str, host: str) -> str:
+    """Append the failing host and error category to a connection/auth-error string.
+
+    Annotates any string :func:`classify_connection_error` recognises, so a
+    DNS failure, a refused connection, a timeout, or an auth/credential
+    error all get labelled. ``host`` is added only when missing; the
+    category is added when missing. Ordinary errors and already-annotated
+    strings pass through untouched, so the helper is idempotent and safe to
+    call on every error result.
+    """
+    if not host or not text:
+        return text
+    low = text.lower()
+    category = classify_connection_error(text)
+    if category is None and not _looks_like_connection_error(low):
+        return text
+    parts: list[str] = []
+    if host.lower() not in low:
+        parts.append(f"host: {host}")
+    if category and f"category: {category}" not in low:
+        parts.append(f"category: {category}")
+    if not parts:
+        return text
+    return f"{text} ({', '.join(parts)})"

--- a/tests/test_codex_provider.py
+++ b/tests/test_codex_provider.py
@@ -365,6 +365,95 @@ async def test_codex_provider_excludes_commentary_from_final_result(
     await provider.disconnect()
 
 
+FAKE_APP_SERVER_CONNECT_ERROR = r'''#!/usr/bin/env python3
+import json
+import sys
+
+turn_id = "turn-1"
+
+def send(payload):
+    print(json.dumps(payload, separators=(",", ":")), flush=True)
+
+for raw in sys.stdin:
+    message = json.loads(raw)
+    method = message.get("method")
+    request_id = message.get("id")
+    if method == "initialize":
+        send({"id": request_id, "result": {"userAgent": "fake-codex"}})
+    elif method == "initialized":
+        pass
+    elif method in {"thread/start", "thread/resume", "thread/fork"}:
+        send({"id": request_id, "result": {
+            "thread": {"id": "thread-1", "turns": []},
+            "model": "gpt-test", "modelProvider": "openai",
+        }})
+    elif method == "turn/start":
+        send({"id": request_id, "result": {"turn": {"id": turn_id, "status": "inProgress", "items": []}}})
+        send({"method": "error", "params": {"willRetry": False, "error": {
+            "message": "API Error: Unable to connect to API (ENOTFOUND)",
+        }}})
+        send({"method": "turn/completed", "params": {"threadId": "thread-1", "turn": {
+            "id": turn_id, "status": "failed", "items": [],
+        }}})
+'''
+
+
+@pytest.mark.asyncio
+async def test_codex_provider_error_result_names_host_and_category(tmp_path: Path) -> None:
+    """A connection-error result from the Codex app-server is annotated with
+    the failing endpoint (OPENAI_BASE_URL host) and a DNS category, so a failed
+    codex schedule names what failed and how (#178)."""
+    script = tmp_path / "fake_codex_connect_error.py"
+    script.write_text(FAKE_APP_SERVER_CONNECT_ERROR, encoding="utf-8")
+    provider = CodexProvider(tmp_path, command=[sys.executable, str(script)])
+    request = AgentRequest(
+        prompt="do the thing",
+        model="gpt-test",
+        mode="auto",
+        provider="codex",
+        extra_env={"OPENAI_BASE_URL": "https://api.openai.com/v1"},
+    )
+    events = []
+    async for event in provider.run_streaming(request, lambda _handle: None):
+        events.append(event)
+
+    result = next(event for event in events if isinstance(event, ResultEvent))
+    assert result.is_error is True
+    assert "host: api.openai.com" in result.result
+    assert "category: dns" in result.result
+    await provider.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_codex_provider_non_connection_error_passes_through(tmp_path: Path) -> None:
+    """A non-connection error from Codex is not annotated (#178)."""
+    script = tmp_path / "fake_codex_auth_error.py"
+    script.write_text(
+        FAKE_APP_SERVER_CONNECT_ERROR.replace(
+            "Unable to connect to API (ENOTFOUND)",
+            "Model refused the request: policy violation",
+        ),
+        encoding="utf-8",
+    )
+    provider = CodexProvider(tmp_path, command=[sys.executable, str(script)])
+    request = AgentRequest(
+        prompt="do the thing",
+        model="gpt-test",
+        mode="auto",
+        provider="codex",
+        extra_env={"OPENAI_BASE_URL": "https://api.openai.com/v1"},
+    )
+    events = []
+    async for event in provider.run_streaming(request, lambda _handle: None):
+        events.append(event)
+
+    result = next(event for event in events if isinstance(event, ResultEvent))
+    assert result.is_error is True
+    assert "host:" not in result.result
+    assert "category:" not in result.result
+    await provider.disconnect()
+
+
 @pytest.mark.asyncio
 async def test_codex_provider_discovers_models_and_reads_thread(tmp_path: Path) -> None:
     command, _log = _fake_command(tmp_path)

--- a/tests/test_connect_errors.py
+++ b/tests/test_connect_errors.py
@@ -1,0 +1,82 @@
+"""Unit tests for the shared connection-error annotation helpers (#178)."""
+
+from ciao.providers.connect_errors import (
+    annotate_connection_host,
+    classify_connection_error,
+)
+
+
+def test_classify_distinguishes_dns_from_refused_and_auth() -> None:
+    """The category tells the operator whether to chase DNS, a refused
+    port, a timeout, or a missing key (#178)."""
+    assert classify_connection_error("getaddrinfo ENOTFOUND api.anthropic.com") == "dns"
+    assert classify_connection_error("Unable to connect to API (ENOTFOUND)") == "dns"
+    assert classify_connection_error("Temporary failure in name resolution") == "dns"
+    assert classify_connection_error("connect ECONNREFUSED 127.0.0.1:11434") == "refused"
+    assert classify_connection_error("connection refused") == "refused"
+    assert classify_connection_error("ETIMEDOUT") == "timeout"
+    assert classify_connection_error("connection timed out") == "timeout"
+    assert classify_connection_error("Invalid API key provided") == "auth"
+    assert classify_connection_error("401 Unauthorized") == "auth"
+    assert classify_connection_error("403 Forbidden") == "auth"
+    # Bare status digits inside unrelated text don't trigger a false auth label.
+    assert classify_connection_error("Generated 401 tokens") is None
+    assert classify_connection_error("failed to fetch") == "connect"
+    assert classify_connection_error("Model refused the request.") is None
+    assert classify_connection_error("") is None
+
+
+def test_auth_takes_precedence_over_dns_markers() -> None:
+    """An auth error that happens to mention a host isn't mislabelled DNS."""
+    assert classify_connection_error(
+        "getaddrinfo ENOTFOUND api.anthropic.com: 401 Unauthorized"
+    ) == "auth"
+
+
+def test_annotate_adds_host_and_category() -> None:
+    out = annotate_connection_host(
+        "API Error: Unable to connect to API (ENOTFOUND)", "api.anthropic.com"
+    )
+    assert "host: api.anthropic.com" in out
+    assert "category: dns" in out
+
+
+def test_annotate_classifies_refused_and_timeout() -> None:
+    assert "category: refused" in annotate_connection_host(
+        "connect ECONNREFUSED 127.0.0.1:11434", "localhost"
+    )
+    assert "category: timeout" in annotate_connection_host(
+        "connection timed out", "api.openai.com"
+    )
+
+
+def test_annotate_labels_auth_separately() -> None:
+    """An auth failure is labelled auth, not dns, so the operator fixes the
+    key instead of the network."""
+    out = annotate_connection_host("Invalid API key", "api.anthropic.com")
+    assert "category: auth" in out
+    assert "category: dns" not in out
+
+
+def test_annotate_is_idempotent_and_skips_non_connection_errors() -> None:
+    once = annotate_connection_host(
+        "API Error: Unable to connect to API (ENOTFOUND)", "api.anthropic.com"
+    )
+    assert annotate_connection_host(once, "api.anthropic.com") == once
+    # Non-connection error: untouched.
+    assert annotate_connection_host("Model refused the request.", "api.anthropic.com") == (
+        "Model refused the request."
+    )
+    # Empty inputs: untouched.
+    assert annotate_connection_host("", "api.anthropic.com") == ""
+    assert annotate_connection_host("ENOTFOUND", "") == "ENOTFOUND"
+
+
+def test_annotate_does_not_double_add_host_when_already_present() -> None:
+    """If the CLI already named the host, we don't duplicate it; the category
+    is still added (#178)."""
+    out = annotate_connection_host(
+        "getaddrinfo ENOTFOUND api.anthropic.com", "api.anthropic.com"
+    )
+    assert out == "getaddrinfo ENOTFOUND api.anthropic.com (category: dns)"
+    assert out.count("api.anthropic.com") == 1

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -470,7 +470,8 @@ def test_claude_convert_result_message(
 def test_claude_error_result_gets_host_annotation(
     claude_provider: ClaudeProvider,
 ) -> None:
-    """A hostless connection error gains the resolved endpoint host (#162)."""
+    """A hostless connection error gains the endpoint host and a DNS
+    category, so a failed schedule names what failed and how (#162, #178)."""
     from claude_agent_sdk import ResultMessage
 
     claude_provider._api_host = "api.anthropic.com"
@@ -485,7 +486,8 @@ def test_claude_error_result_gets_host_annotation(
     )
     result = claude_provider._convert_message(msg)[0]
     assert result.is_error is True
-    assert "(host: api.anthropic.com)" in result.result
+    assert "host: api.anthropic.com" in result.result
+    assert "category: dns" in result.result
 
 
 def test_claude_error_result_annotation_is_selective(
@@ -510,14 +512,21 @@ def test_claude_error_result_annotation_is_selective(
         )
     )[0]
     assert "host:" not in other.result
+    assert "category:" not in other.result
 
-    # Already naming the host: no double-annotation.
+    # Already naming the host: the host is not duplicated, but the category
+    # is still added so the operator can tell DNS from refused/auth (#178).
     assert (
         _annotate_connection_host(
             "getaddrinfo ENOTFOUND api.anthropic.com", "api.anthropic.com"
         )
-        == "getaddrinfo ENOTFOUND api.anthropic.com"
+        == "getaddrinfo ENOTFOUND api.anthropic.com (category: dns)"
     )
+    # Idempotent: a second pass over an already-annotated string is a no-op.
+    annotated = _annotate_connection_host(
+        "API Error: Unable to connect to API (ENOTFOUND)", "api.anthropic.com"
+    )
+    assert _annotate_connection_host(annotated, "api.anthropic.com") == annotated
     # A per-turn ANTHROPIC_BASE_URL override (Ollama/OpenRouter) wins.
     assert (
         _resolve_api_host({"ANTHROPIC_BASE_URL": "https://openrouter.ai/api/v1"})


### PR DESCRIPTION
## Problem

Scheduled dispatches failing with `API Error: Unable to connect to API (ENOTFOUND)` gave no host and no error category, so an operator reading a failed `schedule_dispatch` job run couldn't tell which endpoint failed to resolve (the Anthropic API, an OpenRouter/Ollama gateway, a custom `ANTHROPIC_BASE_URL`, the Codex binary) or whether it was DNS, a refused connection, a timeout, or auth. Reported in #178 across three schedules (claude/opus) between 2026-07-19 00:00 and 07:03 UTC.

The Claude-only host annotation from #162 already appended `(host: ...)` to the Claude provider's connection errors (which also covers Ollama/OpenRouter routed via `ANTHROPIC_BASE_URL`), but it didn't classify the failure and didn't cover the Codex provider.

## Fix

- Promote the annotation helpers into a shared module `ciao/providers/connect_errors.py` with:
  - `classify_connection_error(text)` returning `dns` / `refused` / `timeout` / `auth` / `connect` / `None`, so DNS is distinguishable from a refused port, a timeout, or a missing key;
  - `annotate_connection_host(text, host)` that appends both the failing host (when missing) and the category (when missing). Selective and idempotent: ordinary errors and already-annotated strings pass through untouched.
- `ciao/providers/claude.py`: now annotates error results with `host` **and** `category` (was host-only in #162).
- `ciao/providers/codex.py`: annotates its own error results with the resolved Codex endpoint (`OPENAI_BASE_URL` hostname, else the Codex binary path, else `codex app-server`) and the same category, so a failed codex schedule names what failed and how.

## Result

A failed schedule now records e.g.
`API Error: Unable to connect to API (ENOTFOUND) (host: api.anthropic.com, category: dns)`
instead of the hostless original, for every provider a schedule can dispatch through.

## Tests

- `tests/test_connect_errors.py`: classifier coverage (dns vs refused vs timeout vs auth, auth precedence over DNS, no false positives on bare status digits) and annotation idempotency/selectivity.
- `tests/test_providers.py`: updated for the new category suffix; asserts host + category appear on the Claude ENOTFOUND result.
- `tests/test_codex_provider.py`: a fake app-server emitting a failed connection-error turn asserts the Codex result names the OPENAI_BASE_URL host and `category: dns`; a non-connection error passes through untouched.

```
43 passed  (test_connect_errors / test_providers / test_codex_provider)
1438 passed, 5 deselected (full suite; the 5 deselected are pre-existing env-dependent failures unrelated to this change, confirmed failing on clean origin/main)
```

No layout/capabilities/endpoint/env-var changes, so no doc updates needed.

Fixes #178