### PR TITLE
Unify comment compose popover without selection quote

### DIFF
--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -514,44 +514,16 @@
           Comment
         </button>
 
-        <!-- Floating compose popover: anchored to selection -->
-        <div
-          v-if="commentDraft && draftAnchor"
-          class="chat-comment-pop chat-comment-compose"
-          :style="{ top: draftAnchor.top + 'px', left: draftAnchor.left + 'px' }"
-          @mousedown.stop
-        >
-          <div class="chat-pop-quote">"{{ truncate(commentDraft.selection, 120) }}"</div>
-          <textarea
-            ref="chatCommentInputEl"
-            v-model="commentDraft.text"
-            class="chat-sidebar-draft-input"
-            placeholder="Add a comment…"
-            rows="3"
-            @keydown="onChatCommentKeydown"
-          ></textarea>
-          <div v-if="commentDraftImages.length" class="chat-sidebar-draft-images">
-            <span v-for="(img, i) in commentDraftImages" :key="img" class="draft-image-preview">
-              <img :src="`/api/images/${img}`" :alt="img" class="draft-image-thumb" />
-              <button class="draft-image-remove" @click="removeDraftImage(i)" title="Remove">&times;</button>
-            </span>
-          </div>
-          <div class="chat-sidebar-draft-actions">
-            <label class="image-btn-sm" title="Upload images">
-              <input type="file" accept="image/*" multiple hidden @change="handleDraftImageUpload" />
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>
-            </label>
-            <button class="btn-sm" @click="cancelChatComment" type="button">Cancel</button>
-            <button
-              class="btn-sm primary"
-              :disabled="!commentDraft.text.trim()"
-              @click="saveChatComment"
-              type="button"
-            >Add comment</button>
-          </div>
-        </div>
-
       </Teleport>
+      <CommentComposePopover
+        :anchor="commentDraft && draftAnchor ? draftAnchor : null"
+        v-model="composeText"
+        :images="commentDraftImages"
+        @cancel="cancelChatComment"
+        @save="saveChatComment"
+        @upload="handleDraftImageUpload"
+        @remove-image="removeDraftImage"
+      />
       <!-- Read popover for a comment highlight. Owns its own state so hovering
            a highlight doesn't re-render the transcript; see the component. -->
       <ChatCommentPopover
@@ -905,6 +877,7 @@ import { buildTurnParts, collectTraceOutputs, formatTokenUsage, isAnswerBubble, 
 import { buildForkSnapshot } from '../lib/chatFork'
 import { formatCommentLocation } from '../lib/commentContext'
 import ChatCommentPopover from './ChatCommentPopover.vue'
+import CommentComposePopover from './CommentComposePopover.vue'
 
 type RenderItem =
   | { kind: 'user'; msg: ChatMessage; turnIndex?: number }
@@ -1502,13 +1475,18 @@ const selectionAnchor = ref<{ top: number; left: number } | null>(null)
 const draftAnchor = ref<{ top: number; left: number } | null>(null)
 const showCommentList = ref(false)
 const commentDraft = ref<ChatCommentDraft | null>(null)
-const chatCommentInputEl = ref<HTMLTextAreaElement>()
 const sidebarEditInputEl = ref<HTMLTextAreaElement>()
 const sidebarListEl = ref<HTMLElement>()
 const editingChatCommentId = ref<string | null>(null)
 const editingChatCommentText = ref('')
 const commentDraftImages = ref<string[]>([])
 const editingChatCommentImages = ref<string[]>([])
+const composeText = computed({
+  get: () => commentDraft.value?.text ?? '',
+  set: (v: string) => {
+    if (commentDraft.value) commentDraft.value.text = v
+  },
+})
 let lastChatSelectionText = ''
 let lastChatSelectionRange: Range | null = null
 // Bubble element the current selection originated in. Captured at selection
@@ -1631,10 +1609,7 @@ function openCommentForSelection(): void {
   selectionAnchor.value = null
   lastChatSelectionRange = null
   window.getSelection()?.removeAllRanges()
-  nextTick(() => {
-    chatCommentInputEl.value?.focus()
-    applyHighlights()
-  })
+  nextTick(() => applyHighlights())
 }
 
 function cancelChatComment(): void {
@@ -1681,18 +1656,6 @@ async function handleDraftImageUpload(e: Event): Promise<void> {
 
 function removeDraftImage(index: number): void {
   commentDraftImages.value.splice(index, 1)
-}
-
-function onChatCommentKeydown(e: KeyboardEvent): void {
-  if (e.key === 'Escape') {
-    e.preventDefault()
-    cancelChatComment()
-    return
-  }
-  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-    e.preventDefault()
-    saveChatComment()
-  }
 }
 
 // ── Edit / remove pending chat comments from the sidebar ─────────────
@@ -5089,19 +5052,6 @@ details[open] > .activity-summary::before {
   inset: 0;
   z-index: 40;
   background: rgba(0, 0, 0, 0.32);
-}
-.chat-comment-pop {
-  position: fixed;
-  z-index: 41;
-  width: 280px;
-  max-width: calc(100vw - 16px);
-  background: var(--bg);
-  border: 1px solid var(--border-strong);
-  border-left: 3px solid var(--accent, #60a5fa);
-  border-radius: 8px;
-  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
-  padding: 10px 12px;
-  box-sizing: border-box;
 }
 .btn-sm {
   display: inline-flex;

--- a/web/src/components/CommentComposePopover.vue
+++ b/web/src/components/CommentComposePopover.vue
@@ -1,0 +1,230 @@
+<template>
+  <Teleport to="body">
+    <div
+      v-if="anchor"
+      class="compose"
+      :style="{ top: anchor.top + 'px', left: anchor.left + 'px' }"
+      @mousedown.stop
+    >
+      <textarea
+        ref="inputEl"
+        :value="modelValue"
+        class="compose-input"
+        placeholder="Add a comment…"
+        rows="3"
+        @input="onInput"
+        @keydown="onKeydown"
+      ></textarea>
+      <div v-if="images.length" class="compose-images">
+        <span v-for="(img, i) in images" :key="img" class="compose-image">
+          <img :src="`/api/images/${img}`" :alt="img" class="compose-thumb" />
+          <button
+            class="compose-image-remove"
+            @click="emit('removeImage', i)"
+            title="Remove"
+            type="button"
+          >&times;</button>
+        </span>
+      </div>
+      <div class="compose-actions">
+        <label class="compose-attach" title="Upload images">
+          <input type="file" accept="image/*" multiple hidden @change="onUpload" />
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>
+        </label>
+        <button class="compose-btn" @click="emit('cancel')" type="button">Cancel</button>
+        <button
+          class="compose-btn primary"
+          :disabled="!modelValue.trim()"
+          @click="emit('save')"
+          type="button"
+        >Add comment</button>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+// Shared floating compose popover for selection comments.
+// Used by ChatPanel, FileViewerModal, and PinnedFilePanel so the UI stays
+// identical. Anchor is viewport-fixed (Teleport to body). The selection quote
+// is intentionally omitted — the highlight already shows what was selected.
+import { computed, nextTick, ref, watch } from 'vue'
+
+export type ComposeAnchor = { top: number; left: number }
+
+const props = withDefaults(defineProps<{
+  anchor: ComposeAnchor | null
+  modelValue: string
+  images?: string[]
+}>(), {
+  images: () => [],
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+  cancel: []
+  save: []
+  upload: [event: Event]
+  removeImage: [index: number]
+}>()
+
+const images = computed(() => props.images ?? [])
+const inputEl = ref<HTMLTextAreaElement>()
+
+function onInput(e: Event): void {
+  emit('update:modelValue', (e.target as HTMLTextAreaElement).value)
+}
+
+function onUpload(e: Event): void {
+  emit('upload', e)
+}
+
+function onKeydown(e: KeyboardEvent): void {
+  if (e.key === 'Escape') {
+    e.preventDefault()
+    emit('cancel')
+    return
+  }
+  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+    e.preventDefault()
+    emit('save')
+  }
+}
+
+function focus(): void {
+  nextTick(() => inputEl.value?.focus())
+}
+
+watch(
+  () => props.anchor,
+  (a) => {
+    if (a) focus()
+  },
+)
+
+defineExpose({ focus })
+</script>
+
+<style scoped>
+.compose {
+  position: fixed;
+  z-index: 41;
+  width: 280px;
+  max-width: calc(100vw - 16px);
+  background: var(--bg);
+  border: 1px solid var(--border-strong);
+  border-left: 3px solid var(--accent, #60a5fa);
+  border-radius: 8px;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
+  padding: 10px 12px;
+  box-sizing: border-box;
+}
+.compose-input {
+  width: 100%;
+  resize: vertical;
+  min-height: 60px;
+  font-family: inherit;
+  font-size: var(--text-base);
+  line-height: 1.45;
+  color: var(--fg);
+  background: var(--bg2, rgba(255, 255, 255, 0.04));
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  box-sizing: border-box;
+}
+.compose-input:focus {
+  outline: none;
+  border-color: var(--accent, #60a5fa);
+}
+.compose-images {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 8px 0;
+}
+.compose-image {
+  position: relative;
+  display: inline-flex;
+}
+.compose-thumb {
+  height: 40px;
+  width: 40px;
+  object-fit: cover;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+}
+.compose-image-remove {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: var(--fg);
+  color: var(--bg);
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+}
+.compose-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+}
+.compose-attach {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--fg2);
+  margin-right: auto;
+}
+.compose-attach:hover {
+  background: var(--bg3);
+  color: var(--fg);
+  border-color: var(--fg2);
+}
+.compose-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--fg);
+  cursor: pointer;
+}
+.compose-btn:hover {
+  background: var(--bg2, rgba(255, 255, 255, 0.04));
+}
+.compose-btn.primary {
+  background: var(--accent, #60a5fa);
+  border-color: var(--accent, #60a5fa);
+  color: var(--bg);
+}
+.compose-btn.primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media (max-width: 640px) {
+  .compose {
+    left: 8px !important;
+    right: 8px;
+    width: auto;
+    max-width: none;
+  }
+}
+</style>

--- a/web/src/components/FileViewerModal.vue
+++ b/web/src/components/FileViewerModal.vue
@@ -396,42 +396,15 @@
           </div>
         </div>
 
-        <!-- Floating compose popover: anchored at selection -->
-        <div
-          v-if="commentDraft && draftAnchor"
-          class="fv-comment-pop fv-comment-compose"
-          :style="{ top: draftAnchor.top + 'px', left: draftAnchor.left + 'px' }"
-          @mousedown.stop
-        >
-          <div class="fv-pop-quote">"{{ truncate(commentDraft.selection, 120) }}"</div>
-          <textarea
-            ref="commentInputEl"
-            v-model="commentDraft.text"
-            class="fv-sidebar-draft-input"
-            placeholder="Add a comment…"
-            rows="3"
-            @keydown="onCommentKeydown"
-          ></textarea>
-          <div v-if="commentDraftImages.length" class="fv-sidebar-draft-images">
-            <span v-for="(img, i) in commentDraftImages" :key="img" class="draft-image-preview">
-              <img :src="`/api/images/${img}`" :alt="img" class="draft-image-thumb" />
-              <button class="draft-image-remove" @click="removeDraftImage(i)" title="Remove">×</button>
-            </span>
-          </div>
-          <div class="fv-sidebar-draft-actions">
-            <label class="image-btn-sm" title="Upload images">
-              <input type="file" accept="image/*" multiple hidden @change="handleDraftImageUpload" />
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>
-            </label>
-            <button class="fv-btn-sm" @click="cancelComment" type="button">Cancel</button>
-            <button
-              class="fv-btn-sm primary"
-              :disabled="!commentDraft.text.trim()"
-              @click="saveComment"
-              type="button"
-            >Add comment</button>
-          </div>
-        </div>
+        <CommentComposePopover
+          :anchor="commentDraft && draftAnchor ? draftAnchor : null"
+          v-model="composeText"
+          :images="commentDraftImages"
+          @cancel="cancelComment"
+          @save="saveComment"
+          @upload="handleDraftImageUpload"
+          @remove-image="removeDraftImage"
+        />
 
         <!-- Floating "Comment" button anchored near the active selection. -->
         <button
@@ -485,6 +458,7 @@ import { openWorkspaceFileExternally } from '../lib/openWorkspaceFile'
 import { createTerminalDiffLines, terminalDiffPrefix, type TerminalDiffKind } from '../lib/terminalDiff'
 import { isCsvPath } from '../lib/csv'
 import { formatCommentLocation } from '../lib/commentContext'
+import CommentComposePopover from './CommentComposePopover.vue'
 const ExcalidrawViewer = defineAsyncComponent(() => import('./ExcalidrawViewer.vue'))
 const CsvViewer = defineAsyncComponent(() => import('./CsvViewer.vue'))
 import type { CsvCellComment, CsvCellRef } from './CsvViewer.vue'
@@ -1181,8 +1155,13 @@ type CommentDraft = {
 }
 const selectionAnchor = ref<Anchor | null>(null)
 const draftAnchor = ref<Anchor | null>(null)
-const commentInputEl = ref<HTMLTextAreaElement>()
 const commentDraft = ref<CommentDraft | null>(null)
+const composeText = computed({
+  get: () => commentDraft.value?.text ?? '',
+  set: (v: string) => {
+    if (commentDraft.value) commentDraft.value.text = v
+  },
+})
 let lastSelectionText = ''
 let lastSelectionLines: LineRange = null
 let lastSelectionRange: Range | null = null
@@ -1483,9 +1462,22 @@ function onSelectionChange(): void {
 const commentDraftImages = ref<string[]>([])
 const editingCommentImages = ref<string[]>([])
 
+/** Convert a modal-relative anchor to viewport coords for the shared compose popover. */
+function toViewportAnchor(local: Anchor): Anchor {
+  const modal = modalEl.value
+  if (!modal) return local
+  const r = modal.getBoundingClientRect()
+  const popWidth = 280
+  const pad = 8
+  return {
+    top: Math.min(Math.max(r.top + local.top, pad), Math.max(pad, window.innerHeight - 120)),
+    left: Math.min(Math.max(r.left + local.left, pad), Math.max(pad, window.innerWidth - popWidth - pad)),
+  }
+}
+
 function openCommentForSelection(): void {
   if (!selectionAnchor.value || !lastSelectionText) return
-  draftAnchor.value = selectionAnchor.value
+  draftAnchor.value = toViewportAnchor(selectionAnchor.value)
   commentDraft.value = {
     selection: lastSelectionText,
     anchor: selectionAnchor.value,
@@ -1498,7 +1490,6 @@ function openCommentForSelection(): void {
   lastSelectionRange = null
   lastCsvCell = null
   window.getSelection()?.removeAllRanges()
-  nextTick(() => commentInputEl.value?.focus())
 }
 
 function anchorFromCellRect(rect: DOMRect): Anchor | null {
@@ -1535,7 +1526,7 @@ function onCsvCellActivate(cell: CsvCellRef): void {
 
 function openCommentForCsvCell(): void {
   if (!selectionAnchor.value || !lastCsvCell) return
-  draftAnchor.value = selectionAnchor.value
+  draftAnchor.value = toViewportAnchor(selectionAnchor.value)
   commentDraft.value = {
     selection: lastCsvCell.value,
     anchor: selectionAnchor.value,
@@ -1550,7 +1541,6 @@ function openCommentForCsvCell(): void {
   commentDraftImages.value = []
   selectionAnchor.value = null
   lastSelectionRange = null
-  nextTick(() => commentInputEl.value?.focus())
 }
 
 function cancelComment(): void {
@@ -1603,19 +1593,6 @@ async function handleDraftImageUpload(e: Event): Promise<void> {
 
 function removeDraftImage(index: number): void {
   commentDraftImages.value.splice(index, 1)
-}
-
-function onCommentKeydown(e: KeyboardEvent): void {
-  if (e.key === 'Escape') {
-    e.preventDefault()
-    cancelComment()
-    return
-  }
-  // Cmd/Ctrl+Enter saves — handy when the textarea has multi-line content.
-  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-    e.preventDefault()
-    saveComment()
-  }
 }
 
 // ── Edit existing comment ────────────────────────────────────────────
@@ -2550,14 +2527,6 @@ if (typeof window !== 'undefined') {
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.32);
   padding: 10px 12px;
   box-sizing: border-box;
-}
-.fv-comment-compose { z-index: 33; }
-.fv-pop-quote {
-  color: var(--fg2);
-  font-style: italic;
-  margin-bottom: 8px;
-  word-break: break-word;
-  font-size: var(--text-sm);
 }
 .fv-pop-header {
   display: flex;

--- a/web/src/components/PinnedFilePanel.vue
+++ b/web/src/components/PinnedFilePanel.vue
@@ -281,42 +281,15 @@
         </div>
       </div>
 
-      <!-- Compose popover: anchored at the selection, where you type the note. -->
-      <div
-        v-if="commentDraft && draftAnchor"
-        class="pfp-comment-pop pfp-comment-compose"
-        :style="{ top: draftAnchor.top + 'px', left: draftAnchor.left + 'px' }"
-        @mousedown.stop
-      >
-        <div class="pfp-pop-quote">"{{ truncate(commentDraft.selection, 120) }}"</div>
-        <textarea
-          ref="commentInputEl"
-          v-model="commentDraft.text"
-          class="pfp-sidebar-draft-input"
-          placeholder="Add a comment…"
-          rows="3"
-          @keydown="onCommentKeydown"
-        ></textarea>
-        <div v-if="commentDraftImages.length" class="pfp-sidebar-draft-images">
-          <span v-for="(img, i) in commentDraftImages" :key="img" class="draft-image-preview">
-            <img :src="`/api/images/${img}`" :alt="img" class="draft-image-thumb" />
-            <button class="draft-image-remove" @click="removeDraftImage(i)" title="Remove">×</button>
-          </span>
-        </div>
-        <div class="pfp-sidebar-draft-actions">
-          <label class="image-btn-sm" title="Upload images">
-            <input type="file" accept="image/*" multiple hidden @change="handleDraftImageUpload" />
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>
-          </label>
-          <button class="pfp-btn-sm" @click="cancelComment" type="button">Cancel</button>
-          <button
-            class="pfp-btn-sm primary"
-            :disabled="!commentDraft.text.trim()"
-            @click="saveComment"
-            type="button"
-          >Add comment</button>
-        </div>
-      </div>
+      <CommentComposePopover
+        :anchor="commentDraft && draftAnchor ? draftAnchor : null"
+        v-model="composeText"
+        :images="commentDraftImages"
+        @cancel="cancelComment"
+        @save="saveComment"
+        @upload="handleDraftImageUpload"
+        @remove-image="removeDraftImage"
+      />
 
       <!-- Read popover: hover to preview, click to pin; edit opens the drawer. -->
       <div
@@ -374,6 +347,7 @@ import { formatCommentLocation } from '../lib/commentContext'
 import { useHoverPinPopover } from '../composables/useHoverPinPopover'
 import { api } from '../lib/api'
 import PaneHeader from './PaneHeader.vue'
+import CommentComposePopover from './CommentComposePopover.vue'
 import { useFileViewerStore } from '../stores/fileViewer'
 const ExcalidrawViewer = defineAsyncComponent(() => import('./ExcalidrawViewer.vue'))
 const CsvViewer = defineAsyncComponent(() => import('./CsvViewer.vue'))
@@ -452,7 +426,6 @@ const bodyEl = ref<HTMLElement>()
 const mdEl = ref<HTMLElement>()
 const preEl = ref<HTMLElement>()
 const preCodeEl = ref<HTMLElement>()
-const commentInputEl = ref<HTMLTextAreaElement>()
 
 const cleanPath = computed(() => props.filePath.replace(/:\d+$/, ''))
 const basename = computed(() => {
@@ -1037,6 +1010,12 @@ const selectionAnchor = ref<Anchor | null>(null)
 // draft opens (so it stays put even after the selection is cleared).
 const draftAnchor = ref<Anchor | null>(null)
 const commentDraft = ref<CommentDraft | null>(null)
+const composeText = computed({
+  get: () => commentDraft.value?.text ?? '',
+  set: (v: string) => {
+    if (commentDraft.value) commentDraft.value.text = v
+  },
+})
 let lastSelectionText = ''
 let lastSelectionLines: LineRange = null
 let lastSelectionRange: Range | null = null
@@ -1199,10 +1178,23 @@ function onSelectionChange(): void {
 const commentDraftImages = ref<string[]>([])
 const editingCommentImages = ref<string[]>([])
 
+/** Convert a panel-relative anchor to viewport coords for the shared compose popover. */
+function toViewportAnchor(local: Anchor): Anchor {
+  const main = mainEl.value
+  if (!main) return local
+  const r = main.getBoundingClientRect()
+  const popWidth = 280
+  const pad = 8
+  return {
+    top: Math.min(Math.max(r.top + local.top, pad), Math.max(pad, window.innerHeight - 120)),
+    left: Math.min(Math.max(r.left + local.left, pad), Math.max(pad, window.innerWidth - popWidth - pad)),
+  }
+}
+
 function openCommentForSelection(): void {
   if (!selectionAnchor.value || !lastSelectionText) return
   closeCommentPopover()
-  draftAnchor.value = selectionAnchor.value
+  draftAnchor.value = toViewportAnchor(selectionAnchor.value)
   commentDraft.value = {
     selection: lastSelectionText,
     text: '',
@@ -1214,7 +1206,6 @@ function openCommentForSelection(): void {
   lastSelectionRange = null
   lastCsvCell = null
   window.getSelection()?.removeAllRanges()
-  nextTick(() => commentInputEl.value?.focus())
 }
 
 function anchorFromCellRect(rect: DOMRect): Anchor | null {
@@ -1267,7 +1258,7 @@ function onCsvCellActivate(cell: CsvCellRef): void {
 function openCommentForCsvCell(): void {
   if (!selectionAnchor.value || !lastCsvCell) return
   closeCommentPopover()
-  draftAnchor.value = selectionAnchor.value
+  draftAnchor.value = toViewportAnchor(selectionAnchor.value)
   commentDraft.value = {
     selection: lastCsvCell.value,
     text: '',
@@ -1281,7 +1272,6 @@ function openCommentForCsvCell(): void {
   commentDraftImages.value = []
   selectionAnchor.value = null
   lastSelectionRange = null
-  nextTick(() => commentInputEl.value?.focus())
 }
 
 function cancelComment(): void {
@@ -1333,18 +1323,6 @@ async function handleDraftImageUpload(e: Event): Promise<void> {
 
 function removeDraftImage(index: number): void {
   commentDraftImages.value.splice(index, 1)
-}
-
-function onCommentKeydown(e: KeyboardEvent): void {
-  if (e.key === 'Escape') {
-    e.preventDefault()
-    cancelComment()
-    return
-  }
-  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-    e.preventDefault()
-    saveComment()
-  }
 }
 
 // ── Edit existing comment ────────────────────────────────────────────
@@ -2157,14 +2135,6 @@ watch(() => props.filePath, () => {
   box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
   padding: 10px 12px;
   box-sizing: border-box;
-}
-.pfp-comment-compose { z-index: 33; }
-.pfp-pop-quote {
-  color: var(--fg2);
-  font-style: italic;
-  margin-bottom: 8px;
-  word-break: break-word;
-  font-size: var(--text-sm);
 }
 .pfp-pop-header {
   display: flex;

--- a/web/src/components/__tests__/commentComposePopover.test.ts
+++ b/web/src/components/__tests__/commentComposePopover.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import CommentComposePopover from '../CommentComposePopover.vue'
+
+describe('CommentComposePopover', () => {
+  it('renders without a selection quote', async () => {
+    const wrapper = mount(CommentComposePopover, {
+      props: {
+        anchor: { top: 40, left: 80 },
+        modelValue: 'I did, close',
+        images: [],
+      },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    expect(document.body.textContent).toContain('Add comment')
+    expect(document.body.textContent).toContain('Cancel')
+    expect(document.body.textContent).not.toMatch(/^"/)
+    expect(document.body.querySelector('.compose-input')).not.toBeNull()
+    wrapper.unmount()
+  })
+
+  it('emits save on Cmd+Enter and cancel on Escape', async () => {
+    const wrapper = mount(CommentComposePopover, {
+      props: {
+        anchor: { top: 10, left: 10 },
+        modelValue: 'note',
+      },
+      attachTo: document.body,
+    })
+    await nextTick()
+
+    const input = document.body.querySelector('.compose-input') as HTMLTextAreaElement
+    await input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', metaKey: true, bubbles: true }))
+    expect(wrapper.emitted('save')).toBeTruthy()
+
+    await input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    expect(wrapper.emitted('cancel')).toBeTruthy()
+    wrapper.unmount()
+  })
+
+  it('does not render when anchor is null', async () => {
+    const wrapper = mount(CommentComposePopover, {
+      props: { anchor: null, modelValue: '' },
+      attachTo: document.body,
+    })
+    await nextTick()
+    expect(document.body.querySelector('.compose')).toBeNull()
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Summary
- Extract a shared `CommentComposePopover` used by chat, file viewer, and pinned file
- Drop the redundant selection quote from the compose UI (highlight already shows context)
- Keep quoted selection in agent context; only the UI echo is removed

## Test plan
- [ ] Select text in a chat message → Comment → compose popover has no quote above the textarea
- [ ] Same flow in file viewer and pinned file panel
- [ ] Cancel, Escape, Cmd/Ctrl+Enter, image attach/remove still work
- [ ] Saved comments still send selection context to the agent
- [ ] `cd web && npx vitest run src/components/__tests__/commentComposePopover.test.ts`


Made with [Cursor](https://cursor.com)