### PR TITLE
fix(mcp): inherit chat project/workspace for schedules and loops

### DIFF
--- a/ciao/control_plane.py
+++ b/ciao/control_plane.py
@@ -561,6 +561,7 @@ class CiaoControlPlane:
         control_surface: str | None = None,
     ) -> dict[str, Any]:
         chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         if project_id is not None:
             self._project(principal, project_id)
         updated = self.pcm.update_chat(
@@ -601,6 +602,7 @@ class CiaoControlPlane:
 
     def chat_send(self, principal: McpPrincipal, chat_id: str, prompt: str) -> dict[str, Any]:
         chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         if chat.archived:
             raise ControlPlaneError("chat_archived", "Cannot send to an archived chat.")
         text = prompt.strip()
@@ -612,12 +614,13 @@ class CiaoControlPlane:
         return _ok({"chat_id": chat_id, "status": "started"})
 
     def chat_continue(self, principal: McpPrincipal, chat_id: str) -> dict[str, Any]:
-        self._chat(principal, chat_id)
-        chat = self.pcm.continue_archived_chat(chat_id)
+        chat = self._chat(principal, chat_id)
+        chat = self.pcm.continue_archived_chat(chat.chat_id)
         return _ok(chat.to_dict(local=True))
 
     def chat_retry(self, principal: McpPrincipal, chat_id: str) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         stream = self.pcm.try_chat_retry_now(chat_id)
         return _ok({"chat_id": chat_id, "status": "started" if stream else "not_pending"})
 
@@ -628,7 +631,8 @@ class CiaoControlPlane:
         action: Literal["set", "stop", "try_now"],
         prompt: str = "",
     ) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         if action == "set":
             chat = self.pcm.set_chat_retry(chat_id, prompt, image_refs=[], reason="mcp")
             if chat is None:
@@ -644,7 +648,8 @@ class CiaoControlPlane:
         raise ControlPlaneError("invalid_action", "action must be set, stop, or try_now.")
 
     def chat_new_session(self, principal: McpPrincipal, chat_id: str) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         if chat_id == principal.chat_id:
             return self._defer_until_chat_idle(
                 principal, "chat_new_session", lambda: self.pcm.new_session(chat_id)
@@ -664,7 +669,8 @@ class CiaoControlPlane:
         messages: list[dict[str, Any]] | None = None,
         model_bucket: str = "",
     ) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         if chat_id == principal.chat_id:
             return self._defer_until_chat_idle(
                 principal,
@@ -696,7 +702,8 @@ class CiaoControlPlane:
         messages: list[dict[str, Any]],
         turn_index: int,
     ) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         if turn_index < 0:
             raise ControlPlaneError("invalid_turn", "turn_index must be non-negative.")
         fork = self.pcm.fork_chat(
@@ -726,7 +733,8 @@ class CiaoControlPlane:
         return _ok({"chat_id": target_id, "archived_to": str(outcome.path) if outcome else None})
 
     def chat_delete(self, principal: McpPrincipal, chat_id: str) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         if chat_id == principal.chat_id:
             return self._defer_until_chat_idle(
                 principal,
@@ -736,12 +744,14 @@ class CiaoControlPlane:
         return _ok({"chat_id": chat_id, "deleted": self.pcm.delete_chat(chat_id)})
 
     def chat_mark_read(self, principal: McpPrincipal, chat_id: str) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         chat = self.pcm.mark_read(chat_id)
         return _ok({"chat_id": chat_id, "last_read_at": chat.last_read_at if chat else ""})
 
     async def chat_stop(self, principal: McpPrincipal, chat_id: str) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         if chat_id == principal.chat_id:
             raise ControlPlaneError(
                 "self_stop_forbidden",
@@ -764,7 +774,7 @@ class CiaoControlPlane:
         return record
 
     def handoffs_list(self, principal: McpPrincipal, chat_id: str = "") -> dict[str, Any]:
-        parent_id = chat_id or principal.chat_id
+        parent_id = self._resolve_chat_id(principal, chat_id)
         self._chat(principal, parent_id)
         return _ok([item.to_dict() for item in self._handoff_manager().list_records(parent_id)])
 
@@ -781,7 +791,7 @@ class CiaoControlPlane:
     ) -> dict[str, Any]:
         if principal.role == "handoff":
             raise ControlPlaneError("nested_handoff_forbidden", "A handoff cannot start another handoff.")
-        parent = self._chat(principal, chat_id or principal.chat_id)
+        parent = self._chat(principal, chat_id)
         if not provider.strip() or not model.strip() or not message.strip():
             raise ControlPlaneError("invalid_handoff", "provider, model, and message are required.")
         from ciao.provider_subchats import ProviderRoute
@@ -866,11 +876,34 @@ class CiaoControlPlane:
         return _ok(rows)
 
     def schedule_preview(self, principal: McpPrincipal, **values: Any) -> dict[str, Any]:
+        """Validate schedule fields and resolve workspace/project targets.
+
+        When ``chat_id`` is omitted, ``project_id`` defaults to the caller's
+        active project (same as ``chat_create``) so MCP-created schedules land
+        in the chat's workspace+project instead of an unscoped Personal fallback.
+        """
         workspace = self._workspace(principal)
+        chat_ref = values.get("chat_id")
         project_ref = values.get("project_id")
-        resolved_project_id = (
-            self._resolve_project_id(principal, str(project_ref)) if project_ref else project_ref
-        )
+        web_chat_id: str | None = None
+        web_project_id: str | None = None
+
+        if chat_ref:
+            chat = self._chat(principal, str(chat_ref))
+            web_chat_id = chat.chat_id
+            if project_ref:
+                web_project_id = self._resolve_project_id(principal, str(project_ref))
+                project = self._project(principal, web_project_id)
+                workspace = self._workspace(principal, project.workspace)
+        else:
+            # Inherit the active project when omitted — preferred for vault-aware
+            # automation and keeps the schedule in the same workspace as this chat.
+            project = self._resolve_project(
+                principal, None if project_ref is None else str(project_ref)
+            )
+            web_project_id = project.project_id
+            workspace = self._workspace(principal, project.workspace)
+
         now = datetime.now(UTC).isoformat(timespec="seconds")
         entry = ScheduleEntry(
             schedule_id="preview",
@@ -886,17 +919,18 @@ class CiaoControlPlane:
             frequency=str(values.get("frequency") or "weekly"),
             day_of_month=values.get("day_of_month"),
             run_at_date=values.get("run_at_date"),
-            web_chat_id=values.get("chat_id"),
-            web_project_id=resolved_project_id,
+            web_chat_id=web_chat_id,
+            web_project_id=web_project_id,
             workspace=workspace,
             archive_policy=str(values.get("archive_policy") or "manual"),
             title=str(values.get("title") or ""),
         )
-        if entry.web_chat_id:
-            self._chat(principal, entry.web_chat_id)
-        if entry.web_project_id:
-            self._project(principal, entry.web_project_id)
-        return _ok(self._schedule_payload(entry))
+        payload = self._schedule_payload(entry)
+        if web_project_id:
+            project = self.pcm.get_project(web_project_id)
+            if project is not None:
+                payload["project_name"] = getattr(project, "name", "") or ""
+        return _ok(payload)
 
     def schedule_create(self, principal: McpPrincipal, **values: Any) -> dict[str, Any]:
         preview = self.schedule_preview(principal, **values)["data"]
@@ -919,7 +953,10 @@ class CiaoControlPlane:
             title=preview["title"],
             description=str(values.get("description") or ""),
         )
-        return _ok(self._schedule_payload(entry))
+        payload = self._schedule_payload(entry)
+        if preview.get("project_name"):
+            payload["project_name"] = preview["project_name"]
+        return _ok(payload)
 
     def _schedule(self, principal: McpPrincipal, schedule_id: str) -> ScheduleEntry:
         entry = next((item for item in self.schedules.list_entries() if item.schedule_id == schedule_id), None)
@@ -935,7 +972,11 @@ class CiaoControlPlane:
         if entry.scope == "system" and any(key not in {"enabled", "workspace"} for key in changes):
             raise ControlPlaneError("system_schedule_read_only", "System schedules only allow enabled/workspace changes.")
         if changes.get("project_id"):
-            changes["project_id"] = self._resolve_project_id(principal, str(changes["project_id"]))
+            project_id = self._resolve_project_id(principal, str(changes["project_id"]))
+            project = self._project(principal, project_id)
+            changes["project_id"] = project_id
+            # Keep workspace aligned with the new target (same as the HTTP API).
+            changes.setdefault("workspace", project.workspace)
         aliases = {"daily_time": "daily_time_utc", "timezone": "timezone_name", "chat_id": "web_chat_id", "project_id": "web_project_id"}
         normalized = {aliases.get(key, key): value for key, value in changes.items() if value is not None}
         known = set(ScheduleEntry.__dataclass_fields__)
@@ -978,19 +1019,25 @@ class CiaoControlPlane:
     def loop_create(
         self,
         principal: McpPrincipal,
-        chat_id: str,
-        prompt: str,
+        chat_id: str = "",
+        prompt: str = "",
         interval_minutes: int = 10,
         title: str = "",
         autostart: bool = False,
     ) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
+        project = self._project(principal, chat.project_id)
+        text = prompt.strip()
+        if not text:
+            raise ControlPlaneError("empty_prompt", "Prompt is required.")
         entry = self.loops.create(
-            prompt=prompt,
-            web_chat_id=chat_id,
+            prompt=text,
+            web_chat_id=chat.chat_id,
             interval_minutes=max(1, int(interval_minutes)),
             title=title,
             autostart=autostart,
+            web_project_id=chat.project_id,
+            workspace=project.workspace,
         )
         return _ok(asdict(entry))
 
@@ -1006,7 +1053,11 @@ class CiaoControlPlane:
         aliases = {"chat_id": "web_chat_id"}
         normalized = {aliases.get(key, key): value for key, value in changes.items() if value is not None}
         if "web_chat_id" in normalized:
-            self._chat(principal, str(normalized["web_chat_id"]))
+            chat = self._chat(principal, str(normalized["web_chat_id"]))
+            project = self._project(principal, chat.project_id)
+            normalized["web_chat_id"] = chat.chat_id
+            normalized["web_project_id"] = chat.project_id
+            normalized["workspace"] = project.workspace
         known = set(entry.__dataclass_fields__)
         unknown = sorted(set(normalized) - known)
         if unknown:
@@ -1072,15 +1123,15 @@ class CiaoControlPlane:
     def file_history_list(
         self, principal: McpPrincipal, chat_id: str, file_path: str
     ) -> dict[str, Any]:
-        self._chat(principal, chat_id)
-        return _ok(self.pcm.snapshots.list_snapshots(chat_id=chat_id, file_path=file_path))
+        chat = self._chat(principal, chat_id)
+        return _ok(self.pcm.snapshots.list_snapshots(chat_id=chat.chat_id, file_path=file_path))
 
     def file_snapshot_read(
         self, principal: McpPrincipal, chat_id: str, file_path: str, seq: int
     ) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
         result = self.pcm.snapshots.read_snapshot(
-            chat_id=chat_id, file_path=file_path, seq=max(1, int(seq))
+            chat_id=chat.chat_id, file_path=file_path, seq=max(1, int(seq))
         )
         if result is None:
             raise ControlPlaneError("snapshot_not_found", "The requested snapshot was not found.")
@@ -1096,7 +1147,8 @@ class CiaoControlPlane:
     async def file_snapshot_restore(
         self, principal: McpPrincipal, chat_id: str, file_path: str, seq: int
     ) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         root = Path(self.config.workspace_root).resolve()
         raw = Path(file_path)
         target = raw.resolve() if raw.is_absolute() else self._safe_relative(root, file_path)

--- a/ciao/mcp_server.py
+++ b/ciao/mcp_server.py
@@ -82,7 +82,17 @@ class McpSessionRegistry:
             existing_token = self._by_key.get(key)
             existing = self._by_token.get(existing_token or "")
             if existing is not None and existing.expires_at > now:
-                return existing.token, existing.principal
+                prior = existing.principal
+                # Reuse only when scope still matches. A moved project or
+                # corrected workspace must not keep minting stale-scoped tools.
+                if (
+                    prior.project_id == project_id
+                    and prior.workspace == workspace
+                    and prior.handoff_depth == handoff_depth
+                ):
+                    return existing.token, existing.principal
+                self._by_token.pop(existing.token, None)
+                self._by_key.pop(key, None)
             token = secrets.token_urlsafe(36)
             principal = McpPrincipal(
                 token_id=secrets.token_hex(8),
@@ -790,10 +800,10 @@ class CiaoMcpService:
             """Validate a schedule and compute its next run without saving it.
 
             Call this before schedule_create for a new recurring schedule and
-            show the user the resulting next_run as part of the draft. A
-            missing or invalid next_run means the fields don't validate as
-            given — don't create it yet. See schedule_create's docstring for
-            field semantics (they're identical here)."""
+            show the user the resulting next_run, workspace, and project as
+            part of the draft. A missing or invalid next_run means the fields
+            don't validate as given — don't create it yet. See schedule_create's
+            docstring for field semantics (they're identical here)."""
             values = {key: value for key, value in locals().items() if key != "self"}
             return await self._invoke("schedule_preview", lambda cp, p: cp.schedule_preview(p, **values))
 
@@ -818,7 +828,11 @@ class CiaoMcpService:
 
             Show the user a concise draft and get confirmation before creating
             it, unless they already explicitly asked you to apply it — call
-            schedule_preview first and include its next_run in the draft.
+            schedule_preview first. The draft must include next_run, the
+            target workspace, and the target project (or chat). Ask if they
+            want a different workspace/project when that isn't obvious from
+            the request. Schedules always belong to one logical workspace
+            (Personal, Work, …) and show under Automations for that workspace.
 
             Args:
                 prompt: The prompt dispatched each run. Start with the goal in
@@ -841,12 +855,15 @@ class CiaoMcpService:
                 day_of_month: 1-31, monthly only.
                 run_at_date: "YYYY-MM-DD", once only, must be in the future.
                 project_id: Project id or case-insensitive name — creates a
-                    fresh chat in that project per run. Preferred for
+                    fresh chat in that project per run. When omitted (and
+                    chat_id is also omitted), defaults to this chat's project
+                    and stamps that project's workspace. Preferred for
                     vault-aware automation.
                 chat_id: Posts into one existing chat instead. Use only when
                     conversation continuity across runs matters; resolve it
                     via chats_list first (chat titles aren't unique, unlike
                     project names, so there's no name lookup for this one).
+                    When set, project_id is not auto-inherited.
                 model: Empty inherits the target workspace's default model at
                     dispatch time; override only when necessary.
                 provider: Empty inherits the target workspace's default
@@ -925,8 +942,8 @@ class CiaoMcpService:
 
         @tool(name="loop_create", annotations=_WRITE, structured_output=True)
         async def loop_create(
-            chat_id: str,
             prompt: str,
+            chat_id: str = "",
             interval_minutes: int = 10,
             title: str = "",
             autostart: bool = False,
@@ -938,9 +955,9 @@ class CiaoMcpService:
             should get a fresh project chat.
 
             Args:
-                chat_id: An existing chat id. Resolve it via chats_list first
-                    — chat titles aren't unique, so there's no name lookup
-                    here (unlike schedule_create's project_id).
+                chat_id: An existing chat id, or omit / pass empty / "this" for
+                    the calling chat. If you must target another chat, resolve
+                    its id via chats_list first — chat titles aren't unique.
                 prompt: Give a short, fixed no-change response for a no-op
                     tick, so repeated iterations stay cheap and scannable.
                 interval_minutes: There is no model field — each iteration

--- a/ciao/system_prompt.md
+++ b/ciao/system_prompt.md
@@ -41,7 +41,7 @@ Ciaobot has three memory layers. Use the right one; do not duplicate facts acros
 - Direct CLI fallback: `ciao vault-search "<query>" --limit 5`; rebuild stale search/entity data with `ciao vault-index`.
 - Vault hygiene: `ciao vault-lint` for broken wikilinks, orphans, and near-duplicates.
 
-**Automations**: Ciaobot has its own timezone-aware scheduler (`schedule_*` tools) and sub-day chat loops (`loop_*` tools) — see their tool descriptions for field semantics and the schedule-vs-loop choice. Never use cloud-side claude.ai Routines or a provider's own `/schedule` for a Ciaobot automation; they bypass Ciaobot's project/vault dispatch entirely, so a recurring task set up that way silently loses vault-aware context. Prefer the user's task system for a one-off reminder they will action manually themselves, when one is configured.
+**Automations**: Ciaobot has its own timezone-aware scheduler (`schedule_*` tools) and sub-day chat loops (`loop_*` tools) — see their tool descriptions for field semantics and the schedule-vs-loop choice. New schedules inherit this chat's workspace and project when you omit `project_id`; always confirm workspace + project (or chat) in the draft before creating. Never use cloud-side claude.ai Routines or a provider's own `/schedule` for a Ciaobot automation; they bypass Ciaobot's project/vault dispatch entirely, so a recurring task set up that way silently loses vault-aware context. Prefer the user's task system for a one-off reminder they will action manually themselves, when one is configured.
 
 **Other agent CLIs** (run from the workspace root, non-interactive)
 

--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -4015,8 +4015,12 @@ async def create_loop(request: Request) -> JSONResponse:
         interval_minutes=interval_minutes,
         title=(body.get("title") or "").strip(),
         autostart=bool(body.get("autostart")),
-        web_project_id=getattr(chat, "web_project_id", "") or "",
-        workspace=getattr(chat, "workspace", "") or "",
+        web_project_id=getattr(chat, "project_id", "") or "",
+        workspace=(
+            getattr(pcm.get_project(chat.project_id), "workspace", "")
+            if getattr(chat, "project_id", None) and pcm.get_project(chat.project_id)
+            else ""
+        ),
     )
     if body.get("start"):
         lm.start_loop(entry.loop_id)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -113,6 +113,29 @@ def test_registry_issues_scoped_reusable_and_revocable_tokens() -> None:
     assert registry.status()["active_sessions"] == 0
 
 
+def test_registry_reissues_when_workspace_or_project_changes() -> None:
+    registry = McpSessionRegistry(ttl_seconds=60)
+    token, principal = registry.issue(
+        chat_id="chat-1",
+        project_id="project-1",
+        workspace="personal",
+        provider="claude",
+    )
+
+    moved_token, moved = registry.issue(
+        chat_id="chat-1",
+        project_id="project-work",
+        workspace="work",
+        provider="claude",
+    )
+
+    assert moved_token != token
+    assert moved.workspace == "work"
+    assert moved.project_id == "project-work"
+    assert principal.workspace == "personal"
+    assert registry.status()["active_sessions"] == 1
+
+
 def test_streamable_http_auth_and_structured_tool_result(tmp_path: Path) -> None:
     service, _control_plane = _service(tmp_path)
     token, _ = service.registry.issue(
@@ -471,6 +494,159 @@ def test_schedule_create_resolves_project_by_name(tmp_path: Path) -> None:
     )
 
     assert result["data"]["web_project_id"] == "project-2"
+    assert result["data"]["workspace"] == "personal"
+    assert result["data"]["project_name"] == "Research"
+
+
+def test_schedule_create_defaults_to_callers_project_and_workspace(tmp_path: Path) -> None:
+    from ciao.schedules import ScheduleManager, ScheduleStore
+
+    pcm = _ChatCreatePcm()
+    pcm.projects["project-work"] = SimpleNamespace(
+        project_id="project-work",
+        name="AI-NATIVE-SDK",
+        workspace="work",
+    )
+    schedules = ScheduleManager(
+        store=ScheduleStore(tmp_path),
+        dispatch_to_web=lambda *a, **k: None,
+    )
+    config = SimpleNamespace(
+        workspace=lambda name: object() if name in {"personal", "work"} else None
+    )
+    control_plane = CiaoControlPlane(
+        config,
+        project_chat_manager=pcm,
+        schedule_manager=schedules,
+        loop_manager=SimpleNamespace(),
+    )
+    principal = _chat_create_principal(
+        project_id="project-work",
+        workspace="work",
+    )
+
+    result = control_plane.schedule_create(
+        principal,
+        prompt="Seed the weekly skills CSV.",
+        daily_time="08:00",
+        timezone="Europe/Zurich",
+        frequency="weekly",
+        days_of_week=["mon"],
+    )
+
+    assert result["data"]["web_project_id"] == "project-work"
+    assert result["data"]["workspace"] == "work"
+    assert result["data"]["project_name"] == "AI-NATIVE-SDK"
+    stored = schedules.list_entries()[0]
+    assert stored.web_project_id == "project-work"
+    assert stored.workspace == "work"
+
+
+def test_schedule_create_with_chat_id_skips_project_default(tmp_path: Path) -> None:
+    from ciao.schedules import ScheduleManager, ScheduleStore
+
+    pcm = _ChatCreatePcm()
+    pcm.projects["project-work"] = SimpleNamespace(
+        project_id="project-work",
+        name="AI-NATIVE-SDK",
+        workspace="work",
+    )
+    chat = SimpleNamespace(chat_id="chat-fixed", project_id="project-work")
+    pcm.get_chat = lambda cid: chat if cid == "chat-fixed" else None  # type: ignore[method-assign]
+    schedules = ScheduleManager(
+        store=ScheduleStore(tmp_path),
+        dispatch_to_web=lambda *a, **k: None,
+    )
+    config = SimpleNamespace(
+        workspace=lambda name: object() if name in {"personal", "work"} else None
+    )
+    control_plane = CiaoControlPlane(
+        config,
+        project_chat_manager=pcm,
+        schedule_manager=schedules,
+        loop_manager=SimpleNamespace(),
+    )
+    principal = _chat_create_principal(
+        project_id="project-work",
+        workspace="work",
+    )
+
+    result = control_plane.schedule_create(
+        principal,
+        prompt="Continue this thread weekly.",
+        daily_time="08:00",
+        timezone="UTC",
+        frequency="weekly",
+        chat_id="chat-fixed",
+    )
+
+    assert result["data"]["web_chat_id"] == "chat-fixed"
+    assert result["data"]["web_project_id"] is None
+    assert result["data"]["workspace"] == "work"
+
+
+def test_chat_update_resolves_omitted_chat_id() -> None:
+    pcm = SimpleNamespace(
+        update_chat=lambda cid, **kwargs: SimpleNamespace(
+            chat_id=cid,
+            control_surface="",
+            to_dict=lambda local=True: {"chat_id": cid, **kwargs},
+        ),
+        is_session_local=lambda c: True,
+        get_chat=lambda cid: SimpleNamespace(chat_id=cid, project_id="project-1"),
+        get_project=lambda pid: SimpleNamespace(project_id=pid, workspace="personal"),
+    )
+    config = SimpleNamespace(workspace=lambda name: object() if name == "personal" else None)
+    control_plane = CiaoControlPlane(
+        config,
+        project_chat_manager=pcm,
+        schedule_manager=SimpleNamespace(),
+        loop_manager=SimpleNamespace(),
+    )
+    principal = _chat_create_principal()
+
+    result = control_plane.chat_update(principal, "", title="Renamed")
+
+    assert result["data"]["chat_id"] == "chat-1"
+    assert result["data"]["title"] == "Renamed"
+
+
+def test_loop_create_defaults_to_caller_and_stamps_workspace(tmp_path: Path) -> None:
+    from ciao.loops import LoopManager, LoopStore
+
+    pcm = _ChatCreatePcm()
+    pcm.projects["project-work"] = SimpleNamespace(
+        project_id="project-work",
+        name="AI-NATIVE-SDK",
+        workspace="work",
+    )
+    pcm.get_chat = lambda cid: (  # type: ignore[method-assign]
+        SimpleNamespace(chat_id="chat-work", project_id="project-work")
+        if cid == "chat-work"
+        else None
+    )
+    manager = LoopManager(store=LoopStore(tmp_path))
+    config = SimpleNamespace(
+        workspace=lambda name: object() if name in {"personal", "work"} else None
+    )
+    control_plane = CiaoControlPlane(
+        config,
+        project_chat_manager=pcm,
+        schedule_manager=SimpleNamespace(),
+        loop_manager=manager,
+    )
+    principal = _chat_create_principal(
+        chat_id="chat-work",
+        project_id="project-work",
+        workspace="work",
+    )
+
+    result = control_plane.loop_create(principal, "", "Check PRs", interval_minutes=15)
+
+    assert result["data"]["web_chat_id"] == "chat-work"
+    assert result["data"]["web_project_id"] == "project-work"
+    assert result["data"]["workspace"] == "work"
+    assert result["data"]["interval_minutes"] == 15
 
 
 def test_adversarial_review_synthesizes_panel_results(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- MCP `schedule_create`/`schedule_preview` now default to the calling chat's project and stamp that project's workspace, so Work-workspace schedules no longer fall through to Personal when `project_id` is omitted.
- MCP session tokens re-issue when project/workspace scope changes; chat mutations resolve omitted/`this` chat IDs before writing; loops stamp `workspace`/`web_project_id` (HTTP create path fixed too).
- Tool docs and system prompt require confirming workspace + project (or chat) in the schedule draft.

## Test plan
- [ ] `pytest tests/test_mcp_server.py tests/test_schedule_api_delivery_modes.py tests/test_schedule_workspace_routing.py`
- [ ] From a Work-workspace project chat, create a schedule via MCP without passing `project_id` — confirm Automations shows it under Work with that project
- [ ] Create a loop with omitted `chat_id` — confirm it binds to the calling chat and carries workspace/project
- [ ] Move a chat between projects (or correct workspace) and confirm subsequent MCP tools use the new scope (no stale Personal principal)


Made with [Cursor](https://cursor.com)