### PR TITLE
fix(mobile): stop iOS auto-zoom on input focus; hide homepage behind open sidebar

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -53,6 +53,16 @@ WebKit gesture-event blockers. Individual controls may use
 disabling page zoom. The in-app font scale under Settings > Appearance is an
 additional convenience, not a replacement for browser zoom.
 
+iOS Safari auto-zooms the viewport when an input/textarea/select gets focus
+if its computed `font-size` is below 16px. The global input rule in
+`App.vue` already pins mobile inputs at `16px * var(--font-scale)`, and a
+`@media (pointer: coarse)` carve-out re-pins them to a flat `16px` so
+component-level overrides (markdown editor, comment compose) cannot drop
+back below the zoom threshold. The desktop tightening override is gated on
+`(pointer: fine)` rather than `(min-width: 769px)` so wide touch devices
+(iPad portrait/landscape) never get the smaller typography. Do not weaken
+either rule.
+
 ### WebSocket suspension
 
 iOS Safari suspends JS and WebSockets when the PWA is backgrounded. On resume, `readyState` may still report `OPEN` while no events flow. Listen for `visibilitychange` (visible) and `pageshow` (bfcache restore) on any view that depends on a WebSocket, and force-disconnect + reconnect.

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -562,9 +562,24 @@ input:focus, textarea:focus, select:focus {
   box-shadow: 0 0 0 2px rgba(255, 77, 109, 0.2);
 }
 
-@media (min-width: 769px) {
-  /* Tighten typography on desktop where iOS zoom isn't a concern */
+/* Tighten typography only when the user has a fine pointer (mouse / trackpad).
+   Gating on viewport width alone used to override inputs back to <16px on
+   wide touch devices (iPad portrait/landscape, iPhone landscape, Android
+   tablets), which makes iOS Safari auto-zoom the page on focus. Pointer
+   type is the actual signal: iOS only auto-zooms on touch input, so a
+   coarse pointer always wants the 16px default regardless of width. */
+@media (pointer: fine) {
   input, textarea, select { font-size: calc(14px * var(--font-scale)); padding: 8px 12px; }
+}
+
+/* Touch devices: keep inputs at >= 16px so iOS Safari does not auto-zoom the
+   viewport on focus. Some components (markdown editor, comment compose)
+   override the global input rule with smaller text tokens; this carve-out
+   pins every input/textarea/select to 16px when the pointer is coarse, no
+   matter what scoped styles say. Pairs with the (pointer: fine) tightening
+   above: trackpad/desktop stays tight, touch stays zoom-stable. */
+@media (pointer: coarse) {
+  input, textarea, select { font-size: 16px !important; }
 }
 
 /* ── Shared page layout (schedules, settings, login) ─────────── */

--- a/web/src/components/ChatLayout.vue
+++ b/web/src/components/ChatLayout.vue
@@ -41,7 +41,10 @@
           <div v-else-if="!store.bootstrapped" class="empty-shell home-boot" aria-busy="true">
             <PaneHeader title="ciaobot" @open-sidebar="sidebarCollapsed = false" />
           </div>
-          <div v-else class="empty-shell">
+          <!-- On mobile, the sidebar already lists every active chat. Showing the
+               homepage behind it after closing a chat would just duplicate the
+               same list. Hide the empty-state whenever the mobile sidebar is open. -->
+          <div v-else-if="!(isMobile && !sidebarCollapsed)" class="empty-shell">
             <PaneHeader title="ciaobot" @open-sidebar="sidebarCollapsed = false" />
             <div class="empty-state">
               <div class="empty-mark">
@@ -117,7 +120,10 @@
         <div v-else-if="!store.bootstrapped" class="empty-shell home-boot" aria-busy="true">
           <PaneHeader title="ciaobot" @open-sidebar="sidebarCollapsed = false" />
         </div>
-        <div v-else class="empty-shell">
+        <!-- On mobile, the sidebar already lists every active chat. Showing the
+             homepage behind it after closing a chat would just duplicate the
+             same list. Hide the empty-state whenever the mobile sidebar is open. -->
+        <div v-else-if="!(isMobile && !sidebarCollapsed)" class="empty-shell">
           <PaneHeader title="ciaobot" @open-sidebar="sidebarCollapsed = false" />
           <div class="empty-state">
             <div class="empty-mark">


### PR DESCRIPTION
## Summary

Two mobile UX fixes shipped together.

### 1. Homepage hides behind open sidebar on mobile

On mobile, closing an open chat opens the sidebar (so the user can pick another chat). The homepage empty-state (face + jump-back-in grid + new-chat buttons) used to keep rendering behind the sidebar, duplicating the chat list. Both empty-state branches in ChatLayout.vue are now guarded with v-else-if="!(isMobile && !sidebarCollapsed)` so the homepage only renders on mobile when the sidebar is collapsed. Desktop behavior is unchanged.

### 2. iOS Safari auto-zoom on input focus

iOS Safari zooms the viewport when an input gets focus with computed font-size below 16px. Two pre-existing causes:

- The desktop input-tightening rule in App.vue was gated on @media (min-width: 769px), which also matched wide touch devices (iPad portrait, iPhone landscape, Android tablets). Re-gated to @media (pointer: fine) so only mouse/trackpad users get the smaller typography.
- Several components (comment compose in PinnedFilePanel.vue/FileViewerModal.vue, markdown editor textareas) override the global input rule with var(--text-base) = 13px or a literal 13px. Added an @media (pointer: coarse) carve-out that pins every input/textarea/select to 16px !important on touch devices, so scoped component overrides cannot re-trigger the zoom.

The README gained an explicit note on the 16px invariant and why both rules must be kept. Browser pinch zoom and accessibility zoom are still respected; only the iOS-on-focus auto-zoom is suppressed.

## Files changed
- web/src/components/ChatLayout.vue (+8 / -2) — empty-state guard
- web/src/App.vue (+17 / -2) — pointer-based media queries
- web/README.md (+10) — documents the invariant

## Verification
- npx vue-tsc --noEmit exits 0
- npx vitest run src/components/__tests__/mountSmoke.test.ts passes 16/16 (mounts ChatLayout)
- The 15 pre-existing failures in stores/productTour.test.ts and stores/projects.test.ts are unrelated (per-chat WS reconnect); they reproduce on the upstream branch too
- Live visual QA after Deploy: open a chat on mobile, close it, confirm only the sidebar is visible; tap the comment compose box, confirm the viewport does NOT zoom in.