### PR TITLE
fix(ci,mcp): clear mypy/PWA docs blockers and inherit MCP schedule context

### DIFF
--- a/PWA_API.md
+++ b/PWA_API.md
@@ -24,6 +24,7 @@ The route source of truth is `ciao/web/app.py`. This file is kept in sync by `te
 | POST | `/api/auth` | Login with `PWA_AUTH_TOKEN` |
 | POST | `/api/auth/logout` | Clear session cookie |
 | GET | `/api/auth/check` | Verify current session |
+| GET, POST | `/api/auth/settings` | Read or update PWA password protection settings |
 | GET | `/api/projects` | List projects |
 | POST | `/api/projects` | Create project |
 | PATCH, DELETE | `/api/projects/{project_id}` | Update or delete project |
@@ -34,6 +35,7 @@ The route source of truth is `ciao/web/app.py`. This file is kept in sync by `te
 | GET, POST | `/api/projects/{project_id}/chats` | List or create project chats |
 | GET, POST | `/api/projects/{project_id}/files` | List or upload project files |
 | GET | `/api/chats` | List all chats |
+| GET | `/api/menubar-chats` | Compact chat list for the macOS tray / menubar |
 | POST | `/api/chats/read-all` | Mark all chats read |
 | PATCH, DELETE | `/api/chats/{chat_id}` | Update or delete chat |
 | POST | `/api/chats/{chat_id}/new` | Start a new provider session |
@@ -134,6 +136,7 @@ The route source of truth is `ciao/web/app.py`. This file is kept in sync by `te
 | POST | `/api/local/resync` | Merge `origin/<branch>` back into the checkout |
 | POST | `/api/handover/merge` | Open an interactive chat that resolves sync conflicts on a branch |
 | GET | `/api/node/status` | Read multi-device node failover status and role |
+| POST | `/api/node/connect` | Connect this node as a client tunnel to a remote host |
 | POST | `/api/node/demote` | Demote active node to standby |
 | POST | `/api/node/handover` | Handover active role to another node |
 | POST | `/api/node/peers` | Register or update node peer links |

--- a/ciao/control_plane.py
+++ b/ciao/control_plane.py
@@ -561,6 +561,7 @@ class CiaoControlPlane:
         control_surface: str | None = None,
     ) -> dict[str, Any]:
         chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         if project_id is not None:
             self._project(principal, project_id)
         updated = self.pcm.update_chat(
@@ -601,6 +602,7 @@ class CiaoControlPlane:
 
     def chat_send(self, principal: McpPrincipal, chat_id: str, prompt: str) -> dict[str, Any]:
         chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         if chat.archived:
             raise ControlPlaneError("chat_archived", "Cannot send to an archived chat.")
         text = prompt.strip()
@@ -612,12 +614,13 @@ class CiaoControlPlane:
         return _ok({"chat_id": chat_id, "status": "started"})
 
     def chat_continue(self, principal: McpPrincipal, chat_id: str) -> dict[str, Any]:
-        self._chat(principal, chat_id)
-        chat = self.pcm.continue_archived_chat(chat_id)
+        chat = self._chat(principal, chat_id)
+        chat = self.pcm.continue_archived_chat(chat.chat_id)
         return _ok(chat.to_dict(local=True))
 
     def chat_retry(self, principal: McpPrincipal, chat_id: str) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         stream = self.pcm.try_chat_retry_now(chat_id)
         return _ok({"chat_id": chat_id, "status": "started" if stream else "not_pending"})
 
@@ -628,7 +631,8 @@ class CiaoControlPlane:
         action: Literal["set", "stop", "try_now"],
         prompt: str = "",
     ) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         if action == "set":
             chat = self.pcm.set_chat_retry(chat_id, prompt, image_refs=[], reason="mcp")
             if chat is None:
@@ -644,7 +648,8 @@ class CiaoControlPlane:
         raise ControlPlaneError("invalid_action", "action must be set, stop, or try_now.")
 
     def chat_new_session(self, principal: McpPrincipal, chat_id: str) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         if chat_id == principal.chat_id:
             return self._defer_until_chat_idle(
                 principal, "chat_new_session", lambda: self.pcm.new_session(chat_id)
@@ -664,7 +669,8 @@ class CiaoControlPlane:
         messages: list[dict[str, Any]] | None = None,
         model_bucket: str = "",
     ) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         if chat_id == principal.chat_id:
             return self._defer_until_chat_idle(
                 principal,
@@ -696,7 +702,8 @@ class CiaoControlPlane:
         messages: list[dict[str, Any]],
         turn_index: int,
     ) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         if turn_index < 0:
             raise ControlPlaneError("invalid_turn", "turn_index must be non-negative.")
         fork = self.pcm.fork_chat(
@@ -726,7 +733,8 @@ class CiaoControlPlane:
         return _ok({"chat_id": target_id, "archived_to": str(outcome.path) if outcome else None})
 
     def chat_delete(self, principal: McpPrincipal, chat_id: str) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         if chat_id == principal.chat_id:
             return self._defer_until_chat_idle(
                 principal,
@@ -736,12 +744,14 @@ class CiaoControlPlane:
         return _ok({"chat_id": chat_id, "deleted": self.pcm.delete_chat(chat_id)})
 
     def chat_mark_read(self, principal: McpPrincipal, chat_id: str) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         chat = self.pcm.mark_read(chat_id)
         return _ok({"chat_id": chat_id, "last_read_at": chat.last_read_at if chat else ""})
 
     async def chat_stop(self, principal: McpPrincipal, chat_id: str) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         if chat_id == principal.chat_id:
             raise ControlPlaneError(
                 "self_stop_forbidden",
@@ -764,7 +774,7 @@ class CiaoControlPlane:
         return record
 
     def handoffs_list(self, principal: McpPrincipal, chat_id: str = "") -> dict[str, Any]:
-        parent_id = chat_id or principal.chat_id
+        parent_id = self._resolve_chat_id(principal, chat_id)
         self._chat(principal, parent_id)
         return _ok([item.to_dict() for item in self._handoff_manager().list_records(parent_id)])
 
@@ -781,7 +791,7 @@ class CiaoControlPlane:
     ) -> dict[str, Any]:
         if principal.role == "handoff":
             raise ControlPlaneError("nested_handoff_forbidden", "A handoff cannot start another handoff.")
-        parent = self._chat(principal, chat_id or principal.chat_id)
+        parent = self._chat(principal, chat_id)
         if not provider.strip() or not model.strip() or not message.strip():
             raise ControlPlaneError("invalid_handoff", "provider, model, and message are required.")
         from ciao.provider_subchats import ProviderRoute
@@ -866,11 +876,34 @@ class CiaoControlPlane:
         return _ok(rows)
 
     def schedule_preview(self, principal: McpPrincipal, **values: Any) -> dict[str, Any]:
+        """Validate schedule fields and resolve workspace/project targets.
+
+        When ``chat_id`` is omitted, ``project_id`` defaults to the caller's
+        active project (same as ``chat_create``) so MCP-created schedules land
+        in the chat's workspace+project instead of an unscoped Personal fallback.
+        """
         workspace = self._workspace(principal)
+        chat_ref = values.get("chat_id")
         project_ref = values.get("project_id")
-        resolved_project_id = (
-            self._resolve_project_id(principal, str(project_ref)) if project_ref else project_ref
-        )
+        web_chat_id: str | None = None
+        web_project_id: str | None = None
+
+        if chat_ref:
+            chat = self._chat(principal, str(chat_ref))
+            web_chat_id = chat.chat_id
+            if project_ref:
+                web_project_id = self._resolve_project_id(principal, str(project_ref))
+                project = self._project(principal, web_project_id)
+                workspace = self._workspace(principal, project.workspace)
+        else:
+            # Inherit the active project when omitted — preferred for vault-aware
+            # automation and keeps the schedule in the same workspace as this chat.
+            project = self._resolve_project(
+                principal, None if project_ref is None else str(project_ref)
+            )
+            web_project_id = project.project_id
+            workspace = self._workspace(principal, project.workspace)
+
         now = datetime.now(UTC).isoformat(timespec="seconds")
         entry = ScheduleEntry(
             schedule_id="preview",
@@ -886,17 +919,18 @@ class CiaoControlPlane:
             frequency=str(values.get("frequency") or "weekly"),
             day_of_month=values.get("day_of_month"),
             run_at_date=values.get("run_at_date"),
-            web_chat_id=values.get("chat_id"),
-            web_project_id=resolved_project_id,
+            web_chat_id=web_chat_id,
+            web_project_id=web_project_id,
             workspace=workspace,
             archive_policy=str(values.get("archive_policy") or "manual"),
             title=str(values.get("title") or ""),
         )
-        if entry.web_chat_id:
-            self._chat(principal, entry.web_chat_id)
-        if entry.web_project_id:
-            self._project(principal, entry.web_project_id)
-        return _ok(self._schedule_payload(entry))
+        payload = self._schedule_payload(entry)
+        if web_project_id:
+            project = self.pcm.get_project(web_project_id)
+            if project is not None:
+                payload["project_name"] = getattr(project, "name", "") or ""
+        return _ok(payload)
 
     def schedule_create(self, principal: McpPrincipal, **values: Any) -> dict[str, Any]:
         preview = self.schedule_preview(principal, **values)["data"]
@@ -919,7 +953,10 @@ class CiaoControlPlane:
             title=preview["title"],
             description=str(values.get("description") or ""),
         )
-        return _ok(self._schedule_payload(entry))
+        payload = self._schedule_payload(entry)
+        if preview.get("project_name"):
+            payload["project_name"] = preview["project_name"]
+        return _ok(payload)
 
     def _schedule(self, principal: McpPrincipal, schedule_id: str) -> ScheduleEntry:
         entry = next((item for item in self.schedules.list_entries() if item.schedule_id == schedule_id), None)
@@ -935,7 +972,11 @@ class CiaoControlPlane:
         if entry.scope == "system" and any(key not in {"enabled", "workspace"} for key in changes):
             raise ControlPlaneError("system_schedule_read_only", "System schedules only allow enabled/workspace changes.")
         if changes.get("project_id"):
-            changes["project_id"] = self._resolve_project_id(principal, str(changes["project_id"]))
+            project_id = self._resolve_project_id(principal, str(changes["project_id"]))
+            project = self._project(principal, project_id)
+            changes["project_id"] = project_id
+            # Keep workspace aligned with the new target (same as the HTTP API).
+            changes.setdefault("workspace", project.workspace)
         aliases = {"daily_time": "daily_time_utc", "timezone": "timezone_name", "chat_id": "web_chat_id", "project_id": "web_project_id"}
         normalized = {aliases.get(key, key): value for key, value in changes.items() if value is not None}
         known = set(ScheduleEntry.__dataclass_fields__)
@@ -978,19 +1019,25 @@ class CiaoControlPlane:
     def loop_create(
         self,
         principal: McpPrincipal,
-        chat_id: str,
-        prompt: str,
+        chat_id: str = "",
+        prompt: str = "",
         interval_minutes: int = 10,
         title: str = "",
         autostart: bool = False,
     ) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
+        project = self._project(principal, chat.project_id)
+        text = prompt.strip()
+        if not text:
+            raise ControlPlaneError("empty_prompt", "Prompt is required.")
         entry = self.loops.create(
-            prompt=prompt,
-            web_chat_id=chat_id,
+            prompt=text,
+            web_chat_id=chat.chat_id,
             interval_minutes=max(1, int(interval_minutes)),
             title=title,
             autostart=autostart,
+            web_project_id=chat.project_id,
+            workspace=project.workspace,
         )
         return _ok(asdict(entry))
 
@@ -1006,7 +1053,11 @@ class CiaoControlPlane:
         aliases = {"chat_id": "web_chat_id"}
         normalized = {aliases.get(key, key): value for key, value in changes.items() if value is not None}
         if "web_chat_id" in normalized:
-            self._chat(principal, str(normalized["web_chat_id"]))
+            chat = self._chat(principal, str(normalized["web_chat_id"]))
+            project = self._project(principal, chat.project_id)
+            normalized["web_chat_id"] = chat.chat_id
+            normalized["web_project_id"] = chat.project_id
+            normalized["workspace"] = project.workspace
         known = set(entry.__dataclass_fields__)
         unknown = sorted(set(normalized) - known)
         if unknown:
@@ -1072,15 +1123,15 @@ class CiaoControlPlane:
     def file_history_list(
         self, principal: McpPrincipal, chat_id: str, file_path: str
     ) -> dict[str, Any]:
-        self._chat(principal, chat_id)
-        return _ok(self.pcm.snapshots.list_snapshots(chat_id=chat_id, file_path=file_path))
+        chat = self._chat(principal, chat_id)
+        return _ok(self.pcm.snapshots.list_snapshots(chat_id=chat.chat_id, file_path=file_path))
 
     def file_snapshot_read(
         self, principal: McpPrincipal, chat_id: str, file_path: str, seq: int
     ) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
         result = self.pcm.snapshots.read_snapshot(
-            chat_id=chat_id, file_path=file_path, seq=max(1, int(seq))
+            chat_id=chat.chat_id, file_path=file_path, seq=max(1, int(seq))
         )
         if result is None:
             raise ControlPlaneError("snapshot_not_found", "The requested snapshot was not found.")
@@ -1096,7 +1147,8 @@ class CiaoControlPlane:
     async def file_snapshot_restore(
         self, principal: McpPrincipal, chat_id: str, file_path: str, seq: int
     ) -> dict[str, Any]:
-        self._chat(principal, chat_id)
+        chat = self._chat(principal, chat_id)
+        chat_id = chat.chat_id
         root = Path(self.config.workspace_root).resolve()
         raw = Path(file_path)
         target = raw.resolve() if raw.is_absolute() else self._safe_relative(root, file_path)

--- a/ciao/control_plane.py
+++ b/ciao/control_plane.py
@@ -230,13 +230,29 @@ class CiaoControlPlane:
             return principal.chat_id
         return value
 
-    def _chat(self, principal: McpPrincipal, chat_id: str | None = None) -> Any:
+    def _chat_scope(self, principal: McpPrincipal, chat_id: str | None = None) -> tuple[Any, Any]:
+        """Resolve a chat plus the project that owns it, in one authorization pass.
+
+        Callers that need the workspace should take the project from here rather
+        than looking it up again: ``_chat`` already resolves and authorizes it.
+        """
         resolved_id = self._resolve_chat_id(principal, chat_id)
         chat = self.pcm.get_chat(resolved_id)
         if chat is None:
             raise ControlPlaneError("chat_not_found", f"Chat '{resolved_id}' was not found.")
-        self._project(principal, chat.project_id)
-        return chat
+        return chat, self._project(principal, chat.project_id)
+
+    def _chat(self, principal: McpPrincipal, chat_id: str | None = None) -> Any:
+        return self._chat_scope(principal, chat_id)[0]
+
+    def _chat_id(self, principal: McpPrincipal, chat_id: str | None = None) -> str:
+        """Authorize a chat reference and return its real id.
+
+        ``_chat`` resolves ``""``/``"this"``/``"self"`` internally but returns
+        only the chat, so callers that echo the id back had to remember a second
+        line to recover it. Use this when the chat object itself is not needed.
+        """
+        return str(self._chat(principal, chat_id).chat_id)
 
     def chat_mode(self, principal: McpPrincipal) -> str:
         chat = self.pcm.get_chat(principal.chat_id) if principal.chat_id else None
@@ -560,8 +576,7 @@ class CiaoControlPlane:
         model_bucket: str | None = None,
         control_surface: str | None = None,
     ) -> dict[str, Any]:
-        chat = self._chat(principal, chat_id)
-        chat_id = chat.chat_id
+        chat_id = self._chat_id(principal, chat_id)
         if project_id is not None:
             self._project(principal, project_id)
         updated = self.pcm.update_chat(
@@ -619,8 +634,7 @@ class CiaoControlPlane:
         return _ok(chat.to_dict(local=True))
 
     def chat_retry(self, principal: McpPrincipal, chat_id: str) -> dict[str, Any]:
-        chat = self._chat(principal, chat_id)
-        chat_id = chat.chat_id
+        chat_id = self._chat_id(principal, chat_id)
         stream = self.pcm.try_chat_retry_now(chat_id)
         return _ok({"chat_id": chat_id, "status": "started" if stream else "not_pending"})
 
@@ -631,8 +645,7 @@ class CiaoControlPlane:
         action: Literal["set", "stop", "try_now"],
         prompt: str = "",
     ) -> dict[str, Any]:
-        chat = self._chat(principal, chat_id)
-        chat_id = chat.chat_id
+        chat_id = self._chat_id(principal, chat_id)
         if action == "set":
             chat = self.pcm.set_chat_retry(chat_id, prompt, image_refs=[], reason="mcp")
             if chat is None:
@@ -648,8 +661,7 @@ class CiaoControlPlane:
         raise ControlPlaneError("invalid_action", "action must be set, stop, or try_now.")
 
     def chat_new_session(self, principal: McpPrincipal, chat_id: str) -> dict[str, Any]:
-        chat = self._chat(principal, chat_id)
-        chat_id = chat.chat_id
+        chat_id = self._chat_id(principal, chat_id)
         if chat_id == principal.chat_id:
             return self._defer_until_chat_idle(
                 principal, "chat_new_session", lambda: self.pcm.new_session(chat_id)
@@ -669,8 +681,7 @@ class CiaoControlPlane:
         messages: list[dict[str, Any]] | None = None,
         model_bucket: str = "",
     ) -> dict[str, Any]:
-        chat = self._chat(principal, chat_id)
-        chat_id = chat.chat_id
+        chat_id = self._chat_id(principal, chat_id)
         if chat_id == principal.chat_id:
             return self._defer_until_chat_idle(
                 principal,
@@ -702,8 +713,7 @@ class CiaoControlPlane:
         messages: list[dict[str, Any]],
         turn_index: int,
     ) -> dict[str, Any]:
-        chat = self._chat(principal, chat_id)
-        chat_id = chat.chat_id
+        chat_id = self._chat_id(principal, chat_id)
         if turn_index < 0:
             raise ControlPlaneError("invalid_turn", "turn_index must be non-negative.")
         fork = self.pcm.fork_chat(
@@ -733,8 +743,7 @@ class CiaoControlPlane:
         return _ok({"chat_id": target_id, "archived_to": str(outcome.path) if outcome else None})
 
     def chat_delete(self, principal: McpPrincipal, chat_id: str) -> dict[str, Any]:
-        chat = self._chat(principal, chat_id)
-        chat_id = chat.chat_id
+        chat_id = self._chat_id(principal, chat_id)
         if chat_id == principal.chat_id:
             return self._defer_until_chat_idle(
                 principal,
@@ -744,14 +753,12 @@ class CiaoControlPlane:
         return _ok({"chat_id": chat_id, "deleted": self.pcm.delete_chat(chat_id)})
 
     def chat_mark_read(self, principal: McpPrincipal, chat_id: str) -> dict[str, Any]:
-        chat = self._chat(principal, chat_id)
-        chat_id = chat.chat_id
+        chat_id = self._chat_id(principal, chat_id)
         chat = self.pcm.mark_read(chat_id)
         return _ok({"chat_id": chat_id, "last_read_at": chat.last_read_at if chat else ""})
 
     async def chat_stop(self, principal: McpPrincipal, chat_id: str) -> dict[str, Any]:
-        chat = self._chat(principal, chat_id)
-        chat_id = chat.chat_id
+        chat_id = self._chat_id(principal, chat_id)
         if chat_id == principal.chat_id:
             raise ControlPlaneError(
                 "self_stop_forbidden",
@@ -774,8 +781,7 @@ class CiaoControlPlane:
         return record
 
     def handoffs_list(self, principal: McpPrincipal, chat_id: str = "") -> dict[str, Any]:
-        parent_id = self._resolve_chat_id(principal, chat_id)
-        self._chat(principal, parent_id)
+        parent_id = self._chat_id(principal, chat_id)
         return _ok([item.to_dict() for item in self._handoff_manager().list_records(parent_id)])
 
     async def handoff_start(
@@ -859,11 +865,15 @@ class CiaoControlPlane:
 
     # ---- schedules/loops ----------------------------------------------
 
-    @staticmethod
-    def _schedule_payload(entry: ScheduleEntry) -> dict[str, Any]:
+    def _schedule_payload(self, entry: ScheduleEntry) -> dict[str, Any]:
         data = asdict(entry)
         next_run = compute_next_run(entry)
         data["next_run"] = next_run.isoformat() if next_run else None
+        # Name the target project here so every schedule tool reports it the
+        # same way; enriching at the call site left it missing from list/update.
+        if entry.web_project_id:
+            project = self.pcm.get_project(entry.web_project_id)
+            data["project_name"] = getattr(project, "name", "") or ""
         return data
 
     def schedules_list(self, principal: McpPrincipal) -> dict[str, Any]:
@@ -886,21 +896,22 @@ class CiaoControlPlane:
         chat_ref = values.get("chat_id")
         project_ref = values.get("project_id")
         web_chat_id: str | None = None
-        web_project_id: str | None = None
+        project: Any | None = None
 
         if chat_ref:
             chat = self._chat(principal, str(chat_ref))
             web_chat_id = chat.chat_id
             if project_ref:
-                web_project_id = self._resolve_project_id(principal, str(project_ref))
-                project = self._project(principal, web_project_id)
-                workspace = self._workspace(principal, project.workspace)
+                project = self._resolve_project(principal, str(project_ref))
         else:
             # Inherit the active project when omitted — preferred for vault-aware
             # automation and keeps the schedule in the same workspace as this chat.
             project = self._resolve_project(
                 principal, None if project_ref is None else str(project_ref)
             )
+
+        web_project_id: str | None = None
+        if project is not None:
             web_project_id = project.project_id
             workspace = self._workspace(principal, project.workspace)
 
@@ -925,12 +936,7 @@ class CiaoControlPlane:
             archive_policy=str(values.get("archive_policy") or "manual"),
             title=str(values.get("title") or ""),
         )
-        payload = self._schedule_payload(entry)
-        if web_project_id:
-            project = self.pcm.get_project(web_project_id)
-            if project is not None:
-                payload["project_name"] = getattr(project, "name", "") or ""
-        return _ok(payload)
+        return _ok(self._schedule_payload(entry))
 
     def schedule_create(self, principal: McpPrincipal, **values: Any) -> dict[str, Any]:
         preview = self.schedule_preview(principal, **values)["data"]
@@ -953,10 +959,7 @@ class CiaoControlPlane:
             title=preview["title"],
             description=str(values.get("description") or ""),
         )
-        payload = self._schedule_payload(entry)
-        if preview.get("project_name"):
-            payload["project_name"] = preview["project_name"]
-        return _ok(payload)
+        return _ok(self._schedule_payload(entry))
 
     def _schedule(self, principal: McpPrincipal, schedule_id: str) -> ScheduleEntry:
         entry = next((item for item in self.schedules.list_entries() if item.schedule_id == schedule_id), None)
@@ -1025,8 +1028,7 @@ class CiaoControlPlane:
         title: str = "",
         autostart: bool = False,
     ) -> dict[str, Any]:
-        chat = self._chat(principal, chat_id)
-        project = self._project(principal, chat.project_id)
+        chat, project = self._chat_scope(principal, chat_id)
         text = prompt.strip()
         if not text:
             raise ControlPlaneError("empty_prompt", "Prompt is required.")
@@ -1053,8 +1055,7 @@ class CiaoControlPlane:
         aliases = {"chat_id": "web_chat_id"}
         normalized = {aliases.get(key, key): value for key, value in changes.items() if value is not None}
         if "web_chat_id" in normalized:
-            chat = self._chat(principal, str(normalized["web_chat_id"]))
-            project = self._project(principal, chat.project_id)
+            chat, project = self._chat_scope(principal, str(normalized["web_chat_id"]))
             normalized["web_chat_id"] = chat.chat_id
             normalized["web_project_id"] = chat.project_id
             normalized["workspace"] = project.workspace
@@ -1147,8 +1148,7 @@ class CiaoControlPlane:
     async def file_snapshot_restore(
         self, principal: McpPrincipal, chat_id: str, file_path: str, seq: int
     ) -> dict[str, Any]:
-        chat = self._chat(principal, chat_id)
-        chat_id = chat.chat_id
+        chat_id = self._chat_id(principal, chat_id)
         root = Path(self.config.workspace_root).resolve()
         raw = Path(file_path)
         target = raw.resolve() if raw.is_absolute() else self._safe_relative(root, file_path)

--- a/ciao/dependency_review.py
+++ b/ciao/dependency_review.py
@@ -515,7 +515,7 @@ def _collect_update_candidates(
         if ecosystem == "python":
             registry_version = get_latest_pypi_version(key)
         elif ecosystem == "npm":
-            registry_version = get_latest_npm_version(workspace_root, key)
+            registry_version = get_latest_npm_version(key)
 
         # Use GitHub release version as fallback when registry is unavailable
         release = release_data.get(key, {})

--- a/ciao/loops.py
+++ b/ciao/loops.py
@@ -190,9 +190,7 @@ class LoopManager:
         *,
         dispatch: Callable[[LoopEntry], Awaitable[dict | None]] | None = None,
         chat_busy: Callable[[str], bool] | None = None,
-        # Prefer Callable[[LoopEntry], bool]; str-only callables are still
-        # accepted via the TypeError fallback in _chat_is_dispatchable.
-        chat_exists: Callable[..., bool] | None = None,
+        chat_exists: Callable[[LoopEntry], bool] | None = None,
         is_node_active: Callable[[], bool] | None = None,
     ) -> None:
         self._store = store
@@ -254,10 +252,7 @@ class LoopManager:
     def _chat_is_dispatchable(self, entry: LoopEntry) -> bool:
         if self._chat_exists is None:
             return True
-        try:
-            return self._chat_exists(entry)
-        except TypeError:
-            return self._chat_exists(entry.web_chat_id)
+        return self._chat_exists(entry)
 
     async def run_now(self, loop_id: str) -> dict:
         """Fire one iteration immediately, even if the loop is stopped.

--- a/ciao/loops.py
+++ b/ciao/loops.py
@@ -190,7 +190,9 @@ class LoopManager:
         *,
         dispatch: Callable[[LoopEntry], Awaitable[dict | None]] | None = None,
         chat_busy: Callable[[str], bool] | None = None,
-        chat_exists: Callable[[str], bool] | None = None,
+        # Prefer Callable[[LoopEntry], bool]; str-only callables are still
+        # accepted via the TypeError fallback in _chat_is_dispatchable.
+        chat_exists: Callable[..., bool] | None = None,
         is_node_active: Callable[[], bool] | None = None,
     ) -> None:
         self._store = store

--- a/ciao/main.py
+++ b/ciao/main.py
@@ -13,7 +13,7 @@ import time
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Callable, Literal
+from typing import Any, Callable, Literal
 
 from ciao.config import CiaoConfig
 from ciao.git_sync import sync_workspace

--- a/ciao/main.py
+++ b/ciao/main.py
@@ -13,12 +13,12 @@ import time
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Callable, Literal
+from typing import Callable, Literal
 
 from ciao.config import CiaoConfig
 from ciao.git_sync import sync_workspace
 from ciao.models import ChatContext
-from ciao.loops import LoopManager, LoopStore
+from ciao.loops import LoopEntry, LoopManager, LoopStore
 from ciao.schedules import ScheduleManager, ScheduleStore
 from ciao.sessions import StateStore
 from ciao.signals import RestartRequested
@@ -444,18 +444,11 @@ async def _run_server_locked(config: CiaoConfig) -> int:
     # archived (or deleted) target as not-dispatchable so LoopManager
     # auto-stops the loop instead of erroring every interval with
     # "Cannot send messages to an archived chat" (issue #126).
-    def _loop_target_dispatchable(target: Any) -> bool:
-        if hasattr(target, "web_chat_id"):
-            chat_id = target.web_chat_id
-        else:
-            chat_id = str(target)
-            target = None
-        chat = pcm.get_chat(chat_id)
+    def _loop_target_dispatchable(target: LoopEntry) -> bool:
+        chat = pcm.get_chat(target.web_chat_id)
         if chat is not None and not chat.archived:
             return True
-        if target is not None and pcm._resolve_loop_project(target) is not None:
-            return True
-        return False
+        return pcm._resolve_loop_project(target) is not None
 
     loop_manager = LoopManager(
         store=LoopStore(config.state_path.parent),

--- a/ciao/mcp_server.py
+++ b/ciao/mcp_server.py
@@ -91,8 +91,9 @@ class McpSessionRegistry:
                     and prior.handoff_depth == handoff_depth
                 ):
                     return existing.token, existing.principal
-                self._by_token.pop(existing.token, None)
-                self._by_key.pop(key, None)
+                # revoke() owns the _by_token/_by_key pairing; the lock is an
+                # RLock so re-entering it here is safe.
+                self.revoke(existing.token)
             token = secrets.token_urlsafe(36)
             principal = McpPrincipal(
                 token_id=secrets.token_hex(8),

--- a/ciao/mcp_server.py
+++ b/ciao/mcp_server.py
@@ -82,7 +82,17 @@ class McpSessionRegistry:
             existing_token = self._by_key.get(key)
             existing = self._by_token.get(existing_token or "")
             if existing is not None and existing.expires_at > now:
-                return existing.token, existing.principal
+                prior = existing.principal
+                # Reuse only when scope still matches. A moved project or
+                # corrected workspace must not keep minting stale-scoped tools.
+                if (
+                    prior.project_id == project_id
+                    and prior.workspace == workspace
+                    and prior.handoff_depth == handoff_depth
+                ):
+                    return existing.token, existing.principal
+                self._by_token.pop(existing.token, None)
+                self._by_key.pop(key, None)
             token = secrets.token_urlsafe(36)
             principal = McpPrincipal(
                 token_id=secrets.token_hex(8),
@@ -790,10 +800,10 @@ class CiaoMcpService:
             """Validate a schedule and compute its next run without saving it.
 
             Call this before schedule_create for a new recurring schedule and
-            show the user the resulting next_run as part of the draft. A
-            missing or invalid next_run means the fields don't validate as
-            given — don't create it yet. See schedule_create's docstring for
-            field semantics (they're identical here)."""
+            show the user the resulting next_run, workspace, and project as
+            part of the draft. A missing or invalid next_run means the fields
+            don't validate as given — don't create it yet. See schedule_create's
+            docstring for field semantics (they're identical here)."""
             values = {key: value for key, value in locals().items() if key != "self"}
             return await self._invoke("schedule_preview", lambda cp, p: cp.schedule_preview(p, **values))
 
@@ -818,7 +828,11 @@ class CiaoMcpService:
 
             Show the user a concise draft and get confirmation before creating
             it, unless they already explicitly asked you to apply it — call
-            schedule_preview first and include its next_run in the draft.
+            schedule_preview first. The draft must include next_run, the
+            target workspace, and the target project (or chat). Ask if they
+            want a different workspace/project when that isn't obvious from
+            the request. Schedules always belong to one logical workspace
+            (Personal, Work, …) and show under Automations for that workspace.
 
             Args:
                 prompt: The prompt dispatched each run. Start with the goal in
@@ -841,12 +855,15 @@ class CiaoMcpService:
                 day_of_month: 1-31, monthly only.
                 run_at_date: "YYYY-MM-DD", once only, must be in the future.
                 project_id: Project id or case-insensitive name — creates a
-                    fresh chat in that project per run. Preferred for
+                    fresh chat in that project per run. When omitted (and
+                    chat_id is also omitted), defaults to this chat's project
+                    and stamps that project's workspace. Preferred for
                     vault-aware automation.
                 chat_id: Posts into one existing chat instead. Use only when
                     conversation continuity across runs matters; resolve it
                     via chats_list first (chat titles aren't unique, unlike
                     project names, so there's no name lookup for this one).
+                    When set, project_id is not auto-inherited.
                 model: Empty inherits the target workspace's default model at
                     dispatch time; override only when necessary.
                 provider: Empty inherits the target workspace's default
@@ -925,8 +942,8 @@ class CiaoMcpService:
 
         @tool(name="loop_create", annotations=_WRITE, structured_output=True)
         async def loop_create(
-            chat_id: str,
             prompt: str,
+            chat_id: str = "",
             interval_minutes: int = 10,
             title: str = "",
             autostart: bool = False,
@@ -938,9 +955,9 @@ class CiaoMcpService:
             should get a fresh project chat.
 
             Args:
-                chat_id: An existing chat id. Resolve it via chats_list first
-                    — chat titles aren't unique, so there's no name lookup
-                    here (unlike schedule_create's project_id).
+                chat_id: An existing chat id, or omit / pass empty / "this" for
+                    the calling chat. If you must target another chat, resolve
+                    its id via chats_list first — chat titles aren't unique.
                 prompt: Give a short, fixed no-change response for a no-op
                     tick, so repeated iterations stay cheap and scannable.
                 interval_minutes: There is no model field — each iteration

--- a/ciao/node_proxy.py
+++ b/ciao/node_proxy.py
@@ -8,12 +8,15 @@ and macOS tray act as a thin client.
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, cast
+from typing import TYPE_CHECKING
 
 import httpx
-from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response, StreamingResponse
+
+if TYPE_CHECKING:
+    from ciao.node_state import NodeStateManager
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +66,7 @@ def get_proxy_target_url(request: Request | WebSocket) -> str | None:
     if is_local_path(path):
         return None
 
-    node_mgr = getattr(request.app.state, "node_state_manager", None)
+    node_mgr: NodeStateManager | None = getattr(request.app.state, "node_state_manager", None)
     if node_mgr is None:
         return None
 
@@ -92,8 +95,7 @@ def get_proxy_target_url(request: Request | WebSocket) -> str | None:
     except Exception:
         pass
 
-    # node_mgr comes from getattr → Any; narrow after the truthiness guard above.
-    return cast(str, target)
+    return target
 
 
 def _host_auth_headers(request: Request | WebSocket, target_url: str) -> dict[str, str]:
@@ -206,11 +208,11 @@ async def proxy_http_request(request: Request, active_peer_url: str) -> Response
 class StandbyProxyMiddleware(BaseHTTPMiddleware):
     """Tunnel /api requests to the host when this node is in client mode."""
 
-    async def dispatch(self, request: Request, call_next: Callable[..., Any]) -> Response:
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         target_peer = get_proxy_target_url(request)
         if target_peer:
             return await proxy_http_request(request, target_peer)
-        return cast(Response, await call_next(request))
+        return await call_next(request)
 
 
 async def proxy_websocket(websocket: WebSocket, active_peer_url: str) -> None:

--- a/ciao/node_proxy.py
+++ b/ciao/node_proxy.py
@@ -8,7 +8,7 @@ and macOS tray act as a thin client.
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 import httpx
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -92,7 +92,8 @@ def get_proxy_target_url(request: Request | WebSocket) -> str | None:
     except Exception:
         pass
 
-    return target
+    # node_mgr comes from getattr → Any; narrow after the truthiness guard above.
+    return cast(str, target)
 
 
 def _host_auth_headers(request: Request | WebSocket, target_url: str) -> dict[str, str]:
@@ -209,7 +210,7 @@ class StandbyProxyMiddleware(BaseHTTPMiddleware):
         target_peer = get_proxy_target_url(request)
         if target_peer:
             return await proxy_http_request(request, target_peer)
-        return await call_next(request)
+        return cast(Response, await call_next(request))
 
 
 async def proxy_websocket(websocket: WebSocket, active_peer_url: str) -> None:

--- a/ciao/system_prompt.md
+++ b/ciao/system_prompt.md
@@ -41,7 +41,7 @@ Ciaobot has three memory layers. Use the right one; do not duplicate facts acros
 - Direct CLI fallback: `ciao vault-search "<query>" --limit 5`; rebuild stale search/entity data with `ciao vault-index`.
 - Vault hygiene: `ciao vault-lint` for broken wikilinks, orphans, and near-duplicates.
 
-**Automations**: Ciaobot has its own timezone-aware scheduler (`schedule_*` tools) and sub-day chat loops (`loop_*` tools) — see their tool descriptions for field semantics and the schedule-vs-loop choice. Never use cloud-side claude.ai Routines or a provider's own `/schedule` for a Ciaobot automation; they bypass Ciaobot's project/vault dispatch entirely, so a recurring task set up that way silently loses vault-aware context. Prefer the user's task system for a one-off reminder they will action manually themselves, when one is configured.
+**Automations**: Ciaobot has its own timezone-aware scheduler (`schedule_*` tools) and sub-day chat loops (`loop_*` tools) — see their tool descriptions for field semantics and the schedule-vs-loop choice. New schedules inherit this chat's workspace and project when you omit `project_id`; always confirm workspace + project (or chat) in the draft before creating. Never use cloud-side claude.ai Routines or a provider's own `/schedule` for a Ciaobot automation; they bypass Ciaobot's project/vault dispatch entirely, so a recurring task set up that way silently loses vault-aware context. Prefer the user's task system for a one-off reminder they will action manually themselves, when one is configured.
 
 **Other agent CLIs** (run from the workspace root, non-interactive)
 

--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -4015,8 +4015,12 @@ async def create_loop(request: Request) -> JSONResponse:
         interval_minutes=interval_minutes,
         title=(body.get("title") or "").strip(),
         autostart=bool(body.get("autostart")),
-        web_project_id=getattr(chat, "web_project_id", "") or "",
-        workspace=getattr(chat, "workspace", "") or "",
+        web_project_id=getattr(chat, "project_id", "") or "",
+        workspace=(
+            getattr(pcm.get_project(chat.project_id), "workspace", "")
+            if getattr(chat, "project_id", None) and pcm.get_project(chat.project_id)
+            else ""
+        ),
     )
     if body.get("start"):
         lm.start_loop(entry.loop_id)

--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -4009,18 +4009,17 @@ async def create_loop(request: Request) -> JSONResponse:
     if interval_minutes < 1:
         return JSONResponse({"error": "interval_minutes must be >= 1"}, status_code=400)
 
+    # A loop inherits the workspace of its chat's project, same as a schedule.
+    loop_project_id = getattr(chat, "project_id", "") or ""
+    loop_project = pcm.get_project(loop_project_id) if loop_project_id else None
     entry = lm.create(
         prompt=prompt,
         web_chat_id=web_chat_id,
         interval_minutes=interval_minutes,
         title=(body.get("title") or "").strip(),
         autostart=bool(body.get("autostart")),
-        web_project_id=getattr(chat, "project_id", "") or "",
-        workspace=(
-            getattr(pcm.get_project(chat.project_id), "workspace", "")
-            if getattr(chat, "project_id", None) and pcm.get_project(chat.project_id)
-            else ""
-        ),
+        web_project_id=loop_project_id,
+        workspace=getattr(loop_project, "workspace", "") or "",
     )
     if body.get("start"):
         lm.start_loop(entry.loop_id)

--- a/ciao/web/static/index.html
+++ b/ciao/web/static/index.html
@@ -13,8 +13,8 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-180.png" />
     <title>Ciaobot</title>
-    <script type="module" crossorigin src="/assets/index-DL8LF51Y.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BJUB34wZ.css">
+    <script type="module" crossorigin src="/assets/index-B8quyyh-.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-D8P4zc24.css">
   </head>
   <body>
     <div id="app"></div>

--- a/skills/ciao-release/SKILL.md
+++ b/skills/ciao-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ciao-release
-description: How to cut a Ciaobot release — the patch/minor/major convention, the pre-release checklist (dependencies, docs, capabilities skill), the prepare-release command, what merging into main triggers, and the known traps. Trigger on "release", "cut a release", "publish", "bump the version", "ship a new version", "prepare-release", or any question about how Ciaobot versioning and publishing work.
+description: How to cut a Ciaobot release — the patch/minor/major convention, the pre-release checklist (dependencies, docs, capabilities skill, /code-review --fix gate via /pr), the prepare-release command, what merging into main triggers, and the known traps. Trigger on "release", "cut a release", "publish", "bump the version", "ship a new version", "prepare-release", or any question about how Ciaobot versioning and publishing work.
 ---
 
 # Ciaobot Release
@@ -26,17 +26,17 @@ When unsure between patch and minor, ask: "could a user notice something new or 
 Do these on `develop` (or a short prep branch merged into develop) **before** running prepare-release:
 
 1. **Survey open PRs and issues.** Before cutting, list what's outstanding — `gh pr list --state open` and `gh issue list --state open` on `raffaelefarinaro/ciaobot`. Surface them to the user and **ask** whether any open PRs should land in this release (merge into `develop` first) and whether any reported issues should be fixed before cutting. Never auto-merge PRs or auto-close issues — the user decides what's in scope for the release. Once decisions are made, merge the chosen PRs / land the fixes on `develop` before continuing.
-2. **Fresh review of the release surface — mandatory, blocking step.** Take a clean look at everything shipping since the last release tag — `git log --oneline <last-tag>..develop` and `git diff <last-tag>..develop`. Read it as a reviewer, not the author. Then, **before running `prepare-release`**, invoke both quality skills on that diff and act on their findings — this is not conditional on convenience, it's a required gate like step 1:
-   - `/simplify` — reuse/simplification/efficiency cleanups (quality only).
-   - `/code-review` (`security-review` instead if the diff touches auth, secrets, or external input) — correctness/bug hunt; pass a higher effort for a release.
-   Apply the fixes each skill surfaces (or explicitly tell the user why a finding is being deferred) before moving on to step 3. A release is the checkpoint where small messes get paid down, not deferred further. Only skip a skill if it is genuinely absent from the environment (check with the `Skill` tool / `/help`) — if so, say that explicitly to the user and do the equivalent review by hand instead of silently moving on.
+2. **Fresh review of the release surface — mandatory, blocking step.** Take a clean look at everything shipping since the last release tag — `git log --oneline <last-tag>..develop` and `git diff <last-tag>..develop`. Read it as a reviewer, not the author. Then, **before running `prepare-release`**, run the same quality gate as `/pr` on that range — this is not conditional on convenience, it's a required gate like step 1:
+   - `/code-review --fix <last-tag>..develop` — correctness plus reuse/simplification/efficiency; pass a **higher effort** (or `ultra`) for a release. If the diff touches auth, secrets, or external input, run `security-review` instead (or in addition).
+   - Inspect applied edits with `git diff`; keep, amend, or discard before committing. Explicitly tell the user why any finding is deferred.
+   A release is the checkpoint where small messes get paid down, not deferred further. `/code-review` already covers what `/simplify` used to; do not require a separate `/simplify` pass unless you specifically want cleanup-only autofix without a bug hunt. Only skip `/code-review` if it is genuinely absent from the environment (check with the `Skill` tool / `/help`) — if so, say that explicitly to the user and do the equivalent review by hand instead of silently moving on. Everyday feature PRs use `skills/pr/SKILL.md` (`/pr`) for the same gate on the branch diff.
 3. **Dependencies.** The release tool already checks PyPI/npm and prints available updates as `[auto|manual] [safe|major]`; `auto`-flagged ones (e.g. the Claude Agent SDK) are bumped on `--apply`, the rest are only reported. Run a plan-only pass first (command below, no `--apply`) to see the list, then decide whether to adopt any `manual` updates in a separate commit before releasing. Don't blanket-upgrade majors as part of a release.
 4. **Docs.** Update anything the change touched: `README.md`, `docs/ARCHITECTURE.md`, `docs/DEVELOPMENT.md`, `PWA_API.md` (any new/changed state-changing route **must** be documented here).
 5. **The capabilities skill.** For any new user-facing feature, update `ciao/stock/skills/ciao-capabilities/SKILL.md` — add the feature to the right section and add trigger keywords to its frontmatter `description`. Skim the CHANGELOG since the last release tag to catch features that shipped without a catalog entry.
 6. **This skill.** If the release flow, flags, or traps changed, update `skills/ciao-release/SKILL.md` too.
 7. **CHANGELOG sanity.** The tool generates the entry from commits since the last tag. If commits landed on the release branch after `release: prepare`, append them to the entry before merging.
 
-Once the release PR is open, give its diff one more fresh read before merging — the `release: prepare` commit adds version/CHANGELOG/dependency changes that weren't in your pre-cut review.
+Once the release PR is open, give its diff one more fresh read before merging — the `release: prepare` commit adds version/CHANGELOG/dependency changes that weren't in your pre-cut review. Prefer `/code-review --comment` on the open PR so findings land as inline comments; still act on anything that should block the merge.
 
 ## Environment prerequisites
 

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: pr
+description: Pre-PR quality gate — run /code-review --fix on the branch diff before opening or updating a pull request. Trigger on "open a PR", "create a pull request", "ready for review", "/pr", or when about to push a branch for review.
+---
+
+# PR quality gate
+
+> Contributor/project skill — lives in the repo's workspace `skills/` folder, **not** `ciao/stock/skills/`. It is for people working *on* Ciaobot and is deliberately not packaged or shipped to end-user installs. `ciao sync-skills` mirrors it into `.claude/skills/` (Claude Code) and `.agents/skills/` (Codex). Don't move it into `ciao/stock/`.
+
+Before opening or updating a pull request, run this gate. Do not open the PR until findings are applied or explicitly deferred with the user.
+
+## Steps
+
+1. **Review + apply.** Invoke `/code-review --fix` on the branch diff (commits ahead of upstream plus uncommitted changes). Pass a higher effort for large or risky diffs. If the diff touches auth, secrets, or external input, run `security-review` instead (or in addition).
+2. **Inspect.** Read the applied edits with `git diff`. Keep, amend, or discard (`git add -p` / `git checkout -- .`) before committing anything the review wrote.
+3. **Open or update the PR** only after step 2 (`gh pr create` / push / update).
+
+Optional after the PR exists: `/code-review --comment` posts findings as inline PR comments.
+
+## Notes
+
+- `/code-review` already covers reuse, simplification, and efficiency findings. Do **not** also require `/simplify` unless you specifically want a cleanup-only autofix without a bug hunt.
+- Only skip `/code-review` if it is genuinely absent from the environment (check with the `Skill` tool / `/help`) — say so explicitly and do the equivalent review by hand.
+- Release cuts use the same gate on a wider range; see `skills/ciao-release/SKILL.md`.

--- a/tests/test_loop_api.py
+++ b/tests/test_loop_api.py
@@ -73,7 +73,7 @@ def _make_client(tmp_path: Path) -> tuple[TestClient, LoopManager]:
         store=LoopStore(runtime),
         dispatch=dispatch,
         chat_busy=pcm.chat_stream_active,
-        chat_exists=lambda chat_id: pcm.get_chat(chat_id) is not None,
+        chat_exists=lambda entry: pcm.get_chat(entry.web_chat_id) is not None,
     )
     app = Starlette(
         routes=[

--- a/tests/test_loops.py
+++ b/tests/test_loops.py
@@ -34,7 +34,7 @@ def _make_manager(
         store=store,
         dispatch=dispatch,
         chat_busy=lambda chat_id: busy,
-        chat_exists=lambda chat_id: exists,
+        chat_exists=lambda entry: exists,
     )
     return mgr, dispatched
 
@@ -201,7 +201,7 @@ async def test_fires_as_soon_as_chat_frees_up(store: LoopStore) -> None:
         store=store,
         dispatch=dispatch,
         chat_busy=lambda chat_id: busy_flag["busy"],
-        chat_exists=lambda chat_id: True,
+        chat_exists=lambda entry: True,
     )
     mgr.start_loop(entry.loop_id)
     t0 = datetime(2026, 7, 11, 12, 0, tzinfo=UTC)
@@ -252,7 +252,7 @@ async def test_inflight_iteration_blocks_refire(store: LoopStore) -> None:
         store=store,
         dispatch=dispatch,
         chat_busy=lambda chat_id: False,
-        chat_exists=lambda chat_id: True,
+        chat_exists=lambda entry: True,
     )
     mgr.start_loop(entry.loop_id)
     t0 = datetime(2026, 7, 11, 12, 0, tzinfo=UTC)
@@ -286,7 +286,7 @@ async def test_dispatch_exception_recorded_as_error(store: LoopStore) -> None:
         store=store,
         dispatch=dispatch,
         chat_busy=lambda chat_id: False,
-        chat_exists=lambda chat_id: True,
+        chat_exists=lambda entry: True,
     )
     mgr.start_loop(entry.loop_id)
     await mgr.tick()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -113,6 +113,29 @@ def test_registry_issues_scoped_reusable_and_revocable_tokens() -> None:
     assert registry.status()["active_sessions"] == 0
 
 
+def test_registry_reissues_when_workspace_or_project_changes() -> None:
+    registry = McpSessionRegistry(ttl_seconds=60)
+    token, principal = registry.issue(
+        chat_id="chat-1",
+        project_id="project-1",
+        workspace="personal",
+        provider="claude",
+    )
+
+    moved_token, moved = registry.issue(
+        chat_id="chat-1",
+        project_id="project-work",
+        workspace="work",
+        provider="claude",
+    )
+
+    assert moved_token != token
+    assert moved.workspace == "work"
+    assert moved.project_id == "project-work"
+    assert principal.workspace == "personal"
+    assert registry.status()["active_sessions"] == 1
+
+
 def test_streamable_http_auth_and_structured_tool_result(tmp_path: Path) -> None:
     service, _control_plane = _service(tmp_path)
     token, _ = service.registry.issue(
@@ -471,6 +494,159 @@ def test_schedule_create_resolves_project_by_name(tmp_path: Path) -> None:
     )
 
     assert result["data"]["web_project_id"] == "project-2"
+    assert result["data"]["workspace"] == "personal"
+    assert result["data"]["project_name"] == "Research"
+
+
+def test_schedule_create_defaults_to_callers_project_and_workspace(tmp_path: Path) -> None:
+    from ciao.schedules import ScheduleManager, ScheduleStore
+
+    pcm = _ChatCreatePcm()
+    pcm.projects["project-work"] = SimpleNamespace(
+        project_id="project-work",
+        name="AI-NATIVE-SDK",
+        workspace="work",
+    )
+    schedules = ScheduleManager(
+        store=ScheduleStore(tmp_path),
+        dispatch_to_web=lambda *a, **k: None,
+    )
+    config = SimpleNamespace(
+        workspace=lambda name: object() if name in {"personal", "work"} else None
+    )
+    control_plane = CiaoControlPlane(
+        config,
+        project_chat_manager=pcm,
+        schedule_manager=schedules,
+        loop_manager=SimpleNamespace(),
+    )
+    principal = _chat_create_principal(
+        project_id="project-work",
+        workspace="work",
+    )
+
+    result = control_plane.schedule_create(
+        principal,
+        prompt="Seed the weekly skills CSV.",
+        daily_time="08:00",
+        timezone="Europe/Zurich",
+        frequency="weekly",
+        days_of_week=["mon"],
+    )
+
+    assert result["data"]["web_project_id"] == "project-work"
+    assert result["data"]["workspace"] == "work"
+    assert result["data"]["project_name"] == "AI-NATIVE-SDK"
+    stored = schedules.list_entries()[0]
+    assert stored.web_project_id == "project-work"
+    assert stored.workspace == "work"
+
+
+def test_schedule_create_with_chat_id_skips_project_default(tmp_path: Path) -> None:
+    from ciao.schedules import ScheduleManager, ScheduleStore
+
+    pcm = _ChatCreatePcm()
+    pcm.projects["project-work"] = SimpleNamespace(
+        project_id="project-work",
+        name="AI-NATIVE-SDK",
+        workspace="work",
+    )
+    chat = SimpleNamespace(chat_id="chat-fixed", project_id="project-work")
+    pcm.get_chat = lambda cid: chat if cid == "chat-fixed" else None  # type: ignore[method-assign]
+    schedules = ScheduleManager(
+        store=ScheduleStore(tmp_path),
+        dispatch_to_web=lambda *a, **k: None,
+    )
+    config = SimpleNamespace(
+        workspace=lambda name: object() if name in {"personal", "work"} else None
+    )
+    control_plane = CiaoControlPlane(
+        config,
+        project_chat_manager=pcm,
+        schedule_manager=schedules,
+        loop_manager=SimpleNamespace(),
+    )
+    principal = _chat_create_principal(
+        project_id="project-work",
+        workspace="work",
+    )
+
+    result = control_plane.schedule_create(
+        principal,
+        prompt="Continue this thread weekly.",
+        daily_time="08:00",
+        timezone="UTC",
+        frequency="weekly",
+        chat_id="chat-fixed",
+    )
+
+    assert result["data"]["web_chat_id"] == "chat-fixed"
+    assert result["data"]["web_project_id"] is None
+    assert result["data"]["workspace"] == "work"
+
+
+def test_chat_update_resolves_omitted_chat_id() -> None:
+    pcm = SimpleNamespace(
+        update_chat=lambda cid, **kwargs: SimpleNamespace(
+            chat_id=cid,
+            control_surface="",
+            to_dict=lambda local=True: {"chat_id": cid, **kwargs},
+        ),
+        is_session_local=lambda c: True,
+        get_chat=lambda cid: SimpleNamespace(chat_id=cid, project_id="project-1"),
+        get_project=lambda pid: SimpleNamespace(project_id=pid, workspace="personal"),
+    )
+    config = SimpleNamespace(workspace=lambda name: object() if name == "personal" else None)
+    control_plane = CiaoControlPlane(
+        config,
+        project_chat_manager=pcm,
+        schedule_manager=SimpleNamespace(),
+        loop_manager=SimpleNamespace(),
+    )
+    principal = _chat_create_principal()
+
+    result = control_plane.chat_update(principal, "", title="Renamed")
+
+    assert result["data"]["chat_id"] == "chat-1"
+    assert result["data"]["title"] == "Renamed"
+
+
+def test_loop_create_defaults_to_caller_and_stamps_workspace(tmp_path: Path) -> None:
+    from ciao.loops import LoopManager, LoopStore
+
+    pcm = _ChatCreatePcm()
+    pcm.projects["project-work"] = SimpleNamespace(
+        project_id="project-work",
+        name="AI-NATIVE-SDK",
+        workspace="work",
+    )
+    pcm.get_chat = lambda cid: (  # type: ignore[method-assign]
+        SimpleNamespace(chat_id="chat-work", project_id="project-work")
+        if cid == "chat-work"
+        else None
+    )
+    manager = LoopManager(store=LoopStore(tmp_path))
+    config = SimpleNamespace(
+        workspace=lambda name: object() if name in {"personal", "work"} else None
+    )
+    control_plane = CiaoControlPlane(
+        config,
+        project_chat_manager=pcm,
+        schedule_manager=SimpleNamespace(),
+        loop_manager=manager,
+    )
+    principal = _chat_create_principal(
+        chat_id="chat-work",
+        project_id="project-work",
+        workspace="work",
+    )
+
+    result = control_plane.loop_create(principal, "", "Check PRs", interval_minutes=15)
+
+    assert result["data"]["web_chat_id"] == "chat-work"
+    assert result["data"]["web_project_id"] == "project-work"
+    assert result["data"]["workspace"] == "work"
+    assert result["data"]["interval_minutes"] == 15
 
 
 def test_adversarial_review_synthesizes_panel_results(monkeypatch) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5,6 +5,7 @@ import json
 from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from starlette.applications import Starlette
@@ -401,14 +402,41 @@ class _ChatCreatePcm:
         self.started.append((chat_id, text))
 
 
-def _chat_create_control_plane(pcm: _ChatCreatePcm) -> CiaoControlPlane:
-    config = SimpleNamespace(workspace=lambda name: object() if name == "personal" else None)
+def _chat_create_control_plane(
+    pcm: _ChatCreatePcm,
+    *,
+    schedule_manager: Any = None,
+    workspaces: tuple[str, ...] = ("personal",),
+) -> CiaoControlPlane:
+    config = SimpleNamespace(workspace=lambda name: object() if name in workspaces else None)
     return CiaoControlPlane(
         config,
         project_chat_manager=pcm,
-        schedule_manager=SimpleNamespace(),
+        schedule_manager=SimpleNamespace() if schedule_manager is None else schedule_manager,
         loop_manager=SimpleNamespace(),
     )
+
+
+def _work_project_pcm() -> _ChatCreatePcm:
+    """A pcm holding a project in a non-Personal workspace, to prove inheritance."""
+    pcm = _ChatCreatePcm()
+    pcm.projects["project-work"] = SimpleNamespace(
+        project_id="project-work",
+        name="AI-NATIVE-SDK",
+        workspace="work",
+    )
+    return pcm
+
+
+def _schedule_control_plane(tmp_path: Path, pcm: _ChatCreatePcm) -> tuple[CiaoControlPlane, Any]:
+    """Control plane wired to a real ScheduleManager over a temp store."""
+    from ciao.schedules import ScheduleManager, ScheduleStore
+
+    schedules = ScheduleManager(store=ScheduleStore(tmp_path), dispatch_to_web=lambda *a, **k: None)
+    plane = _chat_create_control_plane(
+        pcm, schedule_manager=schedules, workspaces=("personal", "work")
+    )
+    return plane, schedules
 
 
 def _chat_create_principal(**overrides) -> McpPrincipal:
@@ -499,27 +527,7 @@ def test_schedule_create_resolves_project_by_name(tmp_path: Path) -> None:
 
 
 def test_schedule_create_defaults_to_callers_project_and_workspace(tmp_path: Path) -> None:
-    from ciao.schedules import ScheduleManager, ScheduleStore
-
-    pcm = _ChatCreatePcm()
-    pcm.projects["project-work"] = SimpleNamespace(
-        project_id="project-work",
-        name="AI-NATIVE-SDK",
-        workspace="work",
-    )
-    schedules = ScheduleManager(
-        store=ScheduleStore(tmp_path),
-        dispatch_to_web=lambda *a, **k: None,
-    )
-    config = SimpleNamespace(
-        workspace=lambda name: object() if name in {"personal", "work"} else None
-    )
-    control_plane = CiaoControlPlane(
-        config,
-        project_chat_manager=pcm,
-        schedule_manager=schedules,
-        loop_manager=SimpleNamespace(),
-    )
+    control_plane, schedules = _schedule_control_plane(tmp_path, _work_project_pcm())
     principal = _chat_create_principal(
         project_id="project-work",
         workspace="work",
@@ -543,29 +551,10 @@ def test_schedule_create_defaults_to_callers_project_and_workspace(tmp_path: Pat
 
 
 def test_schedule_create_with_chat_id_skips_project_default(tmp_path: Path) -> None:
-    from ciao.schedules import ScheduleManager, ScheduleStore
-
-    pcm = _ChatCreatePcm()
-    pcm.projects["project-work"] = SimpleNamespace(
-        project_id="project-work",
-        name="AI-NATIVE-SDK",
-        workspace="work",
-    )
+    pcm = _work_project_pcm()
     chat = SimpleNamespace(chat_id="chat-fixed", project_id="project-work")
     pcm.get_chat = lambda cid: chat if cid == "chat-fixed" else None  # type: ignore[method-assign]
-    schedules = ScheduleManager(
-        store=ScheduleStore(tmp_path),
-        dispatch_to_web=lambda *a, **k: None,
-    )
-    config = SimpleNamespace(
-        workspace=lambda name: object() if name in {"personal", "work"} else None
-    )
-    control_plane = CiaoControlPlane(
-        config,
-        project_chat_manager=pcm,
-        schedule_manager=schedules,
-        loop_manager=SimpleNamespace(),
-    )
+    control_plane, _schedules = _schedule_control_plane(tmp_path, pcm)
     principal = _chat_create_principal(
         project_id="project-work",
         workspace="work",

--- a/tests/test_pwa_api_docs.py
+++ b/tests/test_pwa_api_docs.py
@@ -10,6 +10,7 @@ from pathlib import Path
 BROWSER_OR_INTERNAL_ROUTES: dict[str, str] = {
     "/api/auth": "browser login flow; the recipe's auth step covers this",
     "/api/auth/logout": "browser logout; clears the session cookie",
+    "/api/auth/settings": "browser Settings auth form; enable/disable or change PWA password",
     "/api/setup/finish": "browser first-run setup handoff; writes local config and requests restart",
     "/api/setup/mkdir": "browser first-run setup folder picker; creates a local folder (bootstrap + localhost only)",
     "/api/projects/{project_id}/files": "browser multipart upload; agents edit vault files directly",
@@ -42,6 +43,7 @@ BROWSER_OR_INTERNAL_ROUTES: dict[str, str] = {
     "/api/integrations/gws/exchange": "browser GWS integration oauth token exchange",
     "/api/integrations/gws/disconnect": "browser GWS integration disconnect/removal",
     "/api/automation/backfill-insights": "browser Settings button to trigger insights backfill",
+    "/api/node/connect": "browser Settings host/client connect; tunnels this node to a remote host",
     "/api/node/demote": "node state management endpoint; demotes active node to standby",
     "/api/node/handover": "node state management endpoint; hands over active role to peer",
     "/api/node/peers": "node state management endpoint; registers or updates peer nodes",

--- a/web/README.md
+++ b/web/README.md
@@ -29,7 +29,8 @@ web/
     router.ts             routes: /login, /, /chat/:id, /project/:id, /schedules, /settings, /settings/:tab
     components/           one Vue SFC per feature pane (including CommandPaletteModal.vue and FileViewerModal.vue)
     stores/               Pinia stores (auth, projects, tasks, fileViewer)
-    lib/                  pure helpers (api, time, safeMarkdown, etc.)
+    composables/          reactive logic shared between components (useHoverPinPopover)
+    lib/                  pure helpers (api, time, safeMarkdown, etc.) — no Vue imports
 ```
 
 ## iOS PWA gotchas

--- a/web/src/components/ChatLayout.vue
+++ b/web/src/components/ChatLayout.vue
@@ -796,12 +796,14 @@ onBeforeUnmount(() => {
 
 .empty-actions {
   /* Mirror the jump-back-in tile grid so the new-chat buttons line up with
-     the cards (same 560px column, same auto-fill tracks and gap). */
+     the cards (same 560px column, same auto-fit tracks and gap). auto-fit
+     collapses empty tracks so a lone workspace button — or the last one on
+     an odd-count row — stretches full width. */
   width: 100%;
   max-width: 560px;
   margin: 0 auto;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 8px;
 }
 .empty-actions .btn-primary {

--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -141,7 +141,7 @@
 
     <!-- Messages + comment sidebar -->
     <div class="chat-with-sidebar">
-    <div class="messages" ref="messagesEl" data-tour="chat-messages" @click="handleHighlightClick">
+    <div class="messages" ref="messagesEl" data-tour="chat-messages" @click="handleHighlightClick" @mouseover="onChatHighlightHover" @mouseout="onChatHighlightHoverOut">
       <div class="messages-content">
       <template v-for="(item, i) in renderItems" :key="i">
         <!-- Reasoning trace: intermediate assistant text + tool calls grouped -->
@@ -504,6 +504,32 @@
           <span class="chat-comment-trigger-icon">💬</span>
           Comment
         </button>
+        <div
+          v-if="chatCommentPopover?.pinned && chatPopoverComment"
+          class="chat-comment-backdrop"
+          @click="closeChatCommentPopover()"
+        ></div>
+        <div
+          v-if="chatCommentPopover && chatPopoverComment"
+          class="chat-comment-pop"
+          :class="{ 'is-pinned': chatCommentPopover.pinned }"
+          :style="{ top: chatCommentPopover.top + 'px', left: chatCommentPopover.left + 'px' }"
+          @mousedown.stop
+          @mouseenter="onChatPopoverEnter"
+          @mouseleave="onChatPopoverLeave"
+        >
+          <div v-if="chatPopoverComment.images?.length" class="chat-sidebar-card-images">
+            <img
+              v-for="img in chatPopoverComment.images"
+              :key="img"
+              :src="`/api/images/${img}`"
+              :alt="img"
+              class="card-image-thumb"
+              @click.stop
+            />
+          </div>
+          <div class="chat-sidebar-card-note">{{ chatPopoverComment.comment }}</div>
+        </div>
       </Teleport>
       </div>
     </div>
@@ -1536,6 +1562,7 @@ function updateChatSelectionAnchorFromRange(range: Range): void {
 }
 
 function onChatScrollReanchor(): void {
+  if (chatCommentPopover.value) closeChatCommentPopover()
   if (commentDraft.value || !lastChatSelectionRange) return
   try {
     if (!lastChatSelectionRange.startContainer.isConnected) {
@@ -1597,6 +1624,7 @@ function onChatSelectionChange(): void {
 
 function openCommentForSelection(): void {
   if (!selectionAnchor.value || !lastChatSelectionText) return
+  closeChatCommentPopover()
   draftBubbleEl = lastChatSelectionBubble
   commentDraft.value = {
     selection: lastChatSelectionText,
@@ -1731,6 +1759,7 @@ function onEditChatCommentKeydown(e: KeyboardEvent, id: string): void {
   }
 }
 function deleteChatComment(id: string): void {
+  if (chatCommentPopover.value?.id === id) closeChatCommentPopover()
   store.removePendingChatComment(id)
   commentBubbleById.delete(id)
   if (editingChatCommentId.value === id) cancelEditChatComment()
@@ -1891,15 +1920,110 @@ function applyHighlights(): void {
   }
 }
 
-// ── Click sync between highlights and sidebar cards ──────────────────
+// ── Click / hover sync between highlights, read popover, and sidebar ──
+const chatCommentPopover = ref<{ id: string; top: number; left: number; pinned: boolean } | null>(null)
+const chatPopoverComment = computed(() =>
+  chatCommentPopover.value
+    ? store.pendingChatComments.find(c => c.id === chatCommentPopover.value!.id) ?? null
+    : null,
+)
+
+let chatHoverCloseTimer: ReturnType<typeof setTimeout> | null = null
+
+function clearChatHoverClose(): void {
+  if (chatHoverCloseTimer) {
+    clearTimeout(chatHoverCloseTimer)
+    chatHoverCloseTimer = null
+  }
+}
+
+function closeChatCommentPopover(): void {
+  clearChatHoverClose()
+  chatCommentPopover.value = null
+}
+
+function scheduleChatHoverClose(): void {
+  clearChatHoverClose()
+  chatHoverCloseTimer = setTimeout(() => {
+    chatHoverCloseTimer = null
+    if (chatCommentPopover.value && !chatCommentPopover.value.pinned) {
+      chatCommentPopover.value = null
+    }
+  }, 160)
+}
+
+function canChatHoverPreview(): boolean {
+  return typeof window !== 'undefined' && window.matchMedia('(hover: hover)').matches
+}
+
+function anchorChatPopoverFromElement(el: HTMLElement): { top: number; left: number } | null {
+  const rect = el.getBoundingClientRect()
+  const popWidth = 280
+  const pad = 8
+  const top = Math.min(Math.max(rect.bottom + 6, pad), Math.max(pad, window.innerHeight - 80))
+  const left = Math.min(Math.max(rect.left, pad), Math.max(pad, window.innerWidth - popWidth - pad))
+  return { top, left }
+}
+
+function showChatCommentPopover(id: string, el: HTMLElement, pinned: boolean): void {
+  if (id === DRAFT_COMMENT_ID) return
+  if (
+    !pinned
+    && chatCommentPopover.value?.pinned
+    && chatCommentPopover.value.id === id
+  ) {
+    clearChatHoverClose()
+    return
+  }
+  const anchor = anchorChatPopoverFromElement(el)
+  if (!anchor) return
+  clearChatHoverClose()
+  chatCommentPopover.value = { id, top: anchor.top, left: anchor.left, pinned }
+}
+
+function onChatHighlightHover(e: MouseEvent): void {
+  if (!canChatHoverPreview()) return
+  const target = e.target as HTMLElement | null
+  if (!target) return
+  const highlight = target.closest('.comment-highlight') as HTMLElement | null
+  if (!highlight) return
+  const id = highlight.dataset.commentId
+  if (!id || id === DRAFT_COMMENT_ID) return
+  const related = e.relatedTarget as Node | null
+  if (related && highlight.contains(related)) return
+  showChatCommentPopover(id, highlight, false)
+}
+
+function onChatHighlightHoverOut(e: MouseEvent): void {
+  if (!chatCommentPopover.value || chatCommentPopover.value.pinned) return
+  const target = e.target as HTMLElement | null
+  if (!target) return
+  const highlight = target.closest('.comment-highlight') as HTMLElement | null
+  if (!highlight) return
+  const related = e.relatedTarget as Node | null
+  if (related && highlight.contains(related)) return
+  scheduleChatHoverClose()
+}
+
+function onChatPopoverEnter(): void {
+  clearChatHoverClose()
+}
+
+function onChatPopoverLeave(): void {
+  if (chatCommentPopover.value && !chatCommentPopover.value.pinned) {
+    scheduleChatHoverClose()
+  }
+}
+
 function handleHighlightClick(e: MouseEvent): void {
   const target = e.target as HTMLElement | null
   if (!target) return
   const highlight = target.closest('.comment-highlight') as HTMLElement | null
   if (!highlight) return
   const id = highlight.dataset.commentId
-  if (!id) return
+  if (!id || id === DRAFT_COMMENT_ID) return
   e.stopPropagation()
+  showChatCommentPopover(id, highlight, true)
   scrollSidebarToCard(id)
 }
 
@@ -1985,6 +2109,7 @@ onMounted(async () => {
 })
 
 onBeforeUnmount(() => {
+  clearChatHoverClose()
   if (typeof document !== 'undefined') {
     document.removeEventListener('selectionchange', onChatSelectionChange)
   }
@@ -5040,6 +5165,35 @@ details[open] > .activity-summary::before {
 }
 .chat-comment-trigger:hover { filter: brightness(1.08); }
 .chat-comment-trigger-icon { font-size: var(--text-sm); line-height: 1; }
+
+.chat-comment-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: rgba(0, 0, 0, 0.32);
+}
+.chat-comment-pop {
+  position: fixed;
+  z-index: 41;
+  width: 280px;
+  max-width: calc(100vw - 16px);
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  border-left: 3px solid var(--accent, #60a5fa);
+  border-radius: 8px;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
+  padding: 10px 12px;
+  box-sizing: border-box;
+}
+.chat-comment-pop.is-pinned {
+  z-index: 42;
+}
+.chat-comment-pop .chat-sidebar-card-note {
+  margin: 0;
+}
+.chat-comment-pop .chat-sidebar-card-images {
+  margin-bottom: 8px;
+}
 
 .btn-sm {
   display: inline-flex;

--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -910,6 +910,7 @@ import { formatTime, formatDuration } from '../lib/time'
 import { buildTurnParts, collectTraceOutputs, formatTokenUsage, isAnswerBubble, traceSummaryMeta, traceSummaryMetaParts, type TraceOutput } from '../lib/chatActivity'
 import { buildForkSnapshot } from '../lib/chatFork'
 import { formatCommentLocation } from '../lib/commentContext'
+import { useHoverPinPopover } from '../composables/useHoverPinPopover'
 
 type RenderItem =
   | { kind: 'user'; msg: ChatMessage; turnIndex?: number }
@@ -1921,42 +1922,16 @@ function applyHighlights(): void {
 }
 
 // ── Click / hover sync between highlights, read popover, and sidebar ──
-const chatCommentPopover = ref<{ id: string; top: number; left: number; pinned: boolean } | null>(null)
-const chatPopoverComment = computed(() =>
-  chatCommentPopover.value
-    ? store.pendingChatComments.find(c => c.id === chatCommentPopover.value!.id) ?? null
-    : null,
-)
-
-let chatHoverCloseTimer: ReturnType<typeof setTimeout> | null = null
-
-function clearChatHoverClose(): void {
-  if (chatHoverCloseTimer) {
-    clearTimeout(chatHoverCloseTimer)
-    chatHoverCloseTimer = null
-  }
+// The draft highlight has no saved comment to preview, so it is never a target.
+function chatHighlightFromEvent(e: MouseEvent): HTMLElement | null {
+  const target = e.target as HTMLElement | null
+  const highlight = target?.closest('.comment-highlight') as HTMLElement | null
+  const id = highlight?.dataset.commentId
+  return highlight && id && id !== DRAFT_COMMENT_ID ? highlight : null
 }
 
-function closeChatCommentPopover(): void {
-  clearChatHoverClose()
-  chatCommentPopover.value = null
-}
-
-function scheduleChatHoverClose(): void {
-  clearChatHoverClose()
-  chatHoverCloseTimer = setTimeout(() => {
-    chatHoverCloseTimer = null
-    if (chatCommentPopover.value && !chatCommentPopover.value.pinned) {
-      chatCommentPopover.value = null
-    }
-  }, 160)
-}
-
-function canChatHoverPreview(): boolean {
-  return typeof window !== 'undefined' && window.matchMedia('(hover: hover)').matches
-}
-
-function anchorChatPopoverFromElement(el: HTMLElement): { top: number; left: number } | null {
+// Clamped to the viewport: the transcript popover is position: fixed.
+function anchorChatPopoverFromElement(el: HTMLElement): { top: number; left: number } {
   const rect = el.getBoundingClientRect()
   const popWidth = 280
   const pad = 8
@@ -1965,63 +1940,27 @@ function anchorChatPopoverFromElement(el: HTMLElement): { top: number; left: num
   return { top, left }
 }
 
-function showChatCommentPopover(id: string, el: HTMLElement, pinned: boolean): void {
-  if (id === DRAFT_COMMENT_ID) return
-  if (
-    !pinned
-    && chatCommentPopover.value?.pinned
-    && chatCommentPopover.value.id === id
-  ) {
-    clearChatHoverClose()
-    return
-  }
-  const anchor = anchorChatPopoverFromElement(el)
-  if (!anchor) return
-  clearChatHoverClose()
-  chatCommentPopover.value = { id, top: anchor.top, left: anchor.left, pinned }
-}
-
-function onChatHighlightHover(e: MouseEvent): void {
-  if (!canChatHoverPreview()) return
-  const target = e.target as HTMLElement | null
-  if (!target) return
-  const highlight = target.closest('.comment-highlight') as HTMLElement | null
-  if (!highlight) return
-  const id = highlight.dataset.commentId
-  if (!id || id === DRAFT_COMMENT_ID) return
-  const related = e.relatedTarget as Node | null
-  if (related && highlight.contains(related)) return
-  showChatCommentPopover(id, highlight, false)
-}
-
-function onChatHighlightHoverOut(e: MouseEvent): void {
-  if (!chatCommentPopover.value || chatCommentPopover.value.pinned) return
-  const target = e.target as HTMLElement | null
-  if (!target) return
-  const highlight = target.closest('.comment-highlight') as HTMLElement | null
-  if (!highlight) return
-  const related = e.relatedTarget as Node | null
-  if (related && highlight.contains(related)) return
-  scheduleChatHoverClose()
-}
-
-function onChatPopoverEnter(): void {
-  clearChatHoverClose()
-}
-
-function onChatPopoverLeave(): void {
-  if (chatCommentPopover.value && !chatCommentPopover.value.pinned) {
-    scheduleChatHoverClose()
-  }
-}
+const {
+  popover: chatCommentPopover,
+  comment: chatPopoverComment,
+  show: showChatCommentPopover,
+  close: closeChatCommentPopover,
+  clearPendingClose: clearChatHoverClose,
+  onTargetOver: onChatHighlightHover,
+  onTargetOut: onChatHighlightHoverOut,
+  onPopoverEnter: onChatPopoverEnter,
+  onPopoverLeave: onChatPopoverLeave,
+} = useHoverPinPopover({
+  resolveTarget: chatHighlightFromEvent,
+  anchorFor: anchorChatPopoverFromElement,
+  findComment: id => store.pendingChatComments.find(c => c.id === id) ?? null,
+  hasTargets: () => store.pendingChatComments.length > 0,
+})
 
 function handleHighlightClick(e: MouseEvent): void {
-  const target = e.target as HTMLElement | null
-  if (!target) return
-  const highlight = target.closest('.comment-highlight') as HTMLElement | null
-  if (!highlight) return
-  const id = highlight.dataset.commentId
-  if (!id || id === DRAFT_COMMENT_ID) return
+  const highlight = chatHighlightFromEvent(e)
+  const id = highlight?.dataset.commentId
+  if (!highlight || !id) return
   e.stopPropagation()
   showChatCommentPopover(id, highlight, true)
   scrollSidebarToCard(id)

--- a/web/src/components/HomeRecentChats.vue
+++ b/web/src/components/HomeRecentChats.vue
@@ -73,7 +73,9 @@ function workspaceOf(chat: ChatInfo): string {
 }
 .home-recent-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  /* auto-fit (not auto-fill): empty tracks collapse so a lone card — or the
+     last card on an odd-count row — stretches to the full column width. */
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 8px;
 }
 .home-recent-card {

--- a/web/src/components/PinnedFilePanel.vue
+++ b/web/src/components/PinnedFilePanel.vue
@@ -192,6 +192,8 @@
               ref="mdEl"
               v-html="renderedMarkdown"
               @click="onMdClick"
+              @mouseover="onHighlightHover"
+              @mouseout="onHighlightHoverOut"
             ></div>
             <CsvViewer
               v-else-if="isCsv"
@@ -207,6 +209,8 @@
               class="pfp-pre"
               ref="preEl"
               @click="onPreClick"
+              @mouseover="onHighlightHover"
+              @mouseout="onHighlightHoverOut"
             ><code ref="preCodeEl"><span
               v-for="(line, i) in contentLines"
               :key="i"
@@ -314,17 +318,20 @@
         </div>
       </div>
 
-      <!-- Read popover: click a highlight to see the note; edit opens the drawer. -->
+      <!-- Read popover: hover to preview, click to pin; edit opens the drawer. -->
       <div
-        v-if="commentPopover && popoverComment"
-        class="pfp-comment-backdrop"
-        @click="commentPopover = null"
+        v-if="commentPopover?.pinned && popoverComment"
+        class="pfp-comment-backdrop pfp-comment-backdrop--dim"
+        @click="closeCommentPopover()"
       ></div>
       <div
         v-if="commentPopover && popoverComment"
         class="pfp-comment-pop"
+        :class="{ 'is-pinned': commentPopover.pinned }"
         :style="{ top: commentPopover.top + 'px', left: commentPopover.left + 'px' }"
         @mousedown.stop
+        @mouseenter="onPopoverEnter"
+        @mouseleave="onPopoverLeave"
       >
         <div class="pfp-pop-header">
           <span class="pfp-sidebar-card-line" v-if="commentLineLabel(popoverComment)">{{ commentLineLabel(popoverComment) }}</span>
@@ -333,7 +340,6 @@
             <button class="pfp-sidebar-card-remove" @click.stop="deleteFromPopover(popoverComment.id)" title="Delete">×</button>
           </div>
         </div>
-        <div class="pfp-sidebar-card-quote">"{{ truncate(popoverComment.selection, 120) }}"</div>
         <div v-if="popoverComment.images?.length" class="pfp-sidebar-card-images">
           <img v-for="img in popoverComment.images" :key="img" :src="`/api/images/${img}`" :alt="img" class="card-image-thumb" @click.stop />
         </div>
@@ -768,14 +774,82 @@ const commentsForFile = computed(() =>
 
 // On-demand comment surfaces (replace the old fixed-width side column):
 //  - showCommentList: the drawer overlay listing every comment (header pill).
-//  - commentPopover: the read popover shown when a highlight/pin is clicked.
+//  - commentPopover: hover-preview / click-to-pin read popover on a highlight.
 const showCommentList = ref(false)
-const commentPopover = ref<{ id: string; top: number; left: number } | null>(null)
+const commentPopover = ref<{ id: string; top: number; left: number; pinned: boolean } | null>(null)
 const popoverComment = computed(() =>
   commentPopover.value
     ? commentsForFile.value.find(c => c.id === commentPopover.value!.id) ?? null
     : null,
 )
+
+let hoverCloseTimer: ReturnType<typeof setTimeout> | null = null
+
+function clearHoverClose(): void {
+  if (hoverCloseTimer) {
+    clearTimeout(hoverCloseTimer)
+    hoverCloseTimer = null
+  }
+}
+
+function closeCommentPopover(): void {
+  clearHoverClose()
+  commentPopover.value = null
+}
+
+function scheduleHoverClose(): void {
+  clearHoverClose()
+  hoverCloseTimer = setTimeout(() => {
+    hoverCloseTimer = null
+    if (commentPopover.value && !commentPopover.value.pinned) {
+      commentPopover.value = null
+    }
+  }, 160)
+}
+
+function canHoverPreview(): boolean {
+  return typeof window !== 'undefined' && window.matchMedia('(hover: hover)').matches
+}
+
+function highlightElFromEvent(e: MouseEvent): HTMLElement | null {
+  const target = e.target as HTMLElement | null
+  if (!target) return null
+  const hl = target.closest('.comment-highlight') as HTMLElement | null
+  if (hl?.dataset.commentId) return hl
+  const line = target.closest('.pre-line') as HTMLElement | null
+  if (line?.dataset.commentId) return line
+  return null
+}
+
+function onHighlightHover(e: MouseEvent): void {
+  if (!canHoverPreview()) return
+  const el = highlightElFromEvent(e)
+  if (!el) return
+  const id = el.dataset.commentId
+  if (!id) return
+  const related = e.relatedTarget as Node | null
+  if (related && el.contains(related)) return
+  showCommentPopover(id, el, false)
+}
+
+function onHighlightHoverOut(e: MouseEvent): void {
+  if (!commentPopover.value || commentPopover.value.pinned) return
+  const el = highlightElFromEvent(e)
+  if (!el) return
+  const related = e.relatedTarget as Node | null
+  if (related && el.contains(related)) return
+  scheduleHoverClose()
+}
+
+function onPopoverEnter(): void {
+  clearHoverClose()
+}
+
+function onPopoverLeave(): void {
+  if (commentPopover.value && !commentPopover.value.pinned) {
+    scheduleHoverClose()
+  }
+}
 
 function deleteFileComment(id: string): void {
   projectsStore.removeFileComment(cleanPath.value, id)
@@ -783,14 +857,14 @@ function deleteFileComment(id: string): void {
 }
 
 function deleteFromPopover(id: string): void {
-  commentPopover.value = null
+  closeCommentPopover()
   deleteFileComment(id)
 }
 
 // Edit lives in one place (the drawer). The read popover's Edit button opens
 // the drawer with that comment already in edit mode.
 function editFromPopover(c: { id: string; comment: string; images?: string[] }): void {
-  commentPopover.value = null
+  closeCommentPopover()
   showCommentList.value = true
   startEditComment(c)
   nextTick(() => scrollDrawerToCard(c.id))
@@ -974,7 +1048,7 @@ function onMdClick(e: MouseEvent): void {
   const highlight = target.closest('.comment-highlight') as HTMLElement | null
   if (!highlight) return
   const id = highlight.dataset.commentId
-  if (id) showCommentPopover(id, highlight)
+  if (id) showCommentPopover(id, highlight, true)
 }
 
 function onPreClick(e: MouseEvent): void {
@@ -983,7 +1057,7 @@ function onPreClick(e: MouseEvent): void {
   const line = target.closest('.pre-line') as HTMLElement | null
   if (!line) return
   const id = line.dataset.commentId
-  if (id) showCommentPopover(id, line)
+  if (id) showCommentPopover(id, line, true)
 }
 
 // Reapply highlights on content / comment changes.
@@ -1117,7 +1191,7 @@ function updateSelectionAnchorFromRange(range: Range): void {
 function onScrollReanchor(): void {
   // A read popover is pinned to a highlight's screen position, so scrolling
   // the document underneath it would leave it floating detached. Close it.
-  if (commentPopover.value) commentPopover.value = null
+  if (commentPopover.value) closeCommentPopover()
   if (commentDraft.value || !lastSelectionRange) return
   try {
     if (!lastSelectionRange.startContainer.isConnected) {
@@ -1172,7 +1246,7 @@ const editingCommentImages = ref<string[]>([])
 
 function openCommentForSelection(): void {
   if (!selectionAnchor.value || !lastSelectionText) return
-  commentPopover.value = null
+  closeCommentPopover()
   draftAnchor.value = selectionAnchor.value
   commentDraft.value = {
     selection: lastSelectionText,
@@ -1219,11 +1293,21 @@ function anchorFromElement(el: HTMLElement): Anchor | null {
   return { top, left }
 }
 
-function showCommentPopover(id: string, el: HTMLElement): void {
+function showCommentPopover(id: string, el: HTMLElement, pinned: boolean): void {
+  // Don't demote a pinned popover to hover-preview for the same comment.
+  if (
+    !pinned
+    && commentPopover.value?.pinned
+    && commentPopover.value.id === id
+  ) {
+    clearHoverClose()
+    return
+  }
   const anchor = anchorFromElement(el)
   if (!anchor) return
-  cancelEditComment()
-  commentPopover.value = { id, top: anchor.top, left: anchor.left }
+  clearHoverClose()
+  if (pinned) cancelEditComment()
+  commentPopover.value = { id, top: anchor.top, left: anchor.left, pinned }
 }
 
 function onCsvCellSelect(cell: CsvCellRef, rect: DOMRect): void {
@@ -1244,7 +1328,7 @@ function onCsvCellActivate(cell: CsvCellRef): void {
 
 function openCommentForCsvCell(): void {
   if (!selectionAnchor.value || !lastCsvCell) return
-  commentPopover.value = null
+  closeCommentPopover()
   draftAnchor.value = selectionAnchor.value
   commentDraft.value = {
     selection: lastCsvCell.value,
@@ -1407,6 +1491,7 @@ onMounted(() => {
   bodyEl.value?.addEventListener('scroll', onScrollReanchor, { passive: true })
 })
 onBeforeUnmount(() => {
+  clearHoverClose()
   if (typeof document !== 'undefined') {
     document.removeEventListener('selectionchange', onSelectionChange)
   }
@@ -1465,7 +1550,7 @@ watch(
     if (isStreaming) {
       cancelComment()
       editingCommentId.value = null
-      commentPopover.value = null
+      closeCommentPopover()
     } else {
       const justStoppedStreaming = wasStreaming && !isStreaming
       const justFlippedModified = !wasModified && isModified
@@ -1481,7 +1566,7 @@ watch(() => props.filePath, () => {
   selectionAnchor.value = null
   draftAnchor.value = null
   commentDraft.value = null
-  commentPopover.value = null
+  closeCommentPopover()
   showCommentList.value = false
   lastSelectionText = ''
   lastSelectionLines = null
@@ -1857,6 +1942,10 @@ watch(() => props.filePath, () => {
   z-index: 20;
   background: transparent;
 }
+.pfp-comment-backdrop--dim {
+  z-index: 31;
+  background: rgba(0, 0, 0, 0.32);
+}
 .pfp-comment-drawer {
   position: absolute;
   top: 0;
@@ -2123,12 +2212,16 @@ watch(() => props.filePath, () => {
   z-index: 32;
   width: 280px;
   max-width: calc(100% - 16px);
-  background: var(--bg2, rgba(20, 20, 40, 0.98));
-  border: 1px solid var(--border);
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  border-left: 3px solid var(--accent, #60a5fa);
   border-radius: 8px;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.32);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
   padding: 10px 12px;
   box-sizing: border-box;
+}
+.pfp-comment-pop.is-pinned {
+  z-index: 33;
 }
 .pfp-comment-compose { z-index: 33; }
 .pfp-pop-quote {

--- a/web/src/components/PinnedFilePanel.vue
+++ b/web/src/components/PinnedFilePanel.vue
@@ -372,6 +372,7 @@ import { buildMarkdownIndex, resolveWikilinkTarget } from '../lib/wikilinks'
 import { openWorkspaceFileExternally } from '../lib/openWorkspaceFile'
 import { isCsvPath } from '../lib/csv'
 import { formatCommentLocation } from '../lib/commentContext'
+import { useHoverPinPopover } from '../composables/useHoverPinPopover'
 import { api } from '../lib/api'
 import PaneHeader from './PaneHeader.vue'
 import { useFileViewerStore } from '../stores/fileViewer'
@@ -776,41 +777,8 @@ const commentsForFile = computed(() =>
 //  - showCommentList: the drawer overlay listing every comment (header pill).
 //  - commentPopover: hover-preview / click-to-pin read popover on a highlight.
 const showCommentList = ref(false)
-const commentPopover = ref<{ id: string; top: number; left: number; pinned: boolean } | null>(null)
-const popoverComment = computed(() =>
-  commentPopover.value
-    ? commentsForFile.value.find(c => c.id === commentPopover.value!.id) ?? null
-    : null,
-)
 
-let hoverCloseTimer: ReturnType<typeof setTimeout> | null = null
-
-function clearHoverClose(): void {
-  if (hoverCloseTimer) {
-    clearTimeout(hoverCloseTimer)
-    hoverCloseTimer = null
-  }
-}
-
-function closeCommentPopover(): void {
-  clearHoverClose()
-  commentPopover.value = null
-}
-
-function scheduleHoverClose(): void {
-  clearHoverClose()
-  hoverCloseTimer = setTimeout(() => {
-    hoverCloseTimer = null
-    if (commentPopover.value && !commentPopover.value.pinned) {
-      commentPopover.value = null
-    }
-  }, 160)
-}
-
-function canHoverPreview(): boolean {
-  return typeof window !== 'undefined' && window.matchMedia('(hover: hover)').matches
-}
-
+// A markdown highlight span, or a whole line in the plain-text viewer.
 function highlightElFromEvent(e: MouseEvent): HTMLElement | null {
   const target = e.target as HTMLElement | null
   if (!target) return null
@@ -821,35 +789,23 @@ function highlightElFromEvent(e: MouseEvent): HTMLElement | null {
   return null
 }
 
-function onHighlightHover(e: MouseEvent): void {
-  if (!canHoverPreview()) return
-  const el = highlightElFromEvent(e)
-  if (!el) return
-  const id = el.dataset.commentId
-  if (!id) return
-  const related = e.relatedTarget as Node | null
-  if (related && el.contains(related)) return
-  showCommentPopover(id, el, false)
-}
-
-function onHighlightHoverOut(e: MouseEvent): void {
-  if (!commentPopover.value || commentPopover.value.pinned) return
-  const el = highlightElFromEvent(e)
-  if (!el) return
-  const related = e.relatedTarget as Node | null
-  if (related && el.contains(related)) return
-  scheduleHoverClose()
-}
-
-function onPopoverEnter(): void {
-  clearHoverClose()
-}
-
-function onPopoverLeave(): void {
-  if (commentPopover.value && !commentPopover.value.pinned) {
-    scheduleHoverClose()
-  }
-}
+const {
+  popover: commentPopover,
+  comment: popoverComment,
+  show: showCommentPopover,
+  close: closeCommentPopover,
+  clearPendingClose: clearHoverClose,
+  onTargetOver: onHighlightHover,
+  onTargetOut: onHighlightHoverOut,
+  onPopoverEnter,
+  onPopoverLeave,
+} = useHoverPinPopover({
+  resolveTarget: highlightElFromEvent,
+  anchorFor: el => anchorFromElement(el),
+  findComment: id => commentsForFile.value.find(c => c.id === id) ?? null,
+  hasTargets: () => commentsForFile.value.length > 0,
+  onPin: () => cancelEditComment(),
+})
 
 function deleteFileComment(id: string): void {
   projectsStore.removeFileComment(cleanPath.value, id)
@@ -1291,23 +1247,6 @@ function anchorFromElement(el: HTMLElement): Anchor | null {
   const top = Math.min(Math.max(rect.bottom - mainRect.top + 6, pad), Math.max(pad, main.clientHeight - 60))
   const left = Math.min(Math.max(rect.left - mainRect.left, pad), Math.max(pad, main.clientWidth - popWidth - pad))
   return { top, left }
-}
-
-function showCommentPopover(id: string, el: HTMLElement, pinned: boolean): void {
-  // Don't demote a pinned popover to hover-preview for the same comment.
-  if (
-    !pinned
-    && commentPopover.value?.pinned
-    && commentPopover.value.id === id
-  ) {
-    clearHoverClose()
-    return
-  }
-  const anchor = anchorFromElement(el)
-  if (!anchor) return
-  clearHoverClose()
-  if (pinned) cancelEditComment()
-  commentPopover.value = { id, top: anchor.top, left: anchor.left, pinned }
 }
 
 function onCsvCellSelect(cell: CsvCellRef, rect: DOMRect): void {

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -126,27 +126,37 @@
           </div>
           <div v-if="!nodeStatus" class="action-row"><span class="loading">Loading node status&hellip;</span></div>
           <template v-else>
-            <div class="last-run-info">
-              <div class="detail-row">
-                <span class="detail-label">device</span>
-                <code class="detail-val">{{ nodeStatus.node_id }}</code>
+            <!-- Client: this device → host, with reachability on the link -->
+            <div v-if="isNodeClient" class="node-path" aria-label="Client connection">
+              <div class="node-path-endpoint">
+                <span class="node-path-label">this device</span>
+                <code class="node-path-value" :title="nodeStatus.node_id">{{ nodeStatus.node_id }}</code>
               </div>
-              <template v-if="isNodeClient">
-                <div class="detail-row">
-                  <span class="detail-label">connected to</span>
-                  <code class="detail-val">{{ connectedHostUrl || '—' }}</code>
-                </div>
-                <div v-if="nodeStatus.host_reachable != null" class="detail-row">
-                  <span class="detail-label">reachability</span>
-                  <span class="detail-val">{{ nodeStatus.host_reachable ? 'reachable' : 'unreachable' }}</span>
-                </div>
-              </template>
-              <template v-else>
-                <div v-if="nodeStatus.active_since" class="detail-row">
-                  <span class="detail-label">host since</span>
-                  <span class="detail-val">{{ nodeStatus.active_since }}</span>
-                </div>
-              </template>
+              <div class="node-path-link">
+                <span class="node-path-arrow" aria-hidden="true">→</span>
+                <span
+                  v-if="nodeStatus.host_reachable != null"
+                  class="node-path-status"
+                  :class="nodeStatus.host_reachable ? 'node-path-status--ok' : 'node-path-status--bad'"
+                >
+                  {{ nodeStatus.host_reachable ? 'reachable' : 'unreachable' }}
+                </span>
+              </div>
+              <div class="node-path-endpoint node-path-endpoint--host">
+                <span class="node-path-label">host</span>
+                <code class="node-path-value" :title="connectedHostUrl || undefined">{{ connectedHostUrl || '—' }}</code>
+              </div>
+            </div>
+            <!-- Host: local identity -->
+            <div v-else class="node-path node-path--solo">
+              <div class="node-path-endpoint">
+                <span class="node-path-label">this device</span>
+                <code class="node-path-value" :title="nodeStatus.node_id">{{ nodeStatus.node_id }}</code>
+              </div>
+              <div v-if="nodeStatus.active_since" class="node-path-meta">
+                <span class="node-path-label">host since</span>
+                <span class="node-path-value">{{ nodeStatus.active_since }}</span>
+              </div>
             </div>
             <div v-if="nodeActionResult" class="action-result" :class="{ 'action-result--error': nodeActionError }">
               {{ nodeActionResult }}
@@ -4722,6 +4732,98 @@ async function doPackageUpdate() {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.node-path {
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  margin-top: var(--space-1);
+}
+.node-path--solo {
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.node-path-endpoint {
+  flex: 1 1 140px;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+}
+.node-path-endpoint--host {
+  border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
+  background: color-mix(in srgb, var(--accent) 5%, var(--bg));
+}
+.node-path-label {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--fg3, var(--fg2));
+}
+.node-path-value {
+  color: var(--fg);
+  font-size: var(--text-sm);
+  font-family: var(--font);
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+.node-path-link {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 0 2px;
+  min-width: 72px;
+}
+.node-path-arrow {
+  color: var(--accent);
+  font-size: calc(18px * var(--font-scale));
+  font-weight: 700;
+  line-height: 1;
+}
+.node-path-status {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-align: center;
+  white-space: nowrap;
+}
+.node-path-status--ok {
+  color: var(--success);
+}
+.node-path-status--bad {
+  color: var(--warning);
+}
+.node-path-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 0 var(--space-1);
+}
+@container (max-width: 720px) {
+  .node-path:not(.node-path--solo) {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .node-path-link {
+    flex-direction: row;
+    justify-content: flex-start;
+    min-width: 0;
+    padding: 2px 0;
+    gap: var(--space-2);
+  }
+  .node-path:not(.node-path--solo) .node-path-arrow {
+    transform: rotate(90deg);
+  }
 }
 
 .node-peer-list {

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -126,34 +126,34 @@
           </div>
           <div v-if="!nodeStatus" class="action-row"><span class="loading">Loading node status&hellip;</span></div>
           <template v-else>
-            <!-- Client: this device → host, with reachability on the link -->
-            <div v-if="isNodeClient" class="node-path" aria-label="Client connection">
+            <!-- Client: this device → host, with reachability on the link.
+                 Host: this device alone, plus how long it has held the role. -->
+            <div
+              class="node-path"
+              :class="{ 'node-path--solo': !isNodeClient }"
+              :aria-label="isNodeClient ? 'Client connection' : 'Host identity'"
+            >
               <div class="node-path-endpoint">
                 <span class="node-path-label">this device</span>
                 <code class="node-path-value" :title="nodeStatus.node_id">{{ nodeStatus.node_id }}</code>
               </div>
-              <div class="node-path-link">
-                <span class="node-path-arrow" aria-hidden="true">→</span>
-                <span
-                  v-if="nodeStatus.host_reachable != null"
-                  class="node-path-status"
-                  :class="nodeStatus.host_reachable ? 'node-path-status--ok' : 'node-path-status--bad'"
-                >
-                  {{ nodeStatus.host_reachable ? 'reachable' : 'unreachable' }}
-                </span>
-              </div>
-              <div class="node-path-endpoint node-path-endpoint--host">
-                <span class="node-path-label">host</span>
-                <code class="node-path-value" :title="connectedHostUrl || undefined">{{ connectedHostUrl || '—' }}</code>
-              </div>
-            </div>
-            <!-- Host: local identity -->
-            <div v-else class="node-path node-path--solo">
-              <div class="node-path-endpoint">
-                <span class="node-path-label">this device</span>
-                <code class="node-path-value" :title="nodeStatus.node_id">{{ nodeStatus.node_id }}</code>
-              </div>
-              <div v-if="nodeStatus.active_since" class="node-path-meta">
+              <template v-if="isNodeClient">
+                <div class="node-path-link">
+                  <span class="node-path-arrow" aria-hidden="true">→</span>
+                  <span
+                    v-if="nodeStatus.host_reachable != null"
+                    class="badge"
+                    :class="nodeStatus.host_reachable ? 'badge--success' : 'badge--warn'"
+                  >
+                    {{ nodeStatus.host_reachable ? 'reachable' : 'unreachable' }}
+                  </span>
+                </div>
+                <div class="node-path-endpoint node-path-endpoint--host">
+                  <span class="node-path-label">host</span>
+                  <code class="node-path-value" :title="connectedHostUrl || undefined">{{ connectedHostUrl || '—' }}</code>
+                </div>
+              </template>
+              <div v-else-if="nodeStatus.active_since" class="node-path-meta">
                 <span class="node-path-label">host since</span>
                 <span class="node-path-value">{{ nodeStatus.active_since }}</span>
               </div>
@@ -4789,19 +4789,6 @@ async function doPackageUpdate() {
   font-size: calc(18px * var(--font-scale));
   font-weight: 700;
   line-height: 1;
-}
-.node-path-status {
-  font-size: var(--text-xs);
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  text-align: center;
-  white-space: nowrap;
-}
-.node-path-status--ok {
-  color: var(--success);
-}
-.node-path-status--bad {
-  color: var(--warning);
 }
 .node-path-meta {
   display: flex;

--- a/web/src/composables/useHoverPinPopover.ts
+++ b/web/src/composables/useHoverPinPopover.ts
@@ -1,0 +1,138 @@
+import { computed, ref, type ComputedRef, type Ref } from 'vue'
+
+// Shared hover-preview / click-to-pin read popover used by the chat transcript
+// (ChatPanel) and the pinned file viewer (PinnedFilePanel). Both surfaces show
+// the same thing on a commented element: preview it on hover, keep it open when
+// the pointer moves into the popover itself, and pin it on click until dismissed.
+// Only the element lookup and the clamp math differ, so those are injected.
+
+export type PopoverAnchor = { top: number; left: number }
+
+export type HoverPinPopover = {
+  id: string
+  top: number
+  left: number
+  pinned: boolean
+}
+
+export type HoverPinPopoverOptions<T> = {
+  /** Resolve the commented element under a pointer event, or null if there is none. */
+  resolveTarget: (event: MouseEvent) => HTMLElement | null
+  /** Position the popover for an anchor element. Return null to abort the open. */
+  anchorFor: (el: HTMLElement) => PopoverAnchor | null
+  /** Resolve the comment a popover id points at, for the `comment` computed. */
+  findComment: (id: string) => T | null
+  /**
+   * Cheap guard run before any DOM walk. Return false when the surface has no
+   * comments at all, so mouse movement over a plain transcript or file costs
+   * nothing. Defaults to always-true.
+   */
+  hasTargets?: () => boolean
+  /** Side effect when a popover gets pinned, e.g. closing an open editor. */
+  onPin?: () => void
+  /** Grace period before a hover-preview closes, in ms. */
+  closeDelayMs?: number
+}
+
+// One MediaQueryList for the app instead of one per pointer event.
+let hoverMedia: MediaQueryList | null | undefined
+function hoverCapable(): boolean {
+  if (typeof window === 'undefined') return false
+  if (hoverMedia === undefined) hoverMedia = window.matchMedia('(hover: hover)')
+  return hoverMedia?.matches ?? false
+}
+
+export function useHoverPinPopover<T>(options: HoverPinPopoverOptions<T>): {
+  popover: Ref<HoverPinPopover | null>
+  comment: ComputedRef<T | null>
+  show: (id: string, el: HTMLElement, pinned: boolean) => void
+  close: () => void
+  clearPendingClose: () => void
+  onTargetOver: (event: MouseEvent) => void
+  onTargetOut: (event: MouseEvent) => void
+  onPopoverEnter: () => void
+  onPopoverLeave: () => void
+} {
+  const closeDelayMs = options.closeDelayMs ?? 160
+  const popover = ref<HoverPinPopover | null>(null)
+  const comment = computed(() => (popover.value ? options.findComment(popover.value.id) : null))
+
+  let closeTimer: ReturnType<typeof setTimeout> | null = null
+
+  function clearPendingClose(): void {
+    if (closeTimer) {
+      clearTimeout(closeTimer)
+      closeTimer = null
+    }
+  }
+
+  function close(): void {
+    clearPendingClose()
+    popover.value = null
+  }
+
+  function scheduleClose(): void {
+    clearPendingClose()
+    closeTimer = setTimeout(() => {
+      closeTimer = null
+      if (popover.value && !popover.value.pinned) popover.value = null
+    }, closeDelayMs)
+  }
+
+  function show(id: string, el: HTMLElement, pinned: boolean): void {
+    // Don't demote an already-pinned popover to a hover preview.
+    if (!pinned && popover.value?.pinned && popover.value.id === id) {
+      clearPendingClose()
+      return
+    }
+    const anchor = options.anchorFor(el)
+    if (!anchor) return
+    clearPendingClose()
+    if (pinned) options.onPin?.()
+    popover.value = { id, top: anchor.top, left: anchor.left, pinned }
+  }
+
+  // Resolve the element for an event, ignoring moves that stay inside it.
+  function targetFor(event: MouseEvent): HTMLElement | null {
+    if (options.hasTargets && !options.hasTargets()) return null
+    const el = options.resolveTarget(event)
+    if (!el) return null
+    const related = event.relatedTarget as Node | null
+    if (related && el.contains(related)) return null
+    return el
+  }
+
+  function onTargetOver(event: MouseEvent): void {
+    if (!hoverCapable()) return
+    const el = targetFor(event)
+    const id = el?.dataset.commentId
+    if (!el || !id) return
+    show(id, el, false)
+  }
+
+  function onTargetOut(event: MouseEvent): void {
+    if (!popover.value || popover.value.pinned) return
+    if (!targetFor(event)) return
+    scheduleClose()
+  }
+
+  function onPopoverEnter(): void {
+    clearPendingClose()
+  }
+
+  function onPopoverLeave(): void {
+    if (popover.value && !popover.value.pinned) scheduleClose()
+  }
+
+  return {
+    popover,
+    comment,
+    show,
+    close,
+    clearPendingClose,
+    onTargetOver,
+    onTargetOut,
+    onPopoverEnter,
+    onPopoverLeave,
+  }
+}

--- a/web/src/stores/projects.test.ts
+++ b/web/src/stores/projects.test.ts
@@ -50,6 +50,18 @@ class FakeWebSocket {
   onclose: (() => void) | null = null
   onerror: (() => void) | null = null
 
+  // The store distinguishes a socket that completed its handshake from one
+  // rejected during it (auth 403 / origin reject), and only fast-reconnects
+  // the former. This fake connects instantly, so fire onopen as soon as the
+  // store attaches its handler; otherwise every simulated drop looks like a
+  // failed handshake and takes the slow backoff path.
+  #onopen: (() => void) | null = null
+  get onopen() { return this.#onopen }
+  set onopen(fn: (() => void) | null) {
+    this.#onopen = fn
+    fn?.()
+  }
+
   constructor(public url: string) {
     fakeSockets.push(this)
   }


### PR DESCRIPTION
## Summary
Combines the two closed PRs (#190, #191) plus parked UI stash work onto one clean branch off `develop`:

- **CI / docs (from #190):** clear the 6 mypy errors that were failing Ciao CI, and document `/api/auth/settings`, `/api/menubar-chats`, `/api/node/connect` so the PWA_API sync tests pass.
- **MCP context (from #191 / drafts):** schedule/loop creation inherits the caller's active project/workspace when `project_id` is omitted, with clearer chat_id resolution.
- **UI (from stashes):** hover-preview comment popovers that pin on click (`ChatPanel`, `PinnedFilePanel`), and a clearer this-device → host path in Settings.

## Test plan
- [x] `mypy ciao` clean
- [x] Focused MCP + PWA docs tests pass
- [x] `cd web && npm run build` succeeds
- [ ] Ciao CI green on this PR
- [ ] Mobile/desktop: hover preview then click-to-pin on file comments
- [ ] Settings: host vs client path reads correctly