### PR TITLE
Release v0.6.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -162,6 +162,7 @@ jobs:
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' /Applications/Ciaobot.app/Contents/Info.plist)" = "local.ciaobot.app"
           version="${VERSION#v}"
           test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' /Applications/Ciaobot.app/Contents/Info.plist)" = "$version"
+          ciao setup --workspace "${RUNNER_TEMP}/ciaobot-workspace" --app-dir "${RUNNER_TEMP}/ciaobot-apps"
           open -g /Applications/Ciaobot.app --args --background >"${RUNNER_TEMP}/ciaobot-open.log" 2>&1 &
           for _ in {1..30}; do
             pgrep -x ciaobot-desktop >/dev/null && break

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.6.4 - 2026-07-29
+
+### Fixed
+- fix: configure smoke workspace before app launch (`8623999`)
+
 ## v0.6.3 - 2026-07-29
 
 ### Fixed

--- a/ciao/__init__.py
+++ b/ciao/__init__.py
@@ -8,7 +8,7 @@ __all__ = ["__version__"]
 # (ciao/release.py matches ``^__version__ = "..."``). When the package is
 # installed the real distribution version overrides it below; the literal is
 # the fallback for running straight from a source checkout.
-__version__ = "0.6.3"
+__version__ = "0.6.4"
 try:
     __version__ = version("ciaobot")
 except PackageNotFoundError:

--- a/ciao/web/static/sw.js
+++ b/ciao/web/static/sw.js
@@ -1,8 +1,8 @@
-const CACHE_NAME = 'ciaobot-v0.6.3'
+const CACHE_NAME = 'ciaobot-v0.6.4'
 const STATIC_ASSETS = ['/', '/index.html', '/manifest.json']
 const ICON = '/icons/icon-192.png'
 const BADGE = '/icons/icon-192.png'
-const UNREAD_CACHE = 'ciaobot-unread-v0.6.3'
+const UNREAD_CACHE = 'ciaobot-unread-v0.6.4'
 const UNREAD_KEY = '/__unread__'
 
 self.addEventListener('install', (event) => {

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-desktop",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-desktop",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "dependencies": {
         "@tauri-apps/api": "2.11.1"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-desktop",
   "private": true,
-  "version": "0.6.3",
+  "version": "0.6.4",
   "type": "module",
   "engines": {
     "node": "22.x"

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "ciaobot-desktop"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "block2",
  "chrono",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciaobot-desktop"
-version = "0.6.3"
+version = "0.6.4"
 description = "Native macOS shell for Ciaobot"
 edition = "2024"
 rust-version = "1.90"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Ciaobot",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "identifier": "local.ciaobot.app",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ciaobot"
-version = "0.6.3"
+version = "0.6.4"
 description = "Ciaobot personal assistant server."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ciaobot-pwa",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ciaobot-pwa",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "dependencies": {
         "@excalidraw/excalidraw": "^0.18.1",
         "dompurify": "^3.4.12",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ciaobot-pwa",
   "private": true,
-  "version": "0.6.3",
+  "version": "0.6.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,8 +1,8 @@
-const CACHE_NAME = 'ciaobot-v0.6.3'
+const CACHE_NAME = 'ciaobot-v0.6.4'
 const STATIC_ASSETS = ['/', '/index.html', '/manifest.json']
 const ICON = '/icons/icon-192.png'
 const BADGE = '/icons/icon-192.png'
-const UNREAD_CACHE = 'ciaobot-unread-v0.6.3'
+const UNREAD_CACHE = 'ciaobot-unread-v0.6.4'
 const UNREAD_KEY = '/__unread__'
 
 self.addEventListener('install', (event) => {


### PR DESCRIPTION
## Summary
- configure the release-smoke workspace with `ciao setup` before launching the app, so the headless launch starts against an initialized workspace in `RUNNER_TEMP`
- point `--app-dir` at `RUNNER_TEMP` so setup does not touch the cask-installed `/Applications/Ciaobot.app` that the same job later asserts on and uninstalls
- bump engine, PWA, desktop, and service-worker cache versions to 0.6.4

## Scope
One fix commit since v0.6.3 (`8623999`), a single added line in `.github/workflows/publish.yml`. Patch bump.

## Evidence
- version bumped consistently: `pyproject.toml`, `ciao/__init__.py`, `web/package.json` + lock, the five desktop version files, and the cache names in both `web/public/sw.js` and `ciao/web/static/sw.js` (`ciaobot-v0.6.4`, `ciaobot-unread-v0.6.4`)
- branch is exactly two commits ahead of `origin/main` and not behind
- `ciao setup` accepts `--workspace` and `--app-dir`; both are non-interactive and `app_dir` is created with `mkdir(parents=True, exist_ok=True)`, and the job's `curl` port matches setup's `--port` default of 8443
- `/code-review` is not available in this environment; the one-line diff was reviewed by hand instead
- full backend/frontend/Rust/bundle/wheel verification required from this PR's CI before merge