### PR TITLE
Release v0.6.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -162,7 +162,7 @@ jobs:
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' /Applications/Ciaobot.app/Contents/Info.plist)" = "local.ciaobot.app"
           version="${VERSION#v}"
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' /Applications/Ciaobot.app/Contents/Info.plist)" = "$version"
-          open -a Ciaobot --args --background
+          open /Applications/Ciaobot.app --args --background
           for _ in {1..30}; do
             pgrep -x ciaobot-desktop >/dev/null && break
             sleep 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.6.2 - 2026-07-29
+
+### Fixed
+- fix: launch installed app directly in release smoke (`ed47745`)
+
 ## v0.6.1 - 2026-07-29
 
 ### Fixed

--- a/ciao/__init__.py
+++ b/ciao/__init__.py
@@ -8,7 +8,7 @@ __all__ = ["__version__"]
 # (ciao/release.py matches ``^__version__ = "..."``). When the package is
 # installed the real distribution version overrides it below; the literal is
 # the fallback for running straight from a source checkout.
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 try:
     __version__ = version("ciaobot")
 except PackageNotFoundError:

--- a/ciao/web/static/sw.js
+++ b/ciao/web/static/sw.js
@@ -1,8 +1,8 @@
-const CACHE_NAME = 'ciaobot-v0.6.1'
+const CACHE_NAME = 'ciaobot-v0.6.2'
 const STATIC_ASSETS = ['/', '/index.html', '/manifest.json']
 const ICON = '/icons/icon-192.png'
 const BADGE = '/icons/icon-192.png'
-const UNREAD_CACHE = 'ciaobot-unread-v0.6.1'
+const UNREAD_CACHE = 'ciaobot-unread-v0.6.2'
 const UNREAD_KEY = '/__unread__'
 
 self.addEventListener('install', (event) => {

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-desktop",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-desktop",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dependencies": {
         "@tauri-apps/api": "2.11.1"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-desktop",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "engines": {
     "node": "22.x"

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "ciaobot-desktop"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "block2",
  "chrono",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciaobot-desktop"
-version = "0.6.1"
+version = "0.6.2"
 description = "Native macOS shell for Ciaobot"
 edition = "2024"
 rust-version = "1.90"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ciaobot",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "local.ciaobot.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciaobot"
-version = "0.6.1"
+version = "0.6.2"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-pwa",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-pwa",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
         "dompurify": "^3.4.12",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-pwa",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,8 +1,8 @@
-const CACHE_NAME = 'ciaobot-v0.6.1'
+const CACHE_NAME = 'ciaobot-v0.6.2'
 const STATIC_ASSETS = ['/', '/index.html', '/manifest.json']
 const ICON = '/icons/icon-192.png'
 const BADGE = '/icons/icon-192.png'
-const UNREAD_CACHE = 'ciaobot-unread-v0.6.1'
+const UNREAD_CACHE = 'ciaobot-unread-v0.6.2'
 const UNREAD_KEY = '/__unread__'
 
 self.addEventListener('install', (event) => {


### PR DESCRIPTION
## Summary
- launch the Homebrew-installed app by its absolute bundle path in release smoke
- bump engine, PWA, desktop, and updater cache versions to 0.6.2

## Verification
- pytest tests/ (1636 passed, 1 skipped)
- web production build
- frontend tests (248 passed; 13 documented localStorage baseline failures)
- desktop production build
- isolated package smoke for ciaobot 0.6.2
- Cargo verification delegated to PR CI because the local Rust toolchain is unavailable