### PR TITLE
fix: enlarge loop banner icon (#207) and enforce defuddle-first URL reading (#206)

### DIFF
--- a/ciao/system_prompt.md
+++ b/ciao/system_prompt.md
@@ -10,6 +10,13 @@
 - Ask before destructive git operations, external/public actions, and changes to user-visible schema or auth; read-only web and tool retrieval are pre-authorized. Otherwise apply concrete, low-risk fixes directly rather than listing them for approval.
 - Keep private data private. Do not moralize phrasing: interpret in technical context first.
 
+## Reading URLs
+
+- A URL in the prompt means `defuddle parse <url> --md` first. It returns the actual content as markdown, stripping navigation, ads, and JS shells; `WebFetch` handles only plain HTML and spends most of its tokens on that shell noise.
+- Use `WebSearch` to *find* URLs and `defuddle` to *read* them. They are not interchangeable.
+- `WebFetch` is the fallback, never the default: reach for it only when defuddle cannot handle the target (non-HTML, API endpoints, raw binary files).
+- The `web-research` skill carries the details, including YouTube — `defuddle` returns the description plus a timestamped transcript when captions exist. Subagents that read the web follow that skill, so the rule holds in their contexts too.
+
 ## Deliverables and the pinned file panel
 
 - The PWA renders `.md`, `.csv`, `.excalidraw` (diagrams), `.pdf`, `.pptx` (slides), and image files in a side-by-side pinned panel the user can read, view, comment on, and edit inline. A file you create or surface via `file_surface` is auto-surfaced there (desktop, when nothing is already pinned), so the user sees the artifact next to the chat instead of scrolling a long reply.

--- a/ciao/web/static/index.html
+++ b/ciao/web/static/index.html
@@ -13,7 +13,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-180.png" />
     <title>Ciaobot</title>
-    <script type="module" crossorigin src="/assets/index-D7skixjv.js"></script>
+    <script type="module" crossorigin src="/assets/index-CL5qwW7p.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-0_-oViom.css">
   </head>
   <body>

--- a/tests/test_memory_injector.py
+++ b/tests/test_memory_injector.py
@@ -71,6 +71,19 @@ def test_system_prompt_includes_gws_operational_notes() -> None:
     assert "supportsAllDrives" in append
 
 
+def test_system_prompt_includes_url_reading_notes() -> None:
+    """PWA turns get their instructions from system_prompt.md, not the repo's
+    CLAUDE.md, so the defuddle-first rule has to live here or it never fires."""
+    payload = mi.system_prompt_payload("")
+    assert payload is not None
+    append = payload["append"]
+    assert "Reading URLs" in append
+    assert "defuddle parse <url> --md" in append
+    # WebFetch must stay described as the fallback, not an equal option.
+    assert "WebFetch" in append
+    assert "web-research" in append
+
+
 def test_system_prompt_includes_ciaobot_diagnostics_notes() -> None:
     """Installed agents should know which local logs to inspect for support."""
     payload = mi.system_prompt_payload("")

--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -5813,7 +5813,10 @@ details[open] > .activity-summary::before {
   gap: 10px;
   min-width: 0;
 }
-.loop-banner-ico { color: var(--accent); font-weight: 700; flex-shrink: 0; }
+/* Explicit size: inheriting --text-sm left the glyph the same size as the
+   banner text, where the title and Start/Stop buttons overpowered it. Matches
+   the sidebar nav icons so the heartbeat reads at a glance. */
+.loop-banner-ico { color: var(--accent); font-weight: 700; font-size: 18px; line-height: 1; flex-shrink: 0; }
 .loop-banner-text {
   flex: 1;
   font-size: var(--text-sm);


### PR DESCRIPTION
Closes #207. Closes #206.

## #207 — loop banner icon too small

`.loop-banner-ico` had no explicit `font-size`, so it inherited `--text-sm` (~12-13px) and the heartbeat glyph was overpowered by the loop title and the Start/Stop buttons. Sized to 18px with `line-height: 1` to match the sidebar nav icons, per the issue's suggested fix.

Kept the Unicode glyph rather than swapping to SVG. The issue floated SVG as "worth considering" for cross-platform stroke consistency; that is a separate change with its own review surface, and doing it here would mix a one-line sizing fix with an asset change.

## #206 — defuddle-first URL reading never fired in PWA turns

The rule lived only in the ciao repo's `CLAUDE.md`, which is read by Claude Code CLI sessions started from that repo. PWA chat turns — most of what ciaobot does — load `ciao/system_prompt.md` instead, so the rule never applied where it mattered.

Adds a `## Reading URLs` section between `## Response Style and Safety` and `## Deliverables and the pinned file panel`, as specified:

- a URL in the prompt means `defuddle parse <url> --md` first
- `WebSearch` finds URLs, `defuddle` reads them — not interchangeable
- `WebFetch` is the fallback only for non-HTML, API endpoints, raw binary

Plus a drift test (`test_system_prompt_includes_url_reading_notes`) following the existing `gws`/diagnostics section-presence pattern, so a future edit cannot silently drop the rule.

### On the issue's item 3 (subagent audit)

Asked whether subagents inherit enough of the base prompt for the rule to fire. **They do not** — subagent definitions carry their own instructions. But `ciao/stock/agents/researcher.md:8` already delegates to the `web-research` skill, which carries the defuddle-first rule including the YouTube specifics; `memory` and `secretary` do not read URLs as their function. So the new section points at that skill instead of duplicating the rule into three agent files. Flagging this as a judgement call rather than a silent skip.

## Verification

- `pytest tests/` — 1637 passed, 1 skipped, exit 0
- `pytest tests/test_memory_injector.py` — 18 passed, including the new drift test
- `mypy ciao` — clean, 99 source files
- `cd web && npm run build` — exit 0; the tracked `ciao/web/static/index.html` asset hash is committed with the change, since the wheel serves from there
- `/code-review` is unavailable in this environment, so the pre-PR gate was a manual review

## Not included

#187 (branch-backup non-fast-forward loop) is deliberately deferred — the issue offers three incompatible recovery strategies and the fix mutates git state in the user's workspace repo, which wants its own PR. #197, #193, #188 are architecture/feature work, out of scope for a patch.