### PR TITLE
fix: restore develop type checks

### DIFF
--- a/ciao/app_settings.py
+++ b/ciao/app_settings.py
@@ -82,15 +82,18 @@ class AppSettingsStore:
         except (OSError, ValueError):
             logger.warning("Unreadable app settings at %s; using defaults", self._path)
             return AppSettings()
-        known = {f.name for f in fields(AppSettings)}
-        cleaned = {
-            k: v.strip()
-            for k, v in raw.items()
-            if k in known and isinstance(v, str)
+        string_fields = {
+            field.name
+            for field in fields(AppSettings)
+            if field.name != "custom_routing"
         }
+        settings = AppSettings()
+        for key, value in raw.items():
+            if key in string_fields and isinstance(value, str):
+                setattr(settings, key, value.strip())
         custom_routing = raw.get("custom_routing")
         if isinstance(custom_routing, dict):
-            cleaned["custom_routing"] = {
+            settings.custom_routing = {
                 str(provider_id): {
                     str(tier): str(model).strip()
                     for tier, model in routes.items()
@@ -100,7 +103,7 @@ class AppSettingsStore:
                 for provider_id, routes in custom_routing.items()
                 if isinstance(routes, dict)
             }
-        return AppSettings(**cleaned)
+        return settings
 
     def _save(self) -> None:
         payload = {k: v for k, v in asdict(self.settings).items() if v}

--- a/ciao/label_hygiene.py
+++ b/ciao/label_hygiene.py
@@ -238,11 +238,12 @@ def fetch_open_issues(
     issues: list[Issue] = []
     for entry in data:
         raw_labels = entry.get("labels") or []
-        label_names = tuple(
-            (lbl.get("name") if isinstance(lbl, dict) else str(lbl))
-            for lbl in raw_labels
-            if (lbl.get("name") if isinstance(lbl, dict) else lbl) is not None
-        )
+        label_names_list: list[str] = []
+        for label in raw_labels:
+            name = label.get("name") if isinstance(label, dict) else label
+            if name is not None:
+                label_names_list.append(str(name))
+        label_names = tuple(label_names_list)
         issues.append(
             Issue(
                 number=entry["number"],

--- a/tests/test_app_settings.py
+++ b/tests/test_app_settings.py
@@ -64,6 +64,18 @@ def test_load_ignores_unknown_keys_and_non_strings(tmp_path):
     assert store.settings.insights_model == ""
 
 
+def test_load_ignores_non_object_custom_routing(tmp_path):
+    path = tmp_path / "app_settings.json"
+    path.write_text(
+        json.dumps({"title_model": " gemma4:12b-it-qat ", "custom_routing": "bad"})
+    )
+
+    settings = AppSettingsStore(path).settings
+
+    assert settings.title_model == "gemma4:12b-it-qat"
+    assert settings.custom_routing is None
+
+
 def test_load_corrupt_file_gives_defaults(tmp_path):
     path = tmp_path / "app_settings.json"
     path.write_text("{not json")

--- a/tests/test_label_hygiene.py
+++ b/tests/test_label_hygiene.py
@@ -230,6 +230,28 @@ def test_fetch_open_issues_calls_gh_once_and_parses_labels() -> None:
     ]
 
 
+def test_fetch_open_issues_normalizes_non_string_label_values() -> None:
+    def fake_runner(cmd, **kwargs):
+        payload = [
+            {
+                "number": 1,
+                "title": "[Bug] x",
+                "labels": [
+                    {"name": "bug"},
+                    {"name": 7},
+                    {"name": None},
+                    42,
+                    None,
+                ],
+            }
+        ]
+        return _FakeResult(stdout=json.dumps(payload))
+
+    assert fetch_open_issues(runner=fake_runner) == [
+        Issue(1, "[Bug] x", ("bug", "7", "42"))
+    ]
+
+
 def test_apply_additions_only_ever_uses_add_label() -> None:
     calls = []
 


### PR DESCRIPTION
## Summary

- keep malformed `custom_routing` JSON out of the typed app-settings field
- normalize GitHub label values to strings before constructing `Issue`
- add regression tests for both JSON boundaries

This restores the blocking `mypy ciao` check on `develop`. The failures were already present on the base branch and blocked PR #241.

## Verification

- red-green regressions: 2 passed after failing on the original code
- affected test files: 51 passed
- `mypy ciao`: no issues in 101 source files
- `git diff --check`: passed
