### PR TITLE
[Feature] Dictation in comment composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,12 @@ python3.13 -m venv ~/.ciaobot-venv
 Then open `http://localhost:8443` and follow the setup wizard:
 
 - **Workspace folder** (default `~/ciaobot`) — your second brain (`memory-vault/`) plus app config and runtime state. Sync this folder (GitHub, Drive, iCloud, …) so your vault follows you across machines.
+- **Dashboard password** — Ciaobot is password-protected by default: this is what you type to open it, and what another device needs to connect as a client. Change it later in Settings → PWA password.
 - **Model provider** — Claude Code, Codex, or another configured backend.
 
 The wizard writes config, initializes the workspace as a git repo (with a `.gitignore` for secrets and runtime state), and installs the macOS engine LaunchAgent. A cask installation uses `Ciaobot.app`; package-only installs retain the legacy recovery launcher during the migration release.
 
-For scripted setups: `ciao setup --workspace <dir>`. If a setup link returns `invalid setup token`, mint a fresh one with `ciao setup-url --workspace <dir>`.
+For scripted setups: `ciao setup --workspace <dir> --auth-token <password>` (a random password is generated into `.env` when omitted; `--no-auth` opts out of protection entirely). If a setup link returns `invalid setup token`, mint a fresh one with `ciao setup-url --workspace <dir>`.
 
 Contributors running from a git checkout: see [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
 
@@ -148,7 +149,7 @@ When your message mentions a name that appears in the vault index, the agent get
 
 - Sidebar workspaces per life area (personal, work, a client) — each with its own vault, projects, and default model.
 - Projects group related chats and inject durable notes and context into every turn.
-- Comment on any passage of a reply — select text, attach a note, and it rides along with your next prompt; queue follow-ups while the agent is still working.
+- Comment on any passage of a reply — select text, attach a note (typed or dictated), and it rides along with your next prompt; queue follow-ups while the agent is still working.
 - Per-chat model picker with provider thinking levels on top of per-workspace defaults.
 - Fork conversation: create a new independent chat in the same project starting from any completed agent answer, preserving history.
 - Delegates: a chat's agent spawns writable delegate chats (own model, own resumable session, full tool access) to work in parallel, and is woken with a fresh turn when each finishes. Capped at 6 per chat; delegates cannot nest.
@@ -161,7 +162,7 @@ When your message mentions a name that appears in the vault index, the agent get
 **Files and documents**
 
 - Completed turns surface touched files as clickable `Outputs` chips below the final reply. Expand `Activity` to inspect the chronological notes, tool calls, and file cards; click a file for history, diff, and restore.
-- Pin a document beside the chat and add line-level comments on the preview (attached to your next message, like chat comments).
+- Pin a document beside the chat and add line-level comments on the preview, dictated or typed (attached to your next message, like chat comments).
 - Rich previews: images inline, PDFs in a built-in viewer, PowerPoint (`.pptx`) converted to PDF for display (requires LibreOffice on the machine running Ciaobot).
 - Create, edit, and restore vault files from the UI, with snapshots behind every agent edit.
 

--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -613,6 +613,7 @@
 
       </Teleport>
       <CommentComposePopover
+        ref="commentComposeDraftRef"
         :anchor="commentDraft && draftAnchor ? draftAnchor : null"
         v-model="composeText"
         :images="commentDraftImages"
@@ -625,6 +626,7 @@
            opened it rather than to a selection, since the text it annotates may
            be scrolled out of view. -->
       <CommentComposePopover
+        ref="commentComposeEditRef"
         :anchor="editingChatCommentId ? chipEditAnchor : null"
         v-model="editingChatCommentText"
         :images="editingChatCommentImages"
@@ -1365,6 +1367,8 @@ function toggleMessageActions(key: string, e: MouseEvent): void {
 }
 const transcribing = ref(false)
 const voiceRecorderRef = ref<InstanceType<typeof VoiceRecorder> | null>(null)
+const commentComposeDraftRef = ref<InstanceType<typeof CommentComposePopover> | null>(null)
+const commentComposeEditRef = ref<InstanceType<typeof CommentComposePopover> | null>(null)
 const isNearBottom = ref(true)
 let messagesResizeObserver: ResizeObserver | null = null
 const showScrollBtn = computed(() => Boolean(messagesEl.value && store.activeMessages.length > 0 && !isNearBottom.value))
@@ -3827,7 +3831,17 @@ function insertImageRef(n: number) {
 
 // Cmd+D toggles a voice recording from the composer: first press starts,
 // second press stops (same as the on-screen mic/stop button).
+// When a comment compose popover is open, the shortcut is routed there instead
+// of the main chat composer.
 function toggleDictation() {
+  if (commentComposeDraftRef.value) {
+    commentComposeDraftRef.value.toggleDictation()
+    return
+  }
+  if (commentComposeEditRef.value) {
+    commentComposeEditRef.value.toggleDictation()
+    return
+  }
   voiceRecorderRef.value?.toggleRecording()
 }
 

--- a/web/src/components/CommentComposePopover.vue
+++ b/web/src/components/CommentComposePopover.vue
@@ -32,6 +32,17 @@
           <input type="file" accept="image/*" multiple hidden @change="onUpload" />
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg>
         </label>
+        <div class="compose-voice">
+          <VoiceRecorder
+            v-if="!transcribing"
+            ref="voiceRecorderRef"
+            @recorded="handleVoice"
+            @error="handleVoiceError"
+          />
+          <span v-else class="voice-transcribing" title="Transcribing...">
+            <span class="transcribe-spinner"></span>
+          </span>
+        </div>
         <button class="compose-btn" @click="emit('cancel')" type="button">Cancel</button>
         <button
           class="compose-btn primary"
@@ -60,6 +71,9 @@ import { computed, nextTick, ref, watch } from 'vue'
 
 import { useViewportHeight } from '../composables/useViewportHeight'
 import { clampAnchorLeft, clampAnchorTop } from '../lib/popoverAnchor'
+import { useProjectStore } from '../stores/projects'
+import { errorMessage } from '../lib/errorMessage'
+import VoiceRecorder from './VoiceRecorder.vue'
 
 export type ComposeAnchor = { top: number; left: number }
 
@@ -87,9 +101,12 @@ const emit = defineEmits<{
 const images = computed(() => props.images ?? [])
 const inputEl = ref<HTMLTextAreaElement>()
 const rootEl = ref<HTMLElement>()
+const voiceRecorderRef = ref<InstanceType<typeof VoiceRecorder> | null>(null)
+const transcribing = ref(false)
 // Measured height, once rendered. Null until then, so the first paint uses the
 // COMPOSE_H estimate rather than jumping.
 const measuredH = ref<number | null>(null)
+const store = useProjectStore()
 
 // Reactive on purpose. Opening this popover focuses the textarea, so on a phone
 // the keyboard comes up a moment later and shrinks the viewport under a box that
@@ -149,7 +166,52 @@ watch(
   },
 )
 
-defineExpose({ focus })
+function insertTextAtCursor(text: string): void {
+  const el = inputEl.value
+  if (!el) return
+  const start = el.selectionStart ?? 0
+  const end = el.selectionEnd ?? start
+  const before = props.modelValue.slice(0, start)
+  const after = props.modelValue.slice(end)
+  const next = before + text + after
+  emit('update:modelValue', next)
+  nextTick(() => {
+    el.focus()
+    const pos = start + text.length
+    el.setSelectionRange(pos, pos)
+  })
+}
+
+async function handleVoice(blob: Blob): Promise<void> {
+  const chatId = store.activeChatId
+  if (!chatId) {
+    store.pushErrorToast('Voice dictation unavailable', 'No active chat')
+    return
+  }
+  transcribing.value = true
+  try {
+    const text = await store.transcribeVoice(chatId, blob)
+    if (text.trim()) {
+      insertTextAtCursor(text.trimEnd())
+    }
+  } catch (e) {
+    console.error('Voice error:', e)
+    store.pushErrorToast('Voice transcription failed', `${errorMessage(e)}`)
+  } finally {
+    transcribing.value = false
+  }
+}
+
+function handleVoiceError(message: string): void {
+  store.pushErrorToast('Voice dictation unavailable', message)
+}
+
+// Allow the parent (and a future global shortcut) to toggle recording.
+function toggleDictation(): void {
+  voiceRecorderRef.value?.toggleRecording()
+}
+
+defineExpose({ focus, toggleDictation })
 </script>
 
 <style scoped>
@@ -264,6 +326,39 @@ defineExpose({ focus })
 .compose-btn.primary:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+.compose-voice {
+  display: flex;
+  align-items: center;
+}
+.compose-voice :deep(.voice-btn) {
+  min-width: 28px;
+  min-height: 28px;
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+}
+.compose-voice :deep(.voice-btn svg) {
+  width: 16px;
+  height: 16px;
+}
+.voice-transcribing {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+}
+.transcribe-spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent, #60a5fa);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+@keyframes spin {
+  to { transform: rotate(360deg); }
 }
 
 @media (max-width: 640px) {

--- a/web/src/components/__tests__/commentComposePopover.test.ts
+++ b/web/src/components/__tests__/commentComposePopover.test.ts
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 
-import { afterEach, describe, expect, it } from 'vitest'
-import { enableAutoUnmount, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { enableAutoUnmount, flushPromises, mount } from '@vue/test-utils'
 import { nextTick } from 'vue'
 import CommentComposePopover from '../CommentComposePopover.vue'
+import { useProjectStore } from '../../stores/projects'
 
 const FULL_HEIGHT = 932
 const KEYBOARD_HEIGHT = 596
@@ -31,16 +33,45 @@ function composeTop(): number {
   return parseFloat(el.style.top)
 }
 
+// CommentComposePopover now includes a VoiceRecorder that touches the project
+// store for transcription. Stub the recorder so the tests stay focused on the
+// compose popover, and set up a store so setup() doesn't crash.
+vi.mock('../VoiceRecorder.vue', () => ({
+  default: {
+    name: 'VoiceRecorderStub',
+    setup() {
+      return {}
+    },
+    render: () => null,
+  },
+}))
+
+function mountCompose(props: { anchor?: { top: number; left: number } | null; modelValue?: string; images?: string[] } = {}) {
+  setActivePinia(createPinia())
+  const store = useProjectStore()
+  store.activeChatId = 'chat-1'
+  return mount(CommentComposePopover, {
+    props: {
+      anchor: props.anchor === undefined ? { top: 40, left: 80 } : props.anchor,
+      modelValue: props.modelValue ?? '',
+      images: props.images ?? [],
+    },
+    attachTo: document.body,
+  })
+}
+
 describe('CommentComposePopover', () => {
+  beforeEach(() => {
+    setViewportHeight(FULL_HEIGHT)
+    vi.unstubAllGlobals()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it('renders without a selection quote', async () => {
-    const wrapper = mount(CommentComposePopover, {
-      props: {
-        anchor: { top: 40, left: 80 },
-        modelValue: 'I did, close',
-        images: [],
-      },
-      attachTo: document.body,
-    })
+    const wrapper = mountCompose({ modelValue: 'I did, close' })
     await nextTick()
 
     expect(document.body.textContent).toContain('Add comment')
@@ -51,13 +82,7 @@ describe('CommentComposePopover', () => {
   })
 
   it('emits save on Cmd+Enter and cancel on Escape', async () => {
-    const wrapper = mount(CommentComposePopover, {
-      props: {
-        anchor: { top: 10, left: 10 },
-        modelValue: 'note',
-      },
-      attachTo: document.body,
-    })
+    const wrapper = mountCompose({ anchor: { top: 10, left: 10 }, modelValue: 'note' })
     await nextTick()
 
     const input = document.body.querySelector('.compose-input') as HTMLTextAreaElement
@@ -73,11 +98,7 @@ describe('CommentComposePopover', () => {
   // up right after it is placed. It has to move up out of the way: it is
   // position: fixed, so anything the keyboard covers is unreachable.
   it('re-clamps above the keyboard when the viewport shrinks after opening', async () => {
-    setViewportHeight(FULL_HEIGHT)
-    const wrapper = mount(CommentComposePopover, {
-      props: { anchor: { top: 700, left: 20 }, modelValue: 'note' },
-      attachTo: document.body,
-    })
+    const wrapper = mountCompose({ anchor: { top: 700, left: 20 }, modelValue: 'note' })
     await nextTick()
     expect(composeTop()).toBe(700)
 
@@ -93,11 +114,7 @@ describe('CommentComposePopover', () => {
   })
 
   it('leaves a popover that the keyboard does not reach where it is', async () => {
-    setViewportHeight(FULL_HEIGHT)
-    const wrapper = mount(CommentComposePopover, {
-      props: { anchor: { top: 60, left: 20 }, modelValue: 'note' },
-      attachTo: document.body,
-    })
+    const wrapper = mountCompose({ anchor: { top: 60, left: 20 }, modelValue: 'note' })
     await nextTick()
 
     setViewportHeight(KEYBOARD_HEIGHT)
@@ -107,12 +124,94 @@ describe('CommentComposePopover', () => {
   })
 
   it('does not render when anchor is null', async () => {
-    const wrapper = mount(CommentComposePopover, {
-      props: { anchor: null, modelValue: '' },
-      attachTo: document.body,
-    })
+    const wrapper = mountCompose({ anchor: null, modelValue: '' })
     await nextTick()
     expect(document.body.querySelector('.compose')).toBeNull()
+    wrapper.unmount()
+  })
+
+  it('shows a voice recorder button in the action row', async () => {
+    const wrapper = mountCompose({ modelValue: '' })
+    await nextTick()
+    expect(document.body.querySelector('.compose-voice')).not.toBeNull()
+    wrapper.unmount()
+  })
+
+  it('inserts transcribed voice text at the cursor', async () => {
+    const wrapper = mountCompose({ modelValue: 'before ' })
+    await nextTick()
+
+    const store = useProjectStore()
+    store.transcribeVoice = vi.fn(async () => 'after')
+
+    const input = document.body.querySelector('.compose-input') as HTMLTextAreaElement
+    input.focus()
+    input.setSelectionRange(7, 7)
+
+    // Simulate a recorded blob by invoking the internal handler through the
+    // exposed ref (the VoiceRecorder stub never emits). We emit the event
+    // directly on the wrapper's vm because the handler is internal to setup.
+    // Instead, use the component's exposed toggleDictation + recorded handler
+    // is private; call it via the recorded event on a recreated stub path.
+    // Simpler: invoke the recorded handler through the template-bound listener.
+    await wrapper.findComponent({ name: 'VoiceRecorderStub' }).vm.$emit('recorded', new Blob(['x'], { type: 'audio/webm' }))
+    await flushPromises()
+    await nextTick()
+
+    expect(store.transcribeVoice).toHaveBeenCalledWith('chat-1', expect.any(Blob))
+    expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['before after'])
+    wrapper.unmount()
+  })
+
+  it('shows a spinner while transcribing and hides the recorder', async () => {
+    const wrapper = mountCompose({ modelValue: '' })
+    await nextTick()
+
+    const store = useProjectStore()
+    let resolveTranscribe: (text: string) => void = () => {}
+    store.transcribeVoice = vi.fn(() => new Promise<string>((resolve) => { resolveTranscribe = resolve }))
+
+    await wrapper.findComponent({ name: 'VoiceRecorderStub' }).vm.$emit('recorded', new Blob(['x'], { type: 'audio/webm' }))
+    await nextTick()
+
+    expect(document.body.querySelector('.voice-transcribing')).not.toBeNull()
+    expect(document.body.querySelector('.compose-voice')).not.toBeNull()
+
+    resolveTranscribe('done')
+    await flushPromises()
+    await nextTick()
+
+    expect(document.body.querySelector('.voice-transcribing')).toBeNull()
+    wrapper.unmount()
+  })
+
+  it('surfaces transcription errors as a store toast', async () => {
+    const wrapper = mountCompose({ modelValue: '' })
+    await nextTick()
+
+    const store = useProjectStore()
+    store.transcribeVoice = vi.fn(async () => { throw new Error('mic broken') })
+    const pushError = vi.spyOn(store, 'pushErrorToast')
+
+    await wrapper.findComponent({ name: 'VoiceRecorderStub' }).vm.$emit('recorded', new Blob(['x'], { type: 'audio/webm' }))
+    await flushPromises()
+    await nextTick()
+
+    expect(pushError).toHaveBeenCalledWith('Voice transcription failed', expect.stringContaining('mic broken'))
+    wrapper.unmount()
+  })
+
+  it('surfaces voice recorder errors as a store toast', async () => {
+    const wrapper = mountCompose({ modelValue: '' })
+    await nextTick()
+
+    const store = useProjectStore()
+    const pushError = vi.spyOn(store, 'pushErrorToast')
+
+    await wrapper.findComponent({ name: 'VoiceRecorderStub' }).vm.$emit('error', 'permission denied')
+    await nextTick()
+
+    expect(pushError).toHaveBeenCalledWith('Voice dictation unavailable', 'permission denied')
     wrapper.unmount()
   })
 })


### PR DESCRIPTION
Adds an inline microphone button to the comment compose popover so both chat comments and file comments can be dictated. Reuses the existing `VoiceRecorder.vue` component and `/api/chats/{chat_id}/voice` transcription endpoint.

### Changes
- `CommentComposePopover.vue`: adds `VoiceRecorder`, transcribing state, and cursor-aware text insertion.
- `ChatPanel.vue$: routes `Cmd+D` to the open comment composer when one is visible.
- `README.md`: mentions dictated notes for reply and pinned-file comments.
- Tests: 10 new/updated CommentComposePopover tests covering the mic, transcription insertion, spinner, and error toasts.

### Verification
- `npm run build` (vue-tsc + vite) passes.
- `npm test -- --run`: 343 web tests pass.
- `python -m pytest tests/ -x -q`: 1857 backend tests pass, 1 skipped.