### PR TITLE
Composer asset pickers and activity UI for v0.7.2

### DIFF
--- a/ciao/skills_inventory.py
+++ b/ciao/skills_inventory.py
@@ -7,7 +7,11 @@ from pathlib import Path
 from typing import Any
 
 
-def build_skill_inventory(workspace_root: Path | str) -> dict[str, Any]:
+def build_skill_inventory(
+    workspace_root: Path | str,
+    *,
+    include_content: bool = True,
+) -> dict[str, Any]:
     """Return installed/known skills labelled by source.
 
     Source labels intentionally stay coarse for the Settings UI:
@@ -29,17 +33,17 @@ def build_skill_inventory(workspace_root: Path | str) -> dict[str, Any]:
         counts[label] += 1
         source = "skills/" if is_custom else str(lock.get("source") or "skills-lock.json")
         source_type = "custom" if is_custom else str(lock.get("sourceType") or "github")
-        skills.append(
-            {
-                "name": name,
-                "label": label,
-                "source": source,
-                "source_type": source_type,
-                "description": _description_for(root, name, prefer_custom=is_custom),
-                "content": _content_for(root, name, prefer_custom=is_custom),
-                "installed_targets": _installed_targets(root, name),
-            }
-        )
+        skill = {
+            "name": name,
+            "label": label,
+            "source": source,
+            "source_type": source_type,
+            "description": _description_for(root, name, prefer_custom=is_custom),
+            "installed_targets": _installed_targets(root, name),
+        }
+        if include_content:
+            skill["content"] = _content_for(root, name, prefer_custom=is_custom)
+        skills.append(skill)
 
     return {"counts": counts, "skills": skills}
 

--- a/ciao/web/commands.py
+++ b/ciao/web/commands.py
@@ -19,6 +19,8 @@ from typing import Iterable
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from ciao.skills_inventory import build_skill_inventory
+
 logger = logging.getLogger(__name__)
 
 
@@ -30,7 +32,7 @@ class Command:
     name: str
     description: str
     argument_hint: str
-    source: str  # "project" or "user"
+    source: str  # "project", "user", or "skill"
     path: str
 
 
@@ -80,6 +82,37 @@ def list_commands(workspace_root: Path) -> list[Command]:
     return sorted(merged.values(), key=lambda c: c.name)
 
 
+def list_skill_entries(workspace_root: Path, provider: str = "") -> list[Command]:
+    """Return skills installed for a provider in the slash-picker shape.
+
+    Skills are not commands on disk, but Claude and Codex both expose
+    provider-installed skills as user-invocable slash entries. Keep the
+    picker limited to the target that can actually load the skill.
+    """
+    target = provider.strip().lower()
+    inventory = build_skill_inventory(workspace_root, include_content=False)
+    entries: list[Command] = []
+    for skill in inventory.get("skills", []):
+        if not isinstance(skill, dict):
+            continue
+        targets = skill.get("installed_targets") or []
+        if target and target not in targets:
+            continue
+        name = str(skill.get("name") or "").strip()
+        if not name:
+            continue
+        entries.append(
+            Command(
+                name=name,
+                description=str(skill.get("description") or "").strip(),
+                argument_hint="",
+                source="skill",
+                path=str(skill.get("source") or ""),
+            )
+        )
+    return sorted(entries, key=lambda item: item.name)
+
+
 def expand_slash_command(prompt: str, workspace_root: Path) -> str | None:
     """Expand a Ciaobot command for providers without native project commands.
 
@@ -125,11 +158,21 @@ def _workspace_root(request: Request) -> Path:
 async def list_commands_endpoint(request: Request) -> JSONResponse:
     """GET /api/commands — return available slash commands for the UI picker."""
     try:
-        commands = list_commands(_workspace_root(request))
+        workspace_root = _workspace_root(request)
+        commands = list_commands(workspace_root)
+        command_names = {command.name for command in commands}
+        provider = request.query_params.get("provider", "")
+        skills = [
+            skill for skill in list_skill_entries(workspace_root, provider)
+            if skill.name not in command_names
+        ]
     except Exception:  # noqa: BLE001 — never 500 the picker
         logger.exception("listing commands failed")
-        return JSONResponse({"commands": []})
-    return JSONResponse({"commands": [asdict(c) for c in commands]})
+        return JSONResponse({"commands": [], "skills": []})
+    return JSONResponse({
+        "commands": [asdict(command) for command in commands],
+        "skills": [asdict(skill) for skill in skills],
+    })
 
 
 async def rate_limits_endpoint(request: Request) -> JSONResponse:

--- a/ciao/web/static/index.html
+++ b/ciao/web/static/index.html
@@ -13,7 +13,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-180.png" />
     <title>Ciaobot</title>
-    <script type="module" crossorigin src="/assets/index-DdRyC_Gz.js"></script>
+    <script type="module" crossorigin src="/assets/index-CAErxgk9.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DninbV5Y.css">
   </head>
   <body>

--- a/tests/test_commands_api.py
+++ b/tests/test_commands_api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from ciao.web.commands import Command, _parse_frontmatter, list_commands
+from ciao.web.commands import Command, _parse_frontmatter, list_commands, list_skill_entries
 
 
 def _write_cmd(dir_path: Path, name: str, frontmatter: str, body: str = "body") -> None:
@@ -71,3 +71,29 @@ def test_project_wins_over_user_on_collision(tmp_path: Path, monkeypatch) -> Non
 def test_missing_dirs_return_empty(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("HOME", str(tmp_path / "nonexistent-home"))
     assert list_commands(tmp_path / "no-project") == []
+
+
+def test_list_skill_entries_filters_to_provider_install_target(tmp_path: Path) -> None:
+    _write_cmd(
+        tmp_path / "skills" / "claude-only",
+        "SKILL",
+        "---\ndescription: Claude workflow\n---\n",
+    )
+    _write_cmd(
+        tmp_path / "skills" / "both",
+        "SKILL",
+        "---\ndescription: Shared workflow\n---\n",
+    )
+    (tmp_path / ".claude" / "skills" / "claude-only").mkdir(parents=True)
+    (tmp_path / ".claude" / "skills" / "claude-only" / "SKILL.md").write_text(
+        (tmp_path / "skills" / "claude-only" / "SKILL.md").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (tmp_path / ".agents" / "skills" / "both").mkdir(parents=True)
+    (tmp_path / ".agents" / "skills" / "both" / "SKILL.md").write_text(
+        (tmp_path / "skills" / "both" / "SKILL.md").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    assert [skill.name for skill in list_skill_entries(tmp_path, "claude")] == ["claude-only"]
+    assert [skill.name for skill in list_skill_entries(tmp_path, "codex")] == ["both"]

--- a/tests/test_skills_inventory.py
+++ b/tests/test_skills_inventory.py
@@ -98,6 +98,16 @@ def test_build_skill_inventory_reports_codex_install_target(tmp_path: Path) -> N
     assert inventory["skills"][0]["installed_targets"] == ["claude", "codex"]
 
 
+def test_build_skill_inventory_can_omit_skill_content(tmp_path: Path) -> None:
+    _write_skill(tmp_path / "skills", "demo", "Demo")
+    _write_skill(tmp_path / ".claude" / "skills", "demo", "Demo")
+
+    inventory = build_skill_inventory(tmp_path, include_content=False)
+
+    assert inventory["skills"][0]["description"] == "Demo"
+    assert "content" not in inventory["skills"][0]
+
+
 def test_build_skill_inventory_reads_agents_canonical_github_skill(tmp_path: Path) -> None:
     _write_skill(tmp_path / ".agents" / "skills", "brainstorming", "Installed for Codex")
     tmp_path.joinpath("skills-lock.json").write_text(

--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -285,11 +285,18 @@
                 </span>
                 <span class="file-card-chevron" aria-hidden="true">&#8599;</span>
               </button>
-              <div
-                v-else-if="step.tool_name === '_thinking'"
-                class="trace-text trace-thinking"
-                v-html="renderMarkdown(step.content)"
-              ></div>
+              <div v-else-if="step.tool_name === '_thinking'" class="thinking-block">
+                <button
+                  type="button"
+                  class="thinking-toggle"
+                  :aria-expanded="thinkingExpanded"
+                  @click.stop="toggleThinking"
+                >
+                  <span aria-hidden="true">{{ thinkingExpanded ? '\u25BE' : '\u25B8' }}</span>
+                  <span>{{ thinkingExpanded ? 'Thinking' : 'Thinking (collapsed)' }}</span>
+                </button>
+                <div v-if="thinkingExpanded" class="trace-text trace-thinking" v-html="renderMarkdown(step.content)"></div>
+              </div>
               <div v-else class="trace-text" v-html="renderMarkdown(step.content)"></div>
             </template>
             <SubagentPanel v-if="item.subs?.length" :subagents="item.subs" />
@@ -372,6 +379,10 @@
           <div class="message-row" @click="toggleMessageActions(`assistant-${i}`, $event)">
             <div class="message assistant" :class="{ error: item.msg.is_error }" :data-msg-id="item.msg.timestamp ? `msg-${item.msg.timestamp}` : `msg-asst-${i}`" :data-msg-index="i" data-msg-role="assistant">
               <div class="message-content" v-html="renderMarkdown(item.msg.content)"></div>
+              <div v-if="item.msg.is_error" class="error-attribution" role="status">
+                <span class="error-attribution-label">{{ classifyError(item.msg.content).label }}</span>
+                <span>{{ classifyError(item.msg.content).copy }}</span>
+              </div>
               <div v-if="item.outputs?.length" class="answer-outputs" role="group" aria-label="Outputs">
                 <span class="answer-outputs-label">Outputs</span>
                 <div class="answer-output-files">
@@ -452,6 +463,10 @@
         <!-- System message (errors, etc) -->
         <div v-else-if="item.kind === 'system'" class="message system" :data-msg-id="item.msg.timestamp ? `msg-${item.msg.timestamp}` : `msg-sys-${i}`" :data-msg-index="i" data-msg-role="system">
           <div class="message-content" v-html="renderMarkdown(item.msg.content)"></div>
+          <div v-if="isErrorMsg(item.msg.content)" class="error-attribution" role="status">
+            <span class="error-attribution-label">{{ classifyError(item.msg.content).label }}</span>
+            <span>{{ classifyError(item.msg.content).copy }}</span>
+          </div>
           <div v-if="isErrorMsg(item.msg.content)" class="error-actions">
             <button
               v-if="lastUserBefore(i)"
@@ -570,11 +585,18 @@
               </span>
               <span class="file-card-chevron" aria-hidden="true">&#8599;</span>
             </button>
-            <div
-              v-else-if="entry.kind === 'thinking'"
-              class="trace-text trace-thinking"
-              v-html="renderMarkdown(entry.content)"
-            ></div>
+            <div v-else-if="entry.kind === 'thinking'" class="thinking-block">
+              <button
+                type="button"
+                class="thinking-toggle"
+                :aria-expanded="thinkingExpanded"
+                @click.stop="toggleThinking"
+              >
+                <span aria-hidden="true">{{ thinkingExpanded ? '\u25BE' : '\u25B8' }}</span>
+                <span>{{ thinkingExpanded ? 'Thinking' : 'Thinking (collapsed)' }}</span>
+              </button>
+              <div v-if="thinkingExpanded" class="trace-text trace-thinking" v-html="renderMarkdown(entry.content)"></div>
+            </div>
             <div
               v-else-if="entry.kind === 'status'"
               class="trace-text trace-status"
@@ -582,11 +604,18 @@
             ></div>
             <div v-else class="trace-text" v-html="renderMarkdown(entry.content)"></div>
           </template>
-          <div
-            v-if="store.currentStreamingThinking"
-            class="trace-text trace-thinking trace-streaming"
-            v-html="renderMarkdown(store.currentStreamingThinking)"
-          ></div>
+          <div v-if="store.currentStreamingThinking" class="thinking-block">
+            <button
+              type="button"
+              class="thinking-toggle"
+              :aria-expanded="thinkingExpanded"
+              @click.stop="toggleThinking"
+            >
+              <span aria-hidden="true">{{ thinkingExpanded ? '\u25BE' : '\u25B8' }}</span>
+              <span>{{ thinkingExpanded ? 'Thinking' : 'Thinking (collapsed)' }}</span>
+            </button>
+            <div v-if="thinkingExpanded" class="trace-text trace-thinking trace-streaming" v-html="renderMarkdown(store.currentStreamingThinking)"></div>
+          </div>
           <div v-if="store.currentStreamingText" class="trace-text trace-streaming" v-html="renderMarkdown(store.currentStreamingText)"></div>
           <!-- Subagents for the in-flight turn nest in the live trace -->
           <SubagentPanel v-if="liveSubagents.length" :subagents="liveSubagents" />
@@ -865,6 +894,26 @@
       </span>
     </div>
 
+    <!-- @-mention picker (textarea version: inserts plain backend-facing text) -->
+    <div v-if="showMentionPicker" class="commands-picker mention-picker" role="listbox" aria-label="Mentions">
+      <div
+        v-for="(item, i) in filteredMentions"
+        :key="`${item.kind}:${item.insertText}`"
+        class="commands-picker-row mention-picker-row"
+        :class="{ active: i === mentionHighlightIdx }"
+        role="option"
+        :aria-selected="i === mentionHighlightIdx"
+        @mousedown.prevent="mentionPicker.select(item)"
+        @mouseenter="mentionHighlightIdx = i"
+      >
+        <div class="commands-picker-head">
+          <span class="mention-picker-kind">{{ item.kind }}</span>
+          <span class="commands-picker-name">@{{ item.insertText }}</span>
+        </div>
+        <div class="commands-picker-desc">{{ item.description }}</div>
+      </div>
+    </div>
+
     <!-- Slash-command picker (shown when the input starts with "/") -->
     <div v-if="showCommandsPicker" class="commands-picker" role="listbox" aria-label="Slash commands">
       <div
@@ -902,9 +951,10 @@
           :placeholder="inputPlaceholder"
           rows="1"
           @keydown="handleKeydown"
-          @input="autoResize"
+          @input="handleInput"
           @paste="handlePaste"
           @focus="handleInputFocus"
+          @click="mentionPicker.refresh"
         ></textarea>
         <div class="input-actions">
           <!-- Voice recording is allowed during streaming too: the user's
@@ -949,8 +999,8 @@ import SubagentPanel from './SubagentPanel.vue'
 import { api } from '../lib/api'
 import { askConfirm } from '../lib/confirm'
 import { formatAttachedFilePath, nativeAbsoluteFilePath } from '../lib/chatAttachments'
-import { readChatDraft, writeChatDraft } from '../lib/chatDrafts'
-import type { Loop, Schedule, ModelsResponse, ChatMessage, SubagentTranscript } from '../lib/types'
+import { readChatDraft, readSentPromptHistory, recordSentPrompt, writeChatDraft } from '../lib/chatDrafts'
+import type { AgentAssetsResponse, Loop, Schedule, ModelsResponse, ChatMessage, SubagentTranscript } from '../lib/types'
 import { useTaskStore } from '../stores/tasks'
 import PaneHeader from './PaneHeader.vue'
 import ModelSelector from './ModelSelector.vue'
@@ -965,11 +1015,14 @@ import {
   selectedModelEntry,
 } from '../lib/fableModel'
 import { renderMarkdown as renderSafeMarkdown } from '../lib/safeMarkdown'
+import { classifyError } from '../lib/errorAttribution'
 import { formatTime, formatDuration } from '../lib/time'
 import { buildTurnParts, collectTraceOutputs, findFinalAnswerIndex, formatTokenUsage, traceSummaryMetaParts, type TraceOutput } from '../lib/chatActivity'
 import { buildForkSnapshot } from '../lib/chatFork'
 import { formatCommentLocation, type ChatCommentAnchor } from '../lib/commentContext'
 import { clampAnchorLeft, clampAnchorTop } from '../lib/popoverAnchor'
+import { useMentionPicker, type MentionAgent, type MentionFile } from '../composables/useMentionPicker'
+import { useThinkingPreference } from '../composables/useThinkingPreference'
 import {
   clearPlanReturnMode,
   includeBuiltinPlanCommand,
@@ -1040,10 +1093,14 @@ const emit = defineEmits<{ close: [], 'open-sidebar': [] }>()
 
 const store = useProjectStore()
 const fileViewer = useFileViewerStore()
+const { thinkingExpanded, toggleThinking } = useThinkingPreference()
 const draftChatId = store.activeChatId
 const inputText = ref(readChatDraft(draftChatId))
 const inputRevision = ref(0)
 const inputEl = ref<HTMLTextAreaElement>()
+const promptHistoryIndex = ref(-1)
+const promptHistoryDraft = ref('')
+let settingPromptHistoryText = false
 const isContinuing = ref(false)
 const becomingHost = ref(false)
 const hostHandoverError = ref('')
@@ -1053,8 +1110,52 @@ const hostHandoverError = ref('')
 // chats immediately after typing.
 watch(inputText, (text) => {
   inputRevision.value += 1
-  writeChatDraft(draftChatId, text)
+  if (!settingPromptHistoryText) {
+    promptHistoryIndex.value = -1
+    promptHistoryDraft.value = ''
+    writeChatDraft(draftChatId, text)
+  }
 }, { flush: 'sync' })
+
+function promptHistory(): string[] {
+  return readSentPromptHistory(draftChatId)
+}
+
+function setPromptHistoryText(text: string): void {
+  settingPromptHistoryText = true
+  inputText.value = text
+  settingPromptHistoryText = false
+  nextTick(() => autoResize())
+}
+
+function handlePromptHistoryKey(e: KeyboardEvent): boolean {
+  if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return false
+  const history = promptHistory()
+  if (!history.length) return false
+
+  if (e.key === 'ArrowUp') {
+    if (promptHistoryIndex.value < 0 && inputText.value.trim() !== '') return false
+    e.preventDefault()
+    if (promptHistoryIndex.value < 0) promptHistoryDraft.value = inputText.value
+    promptHistoryIndex.value = promptHistoryIndex.value < 0
+      ? history.length - 1
+      : Math.max(0, promptHistoryIndex.value - 1)
+    setPromptHistoryText(history[promptHistoryIndex.value])
+    return true
+  }
+
+  if (promptHistoryIndex.value < 0) return false
+  e.preventDefault()
+  if (promptHistoryIndex.value >= history.length - 1) {
+    promptHistoryIndex.value = -1
+    setPromptHistoryText(promptHistoryDraft.value)
+    promptHistoryDraft.value = ''
+  } else {
+    promptHistoryIndex.value += 1
+    setPromptHistoryText(history[promptHistoryIndex.value])
+  }
+  return true
+}
 
 async function disconnectAndBecomeHost() {
   if (becomingHost.value) return
@@ -1439,6 +1540,20 @@ const projectFiles = ref<ContextProjectFile[]>([])
 const projectFilesLoading = ref(false)
 const projectFilesError = ref('')
 const showProjectFiles = computed(() => Boolean(project.value?.vault_folder))
+const mentionAgents = ref<MentionAgent[]>([])
+const mentionFiles = computed<MentionFile[]>(() => projectFiles.value.map(file => ({
+  path: file.path,
+  vault_path: file.vault_path,
+})))
+const mentionPicker = useMentionPicker({
+  draft: inputText,
+  input: inputEl,
+  files: mentionFiles,
+  agents: mentionAgents,
+})
+const filteredMentions = mentionPicker.filteredItems
+const mentionHighlightIdx = mentionPicker.highlightIndex
+const showMentionPicker = mentionPicker.showPicker
 
 async function loadProjectFiles() {
   if (!project.value || !project.value.vault_folder) {
@@ -1480,9 +1595,19 @@ function openProjectFile(f: ContextProjectFile): void {
 
 watch(
   () => [showContext.value, project.value?.project_id, project.value?.vault_folder] as const,
-  ([open]) => { if (open) loadProjectFiles() },
+  ([open]) => { if (open || project.value?.vault_folder) loadProjectFiles() },
   { immediate: true }
 )
+
+async function loadMentionAgents(): Promise<void> {
+  try {
+    const response = await api.get<AgentAssetsResponse>('/api/agent-assets')
+    mentionAgents.value = Array.isArray(response.subagents) ? response.subagents : []
+  } catch {
+    // Mentions are an enhancement; an unavailable asset catalog leaves files usable.
+    mentionAgents.value = []
+  }
+}
 
 // Deduped list of files the agent has written/edited in this chat. Most
 // recent occurrence wins for action label; count shows how many times the
@@ -2547,6 +2672,7 @@ onMounted(async () => {
     const r = await api.get<{ commands: SlashCommand[] }>('/api/commands')
     slashCommands.value = includeBuiltinPlanCommand(r.commands ?? [])
   } catch { /* keep the built-in /plan entry available */ }
+  await loadMentionAgents()
   notifyChatFocused(chat.value?.chat_id)
   messagesEl.value?.addEventListener('scroll', checkScroll, { passive: true })
   if (messagesEl.value && typeof ResizeObserver !== 'undefined') {
@@ -2566,7 +2692,10 @@ onMounted(async () => {
 })
 
 onBeforeUnmount(() => {
-  writeChatDraft(draftChatId, inputText.value)
+  writeChatDraft(
+    draftChatId,
+    promptHistoryIndex.value < 0 ? inputText.value : promptHistoryDraft.value,
+  )
   window.removeEventListener('ciao:native-file-drag-enter', handleNativeFileDragEnter)
   window.removeEventListener('ciao:native-file-drag-leave', handleNativeFileDragLeave)
   window.removeEventListener('ciao:native-file-drop', handleNativeFileDrop)
@@ -3155,7 +3284,16 @@ function autoResize() {
   }
 }
 
+function handleInput(): void {
+  autoResize()
+  mentionPicker.refresh()
+}
+
 function handleKeydown(e: KeyboardEvent) {
+  // Mention navigation uses the same keyboard-first picker contract as slash
+  // commands, but only consumes keys while an @ token is active.
+  if (mentionPicker.handleKeydown(e)) return
+
   // Slash-command picker navigation takes precedence over send/newline.
   if (showCommandsPicker.value) {
     if (e.key === 'ArrowDown') {
@@ -3200,6 +3338,12 @@ function handleKeydown(e: KeyboardEvent) {
     return
   }
 
+  // Recalling history is deliberately limited to the textarea's empty state
+  // so ArrowUp/ArrowDown keep their normal cursor-navigation meaning while a
+  // prompt is being edited. Once recall starts, the arrows walk that session's
+  // bounded history and Down restores the draft that was present beforehand.
+  if (handlePromptHistoryKey(e)) return
+
   // Cmd+Enter (mac) / Ctrl+Enter (linux/win) sends the message. Bare Enter
   // inserts a newline: this avoids accidental sends, especially on phones
   // where Enter is the default virtual-keyboard action. Mid-stream sends are
@@ -3239,6 +3383,7 @@ function send() {
     void handlePlanCommand(action, originChatId, returnMode, submittedText, submittedRevision)
     return
   }
+  if (text) recordSentPrompt(chat.value.chat_id, inputText.value)
   // Always "queue": when a response is in flight the backend buffers and
   // flushes on turn end; for a fresh turn this starts it.
   let sendText = text
@@ -4391,6 +4536,22 @@ defineExpose({ toggleDictation, archiveActiveChat })
   gap: 6px;
   flex-wrap: wrap;
 }
+
+.error-attribution {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: baseline;
+  margin-top: 8px;
+  color: var(--fg2);
+  font-size: var(--text-xs);
+  line-height: 1.4;
+}
+
+.error-attribution-label {
+  color: var(--error);
+  font-weight: 600;
+}
 .fix-btn { color: var(--accent); border-color: var(--accent); }
 .fix-btn:hover { background: var(--accent); color: var(--bg); border-color: var(--accent); }
 
@@ -4608,6 +4769,32 @@ defineExpose({ toggleDictation, archiveActiveChat })
   min-width: 0;
   overflow-wrap: break-word;
 }
+
+.thinking-block {
+  min-width: 0;
+}
+
+.thinking-toggle {
+  min-height: var(--touch);
+  padding: 4px 8px 4px 2px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 0;
+  background: transparent;
+  color: var(--fg2);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--text-xs);
+  opacity: 0.85;
+}
+
+.thinking-toggle:hover { color: var(--fg); }
+.thinking-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .trace-text :deep(a) {
   color: var(--accent);
   text-decoration: underline;
@@ -5456,6 +5643,26 @@ details[open] > .activity-summary::before {
   line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+}
+
+.mention-picker-row {
+  min-height: var(--touch);
+  box-sizing: border-box;
+  touch-action: manipulation;
+}
+.mention-picker-kind {
+  color: var(--accent2);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.75em;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+.mention-picker-row .commands-picker-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* Input bar */

--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -908,7 +908,7 @@
       >
         <div class="commands-picker-head">
           <span class="mention-picker-kind">{{ item.kind }}</span>
-          <span class="commands-picker-name">@{{ item.insertText }}</span>
+          <span class="commands-picker-name" :title="`@${item.insertText}`">@{{ item.label }}</span>
         </div>
         <div class="commands-picker-desc">{{ item.description }}</div>
       </div>
@@ -927,6 +927,7 @@
         @mouseenter="commandHighlightIdx = i"
       >
         <div class="commands-picker-head">
+          <span v-if="cmd.source === 'skill'" class="commands-picker-kind">skill</span>
           <span class="commands-picker-name">/{{ cmd.name }}</span>
           <span v-if="cmd.argument_hint" class="commands-picker-hint">{{ cmd.argument_hint }}</span>
         </div>
@@ -1000,7 +1001,7 @@ import { api } from '../lib/api'
 import { askConfirm } from '../lib/confirm'
 import { formatAttachedFilePath, nativeAbsoluteFilePath } from '../lib/chatAttachments'
 import { readChatDraft, readSentPromptHistory, recordSentPrompt, writeChatDraft } from '../lib/chatDrafts'
-import type { AgentAssetsResponse, Loop, Schedule, ModelsResponse, ChatMessage, SubagentTranscript } from '../lib/types'
+import type { AgentAssetsResponse, CommandsResponse, Loop, Schedule, ModelsResponse, ChatMessage, SubagentTranscript } from '../lib/types'
 import { useTaskStore } from '../stores/tasks'
 import PaneHeader from './PaneHeader.vue'
 import ModelSelector from './ModelSelector.vue'
@@ -1021,7 +1022,13 @@ import { buildTurnParts, collectTraceOutputs, findFinalAnswerIndex, formatTokenU
 import { buildForkSnapshot } from '../lib/chatFork'
 import { formatCommentLocation, type ChatCommentAnchor } from '../lib/commentContext'
 import { clampAnchorLeft, clampAnchorTop } from '../lib/popoverAnchor'
-import { useMentionPicker, type MentionAgent, type MentionFile } from '../composables/useMentionPicker'
+import {
+  useMentionPicker,
+  type MentionAgent,
+  type MentionChat,
+  type MentionFile,
+  type MentionProject,
+} from '../composables/useMentionPicker'
 import { useThinkingPreference } from '../composables/useThinkingPreference'
 import {
   clearPlanReturnMode,
@@ -1226,6 +1233,20 @@ function primaryAction() {
 const slashCommands = ref<SlashCommand[]>(includeBuiltinPlanCommand([]))
 const commandHighlightIdx = ref(0)
 
+async function loadSlashCommands(): Promise<void> {
+  try {
+    const provider = encodeURIComponent(chat.value.provider || '')
+    const response = await api.get<CommandsResponse>(`/api/commands?provider=${provider}`)
+    slashCommands.value = includeBuiltinPlanCommand([
+      ...(response.commands || []),
+      ...(response.skills || []),
+    ])
+  } catch {
+    // Keep the built-in /plan entry available when asset discovery is offline.
+    slashCommands.value = includeBuiltinPlanCommand([])
+  }
+}
+
 const filteredCommands = computed<SlashCommand[]>(() => {
   const text = inputText.value
   if (!text.startsWith('/')) return []
@@ -1259,6 +1280,9 @@ const editingTitle = ref(false)
 const titleValue = ref('')
 const dragOver = ref(false)
 const chat = computed(() => store.activeChat!)
+watch(() => chat.value.provider, () => {
+  void loadSlashCommands()
+})
 const planModeSaving = ref(false)
 
 async function togglePlanMode(
@@ -1541,6 +1565,25 @@ const projectFilesLoading = ref(false)
 const projectFilesError = ref('')
 const showProjectFiles = computed(() => Boolean(project.value?.vault_folder))
 const mentionAgents = ref<MentionAgent[]>([])
+const mentionChats = computed<MentionChat[]>(() => {
+  const activeProjects = new Map(store.projects.map(item => [item.project_id, item]))
+  return store.chats
+    .filter(chatItem => !chatItem.archived && chatItem.local !== false && activeProjects.has(chatItem.project_id))
+    .map(chatItem => ({
+      chat_id: chatItem.chat_id,
+      title: chatItem.title,
+      project_id: chatItem.project_id,
+      project_name: activeProjects.get(chatItem.project_id)?.name,
+      workspace: activeProjects.get(chatItem.project_id)?.workspace,
+      archived: chatItem.archived,
+      local: chatItem.local,
+    }))
+})
+const mentionProjects = computed<MentionProject[]>(() => store.projects.map(projectItem => ({
+  project_id: projectItem.project_id,
+  name: projectItem.name,
+  workspace: projectItem.workspace,
+})))
 const mentionFiles = computed<MentionFile[]>(() => projectFiles.value.map(file => ({
   path: file.path,
   vault_path: file.vault_path,
@@ -1550,6 +1593,8 @@ const mentionPicker = useMentionPicker({
   input: inputEl,
   files: mentionFiles,
   agents: mentionAgents,
+  chats: mentionChats,
+  projects: mentionProjects,
 })
 const filteredMentions = mentionPicker.filteredItems
 const mentionHighlightIdx = mentionPicker.highlightIndex
@@ -2668,10 +2713,7 @@ onMounted(async () => {
     providerDefaults.value = r.provider_defaults || {}
     thinkingLevels.value = r.thinking_levels || {}
   } catch { /* use defaults */ }
-  try {
-    const r = await api.get<{ commands: SlashCommand[] }>('/api/commands')
-    slashCommands.value = includeBuiltinPlanCommand(r.commands ?? [])
-  } catch { /* keep the built-in /plan entry available */ }
+  await loadSlashCommands()
   await loadMentionAgents()
   notifyChatFocused(chat.value?.chat_id)
   messagesEl.value?.addEventListener('scroll', checkScroll, { passive: true })
@@ -5624,6 +5666,14 @@ details[open] > .activity-summary::before {
 .commands-picker-name {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-weight: 600;
+  flex-shrink: 0;
+}
+.commands-picker-kind {
+  color: var(--accent2);
+  font-size: 0.72em;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   flex-shrink: 0;
 }
 .commands-picker-hint {

--- a/web/src/components/__tests__/ChatPanelPlanMode.test.ts
+++ b/web/src/components/__tests__/ChatPanelPlanMode.test.ts
@@ -122,7 +122,11 @@ function planReturnModeStorageKey(chatId: string): string {
   return `ciao-plan-return-mode:${chatId}`
 }
 
-async function mountPanel(options: { mode?: string; commandsFail?: boolean } = {}): Promise<Harness> {
+async function mountPanel(options: {
+  mode?: string
+  commandsFail?: boolean
+  skills?: Array<{ name: string; description: string; argument_hint: string; source: 'skill'; path: string }>
+} = {}): Promise<Harness> {
   const pinia = createPinia()
   setActivePinia(pinia)
   const store = useProjectStore()
@@ -138,9 +142,9 @@ async function mountPanel(options: { mode?: string; commandsFail?: boolean } = {
 
   vi.spyOn(api, 'get').mockImplementation((path: string) => {
     if (path === '/api/models') return Promise.resolve(MODELS_RESPONSE) as never
-    if (path === '/api/commands') {
+    if (path.startsWith('/api/commands')) {
       if (options.commandsFail) return Promise.reject(new Error('commands unavailable')) as never
-      return Promise.resolve({ commands: [] }) as never
+      return Promise.resolve({ commands: [], skills: options.skills || [] }) as never
     }
     return Promise.resolve([]) as never
   })
@@ -342,6 +346,26 @@ describe('ChatPanel /plan interactions', () => {
     await wrapper.get('textarea.chat-input').setValue('/')
 
     expect(wrapper.find('.commands-picker-name').text()).toBe('/plan')
+    wrapper.unmount()
+  })
+
+  it('lists provider skills in the slash picker', async () => {
+    const { wrapper } = await mountPanel({
+      skills: [{
+        name: 'research',
+        description: 'Research with the loaded skill',
+        argument_hint: '',
+        source: 'skill',
+        path: 'skills/',
+      }],
+    })
+
+    await wrapper.get('textarea.chat-input').setValue('/res')
+    const row = wrapper.get('.commands-picker-row')
+    expect(row.text()).toContain('skill')
+    expect(row.text()).toContain('/research')
+    await row.trigger('mousedown')
+    expect(textareaValue(wrapper)).toBe('/research')
     wrapper.unmount()
   })
 

--- a/web/src/components/__tests__/ChatPanelPromptHistory.test.ts
+++ b/web/src/components/__tests__/ChatPanelPromptHistory.test.ts
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { defineComponent, h } from 'vue'
+import { flushPromises, shallowMount, type VueWrapper } from '@vue/test-utils'
+import { api } from '../../lib/api'
+import { readChatDraft, readSentPromptHistory, recordSentPrompt } from '../../lib/chatDrafts'
+import type { ChatInfo, ProjectInfo } from '../../lib/types'
+import ChatPanel from '../ChatPanel.vue'
+import { useProjectStore } from '../../stores/projects'
+import { useTaskStore } from '../../stores/tasks'
+
+const PaneHeaderStub = defineComponent({
+  name: 'PaneHeaderStub',
+  setup(_, { slots }) {
+    return () => h('header', { class: 'pane-header' }, [
+      slots.title?.(),
+      h('div', { class: 'header-actions' }, slots.actions?.()),
+    ])
+  },
+})
+
+const ChildStub = defineComponent({
+  name: 'ChildStub',
+  setup() {
+    return () => h('div')
+  },
+})
+
+const ChatCommentPopoverStub = defineComponent({
+  name: 'ChatCommentPopoverStub',
+  setup(_, { expose }) {
+    expose({
+      openId: null,
+      close: vi.fn(),
+      clearPendingClose: vi.fn(),
+      onTargetOver: vi.fn(),
+      onTargetOut: vi.fn(),
+      pinFromEvent: vi.fn(),
+      show: vi.fn(),
+    })
+    return () => h('div')
+  },
+})
+
+const MODELS_RESPONSE = {
+  models: ['haiku', 'sonnet', 'opus', 'fable'],
+  default: 'sonnet',
+  provider_models: { claude: ['haiku', 'sonnet', 'opus', 'fable'] },
+  provider_defaults: { claude: 'sonnet' },
+  thinking_levels: {},
+  model_reasoning_levels: {},
+  model_options: {},
+  backends: { anthropic: true },
+}
+
+function makeProject(): ProjectInfo {
+  return {
+    project_id: 'project-1',
+    name: 'General',
+    workspace: 'personal',
+    context: '',
+    created_at: '',
+    order: 0,
+    vault_folder: '',
+  }
+}
+
+function makeChat(chatId: string): ChatInfo {
+  return {
+    chat_id: chatId,
+    project_id: 'project-1',
+    title: chatId,
+    model: 'sonnet',
+    provider: 'claude',
+    mode: 'normal',
+    session_id: '',
+    created_at: '',
+    archived: false,
+  }
+}
+
+class MemoryStorage {
+  private values = new Map<string, string>()
+
+  getItem(key: string): string | null { return this.values.get(key) ?? null }
+  setItem(key: string, value: string): void { this.values.set(key, value) }
+  removeItem(key: string): void { this.values.delete(key) }
+  clear(): void { this.values.clear() }
+}
+
+async function mountPanel(): Promise<{
+  wrapper: VueWrapper
+  sendMessage: ReturnType<typeof vi.spyOn>
+}> {
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  const store = useProjectStore()
+  store.projects = [makeProject()]
+  store.chats = [makeChat('chat-1')]
+  store.activeChatId = 'chat-1'
+  store.messages = { 'chat-1': [] }
+  store.bootstrapped = true
+
+  const taskStore = useTaskStore()
+  vi.spyOn(taskStore, 'fetchLoops').mockResolvedValue()
+  vi.spyOn(taskStore, 'fetchSchedules').mockResolvedValue()
+
+  vi.spyOn(api, 'get').mockImplementation((path: string) => {
+    if (path === '/api/models') return Promise.resolve(MODELS_RESPONSE) as never
+    if (path === '/api/commands') return Promise.resolve({ commands: [] }) as never
+    return Promise.resolve([]) as never
+  })
+
+  const sendMessage = vi.spyOn(store, 'sendMessage')
+  const wrapper = shallowMount(ChatPanel, {
+    global: {
+      plugins: [pinia],
+      stubs: {
+        PaneHeader: PaneHeaderStub,
+        ModelSelector: ChildStub,
+        VoiceRecorder: ChildStub,
+        SubagentPanel: ChildStub,
+        ChatCommentPopover: ChatCommentPopoverStub,
+        CommentComposePopover: ChildStub,
+        RouterLink: ChildStub,
+      },
+    },
+  })
+  await flushPromises()
+  return { wrapper, sendMessage }
+}
+
+function textareaValue(wrapper: VueWrapper): string {
+  return (wrapper.get('textarea.chat-input').element as HTMLTextAreaElement).value
+}
+
+describe('ChatPanel sent-prompt history', () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: new MemoryStorage(),
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  it('walks older and newer prompts, then restores the pre-recall draft', async () => {
+    recordSentPrompt('chat-1', 'first prompt')
+    recordSentPrompt('chat-1', 'latest prompt')
+    const { wrapper } = await mountPanel()
+    const textarea = wrapper.get('textarea.chat-input')
+
+    await textarea.trigger('keydown', { key: 'ArrowUp' })
+    expect(textareaValue(wrapper)).toBe('latest prompt')
+    await textarea.trigger('keydown', { key: 'ArrowUp' })
+    expect(textareaValue(wrapper)).toBe('first prompt')
+    await textarea.trigger('keydown', { key: 'ArrowDown' })
+    expect(textareaValue(wrapper)).toBe('latest prompt')
+    await textarea.trigger('keydown', { key: 'ArrowDown' })
+    expect(textareaValue(wrapper)).toBe('')
+    expect(readChatDraft('chat-1')).toBe('')
+    wrapper.unmount()
+  })
+
+  it('keeps normal cursor editing when history is not active and text is non-empty', async () => {
+    recordSentPrompt('chat-1', 'sent prompt')
+    const { wrapper } = await mountPanel()
+    const textarea = wrapper.get('textarea.chat-input')
+
+    await textarea.setValue('current draft')
+    await textarea.trigger('keydown', { key: 'ArrowUp' })
+    expect(textareaValue(wrapper)).toBe('current draft')
+    await textarea.trigger('keydown', { key: 'ArrowDown' })
+    expect(textareaValue(wrapper)).toBe('current draft')
+    wrapper.unmount()
+  })
+
+  it('records a trimmed prompt when the composer sends', async () => {
+    const { wrapper, sendMessage } = await mountPanel()
+    sendMessage.mockImplementation(() => undefined)
+
+    await wrapper.get('textarea.chat-input').setValue('  sent prompt  ')
+    await wrapper.get('button.send-btn').trigger('click')
+
+    expect(readSentPromptHistory('chat-1')).toEqual(['sent prompt'])
+    wrapper.unmount()
+  })
+})

--- a/web/src/components/__tests__/ChatPanelPromptHistory.test.ts
+++ b/web/src/components/__tests__/ChatPanelPromptHistory.test.ts
@@ -109,7 +109,7 @@ async function mountPanel(): Promise<{
 
   vi.spyOn(api, 'get').mockImplementation((path: string) => {
     if (path === '/api/models') return Promise.resolve(MODELS_RESPONSE) as never
-    if (path === '/api/commands') return Promise.resolve({ commands: [] }) as never
+    if (path.startsWith('/api/commands')) return Promise.resolve({ commands: [], skills: [] }) as never
     return Promise.resolve([]) as never
   })
 

--- a/web/src/components/__tests__/ChatPanelRetry.test.ts
+++ b/web/src/components/__tests__/ChatPanelRetry.test.ts
@@ -108,7 +108,7 @@ async function mountPanel(): Promise<{
 
   vi.spyOn(api, 'get').mockImplementation((path: string) => {
     if (path === '/api/models') return Promise.resolve(MODELS_RESPONSE) as never
-    if (path === '/api/commands') return Promise.resolve({ commands: [] }) as never
+    if (path.startsWith('/api/commands')) return Promise.resolve({ commands: [], skills: [] }) as never
     return Promise.resolve([]) as never
   })
 

--- a/web/src/composables/useMentionPicker.test.ts
+++ b/web/src/composables/useMentionPicker.test.ts
@@ -51,6 +51,27 @@ describe('useMentionPicker', () => {
     expect(items).toHaveLength(2)
   })
 
+  it('includes active chats and projects with stable reference tokens', () => {
+    const items = buildMentionItems(
+      [],
+      [],
+      [
+        { chat_id: 'chat-1', title: 'Planning', project_id: 'project-1', project_name: 'Ciaobot', workspace: 'personal' },
+        { chat_id: 'chat-archived', title: 'Old chat', project_id: 'project-1', archived: true },
+      ],
+      [
+        { project_id: 'project-1', name: 'Ciaobot', workspace: 'personal' },
+        { project_id: 'project-completed', name: 'Done', completed: true },
+      ],
+    )
+
+    expect(items).toEqual([
+      expect.objectContaining({ kind: 'chat', label: 'Planning', insertText: 'chat/chat-1' }),
+      expect.objectContaining({ kind: 'project', label: 'Ciaobot', insertText: 'project/project-1' }),
+    ])
+    expect(filterMentionItems(items, 'ciaobot').map(item => item.kind)).toEqual(['chat', 'project'])
+  })
+
   it('inserts plain mention text and restores the caret after the token', async () => {
     const draft = ref('Review @read')
     const input = ref<HTMLTextAreaElement | undefined>(makeTextarea(draft.value))

--- a/web/src/composables/useMentionPicker.test.ts
+++ b/web/src/composables/useMentionPicker.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest'
+import { nextTick, ref } from 'vue'
+import {
+  buildMentionItems,
+  filterMentionItems,
+  findMentionTrigger,
+  useMentionPicker,
+} from './useMentionPicker'
+
+function makeTextarea(value: string, cursor = value.length): HTMLTextAreaElement {
+  const textarea = document.createElement('textarea')
+  textarea.value = value
+  textarea.selectionStart = cursor
+  textarea.selectionEnd = cursor
+  return textarea
+}
+
+describe('useMentionPicker', () => {
+  it('finds a token at the caret without treating email addresses as mentions', () => {
+    const pathDraft = 'read @memory-vault/personal/README.md'
+    expect(findMentionTrigger(pathDraft, pathDraft.length)).toEqual({
+      start: 5,
+      end: pathDraft.length,
+      query: 'memory-vault/personal/README.md',
+    })
+    const emailDraft = 'mail me@example.com'
+    expect(findMentionTrigger(emailDraft, emailDraft.length)).toBeNull()
+    expect(findMentionTrigger('before@agent', 12)).toBeNull()
+  })
+
+  it('filters agents and vault files together and deduplicates sources', () => {
+    const items = buildMentionItems(
+      [
+        { path: 'README.md', vault_path: 'memory-vault/personal/README.md' },
+        { path: 'README.md', vault_path: 'memory-vault/personal/README.md' },
+      ],
+      [
+        { name: 'researcher', description: 'Find evidence' },
+        { name: 'Researcher', description: 'Duplicate name' },
+      ],
+    )
+
+    expect(filterMentionItems(items, 'read')).toEqual([
+      expect.objectContaining({ kind: 'file', insertText: 'memory-vault/personal/README.md' }),
+    ])
+    expect(filterMentionItems(items, 'RESEARCH')).toEqual([
+      expect.objectContaining({ kind: 'agent', insertText: 'researcher' }),
+    ])
+    expect(items).toHaveLength(2)
+  })
+
+  it('inserts plain mention text and restores the caret after the token', async () => {
+    const draft = ref('Review @read')
+    const input = ref<HTMLTextAreaElement | undefined>(makeTextarea(draft.value))
+    const picker = useMentionPicker({
+      draft,
+      input,
+      files: [{ path: 'README.md', vault_path: 'memory-vault/personal/README.md' }],
+      agents: [{ name: 'researcher', description: 'Find evidence' }],
+    })
+
+    picker.refresh()
+    expect(picker.filteredItems.value[0]?.insertText).toBe('memory-vault/personal/README.md')
+    picker.select(picker.filteredItems.value[0])
+    await nextTick()
+
+    expect(draft.value).toBe('Review @memory-vault/personal/README.md ')
+    expect(input.value?.selectionStart).toBe(draft.value.length)
+    expect(input.value?.selectionEnd).toBe(draft.value.length)
+    expect(picker.showPicker.value).toBe(false)
+  })
+
+  it('keeps the menu session local to the active token and handles Escape', () => {
+    const draft = ref('@res')
+    const input = ref<HTMLTextAreaElement | undefined>(makeTextarea(draft.value))
+    const picker = useMentionPicker({ draft, input, files: [], agents: [{ name: 'researcher' }] })
+    picker.refresh()
+    expect(picker.showPicker.value).toBe(true)
+
+    const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+    picker.handleKeydown(event)
+    expect(picker.showPicker.value).toBe(false)
+    expect(draft.value).toBe('@res')
+  })
+})

--- a/web/src/composables/useMentionPicker.ts
+++ b/web/src/composables/useMentionPicker.ts
@@ -1,6 +1,6 @@
 import { computed, nextTick, ref, toValue, watch, type MaybeRefOrGetter, type Ref } from 'vue'
 
-export type MentionKind = 'file' | 'agent'
+export type MentionKind = 'file' | 'agent' | 'chat' | 'project'
 
 export interface MentionFile {
   path: string
@@ -10,6 +10,24 @@ export interface MentionFile {
 export interface MentionAgent {
   name: string
   description?: string
+}
+
+export interface MentionChat {
+  chat_id: string
+  title: string
+  project_id: string
+  project_name?: string
+  workspace?: string
+  archived?: boolean
+  local?: boolean
+}
+
+export interface MentionProject {
+  project_id: string
+  name: string
+  workspace?: string
+  archived?: boolean
+  completed?: boolean
 }
 
 export interface MentionItem {
@@ -43,6 +61,8 @@ export function findMentionTrigger(text: string, cursor: number): MentionTrigger
 export function buildMentionItems(
   files: MentionFile[],
   agents: MentionAgent[],
+  chats: MentionChat[] = [],
+  projects: MentionProject[] = [],
 ): MentionItem[] {
   const items: MentionItem[] = []
   const seen = new Set<string>()
@@ -58,6 +78,38 @@ export function buildMentionItems(
       label: name,
       insertText: name,
       description: agent.description?.trim() || 'Named agent',
+    })
+  }
+
+  for (const chat of chats) {
+    const title = chat.title.trim()
+    const chatId = chat.chat_id.trim()
+    if (!title || !chatId || chat.archived || chat.local === false) continue
+    const key = `chat:${chatId.toLowerCase()}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    const context = [chat.project_name?.trim(), chat.workspace?.trim()].filter(Boolean)
+    items.push({
+      kind: 'chat',
+      label: title,
+      insertText: `chat/${chatId}`,
+      description: context.length ? `Chat · ${context.join(' · ')}` : 'Chat',
+    })
+  }
+
+  for (const project of projects) {
+    const name = project.name.trim()
+    const projectId = project.project_id.trim()
+    if (!name || !projectId || project.archived || project.completed) continue
+    const key = `project:${projectId.toLowerCase()}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    const workspace = project.workspace?.trim()
+    items.push({
+      kind: 'project',
+      label: name,
+      insertText: `project/${projectId}`,
+      description: workspace ? `Project · ${workspace}` : 'Project',
     })
   }
 
@@ -84,7 +136,8 @@ export function filterMentionItems(items: MentionItem[], query: string): Mention
   return items
     .filter(item =>
       item.label.toLocaleLowerCase().includes(needle)
-      || item.insertText.toLocaleLowerCase().includes(needle),
+      || item.insertText.toLocaleLowerCase().includes(needle)
+      || item.description.toLocaleLowerCase().includes(needle),
     )
     .slice(0, MAX_MENTION_RESULTS)
 }
@@ -94,6 +147,8 @@ export interface UseMentionPickerOptions {
   input: Ref<HTMLTextAreaElement | undefined>
   files: MaybeRefOrGetter<MentionFile[]>
   agents: MaybeRefOrGetter<MentionAgent[]>
+  chats?: MaybeRefOrGetter<MentionChat[]>
+  projects?: MaybeRefOrGetter<MentionProject[]>
 }
 
 /**
@@ -109,6 +164,8 @@ export function useMentionPicker(options: UseMentionPickerOptions) {
   const allItems = computed(() => buildMentionItems(
     toValue(options.files),
     toValue(options.agents),
+    toValue(options.chats) || [],
+    toValue(options.projects) || [],
   ))
   const filteredItems = computed(() => {
     const active = trigger.value

--- a/web/src/composables/useMentionPicker.ts
+++ b/web/src/composables/useMentionPicker.ts
@@ -1,0 +1,212 @@
+import { computed, nextTick, ref, toValue, watch, type MaybeRefOrGetter, type Ref } from 'vue'
+
+export type MentionKind = 'file' | 'agent'
+
+export interface MentionFile {
+  path: string
+  vault_path: string
+}
+
+export interface MentionAgent {
+  name: string
+  description?: string
+}
+
+export interface MentionItem {
+  kind: MentionKind
+  label: string
+  insertText: string
+  description: string
+}
+
+export interface MentionTrigger {
+  start: number
+  end: number
+  query: string
+}
+
+const MAX_MENTION_RESULTS = 50
+
+/** Find an @ token immediately before the textarea caret. */
+export function findMentionTrigger(text: string, cursor: number): MentionTrigger | null {
+  const end = Math.max(0, Math.min(cursor, text.length))
+  const beforeCaret = text.slice(0, end)
+  const match = beforeCaret.match(/(?:^|\s)@([^\s@]*)$/)
+  if (!match) return null
+
+  const matchStart = end - match[0].length
+  const at = beforeCaret.indexOf('@', matchStart)
+  return at < 0 ? null : { start: at, end, query: match[1] || '' }
+}
+
+/** Build the two supported mention sources from existing API response shapes. */
+export function buildMentionItems(
+  files: MentionFile[],
+  agents: MentionAgent[],
+): MentionItem[] {
+  const items: MentionItem[] = []
+  const seen = new Set<string>()
+
+  for (const agent of agents) {
+    const name = agent.name.trim()
+    if (!name) continue
+    const key = `agent:${name.toLowerCase()}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    items.push({
+      kind: 'agent',
+      label: name,
+      insertText: name,
+      description: agent.description?.trim() || 'Named agent',
+    })
+  }
+
+  for (const file of files) {
+    const vaultPath = file.vault_path.trim()
+    if (!vaultPath) continue
+    const key = `file:${vaultPath.toLowerCase()}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    items.push({
+      kind: 'file',
+      label: vaultPath,
+      insertText: vaultPath,
+      description: file.path.trim() || 'Vault file',
+    })
+  }
+
+  return items
+}
+
+export function filterMentionItems(items: MentionItem[], query: string): MentionItem[] {
+  const needle = query.trim().toLocaleLowerCase()
+  if (!needle) return items.slice(0, MAX_MENTION_RESULTS)
+  return items
+    .filter(item =>
+      item.label.toLocaleLowerCase().includes(needle)
+      || item.insertText.toLocaleLowerCase().includes(needle),
+    )
+    .slice(0, MAX_MENTION_RESULTS)
+}
+
+export interface UseMentionPickerOptions {
+  draft: Ref<string>
+  input: Ref<HTMLTextAreaElement | undefined>
+  files: MaybeRefOrGetter<MentionFile[]>
+  agents: MaybeRefOrGetter<MentionAgent[]>
+}
+
+/**
+ * Cursor-aware mention menu state for the plain textarea composer.
+ *
+ * The selected value is deliberately plain text: the backend receives the
+ * same vault path or named-agent token that the existing context surfaces use.
+ */
+export function useMentionPicker(options: UseMentionPickerOptions) {
+  const trigger = ref<MentionTrigger | null>(null)
+  const highlightIndex = ref(0)
+
+  const allItems = computed(() => buildMentionItems(
+    toValue(options.files),
+    toValue(options.agents),
+  ))
+  const filteredItems = computed(() => {
+    const active = trigger.value
+    return active ? filterMentionItems(allItems.value, active.query) : []
+  })
+  const showPicker = computed(() => Boolean(trigger.value && filteredItems.value.length))
+
+  watch(filteredItems, (items) => {
+    if (highlightIndex.value >= items.length) highlightIndex.value = 0
+  })
+
+  function refresh(): void {
+    const el = options.input.value
+    if (!el || el.selectionStart !== el.selectionEnd) {
+      trigger.value = null
+      return
+    }
+    trigger.value = findMentionTrigger(options.draft.value, el.selectionStart)
+    highlightIndex.value = 0
+  }
+
+  function dismiss(): void {
+    trigger.value = null
+    highlightIndex.value = 0
+  }
+
+  function select(item: MentionItem): void {
+    const active = trigger.value
+    const el = options.input.value
+    if (!active || !el) return
+
+    const before = options.draft.value.slice(0, active.start)
+    const after = options.draft.value.slice(active.end)
+    const token = `@${item.insertText}`
+    // Leave the existing separator alone when inserting before whitespace;
+    // otherwise keep the caret ready for the next word.
+    const suffix = after && /^\s/.test(after) ? '' : ' '
+    options.draft.value = before + token + suffix + after
+    dismiss()
+
+    nextTick(() => {
+      const input = options.input.value
+      if (!input) return
+      input.value = options.draft.value
+      const caret = active.start + token.length + suffix.length
+      input.setSelectionRange(caret, caret)
+      input.focus()
+    })
+  }
+
+  /** Return true when the mention picker consumed the keyboard event. */
+  function handleKeydown(event: KeyboardEvent): boolean {
+    if (!showPicker.value) return false
+    const items = filteredItems.value
+    if (!items.length) return false
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      highlightIndex.value = (highlightIndex.value + 1) % items.length
+      return true
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      highlightIndex.value = (highlightIndex.value - 1 + items.length) % items.length
+      return true
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      event.stopPropagation()
+      dismiss()
+      return true
+    }
+    if (event.key === 'Tab' || (event.key === 'Enter' && !event.shiftKey && !event.metaKey && !event.ctrlKey)) {
+      event.preventDefault()
+      select(items[highlightIndex.value])
+      return true
+    }
+    return false
+  }
+
+  // Programmatic draft changes (send, slash-command selection, chat switch)
+  // must not leave a stale menu anchored to the old token.
+  watch(options.draft, () => {
+    if (!trigger.value) return
+    const el = options.input.value
+    const current = el && el.selectionStart === el.selectionEnd
+      ? findMentionTrigger(options.draft.value, el.selectionStart)
+      : null
+    if (!current) dismiss()
+  })
+
+  return {
+    filteredItems,
+    highlightIndex,
+    showPicker,
+    refresh,
+    dismiss,
+    select,
+    handleKeydown,
+  }
+}

--- a/web/src/composables/useThinkingPreference.test.ts
+++ b/web/src/composables/useThinkingPreference.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import {
+  readThinkingExpanded,
+  THINKING_EXPANDED_STORAGE_KEY,
+  writeThinkingExpanded,
+} from './useThinkingPreference'
+
+class MemoryStorage {
+  private values = new Map<string, string>()
+  getItem(key: string): string | null { return this.values.get(key) ?? null }
+  setItem(key: string, value: string): void { this.values.set(key, value) }
+}
+
+describe('thinking preference', () => {
+  it('defaults to expanded and persists the user choice', () => {
+    const storage = new MemoryStorage()
+    expect(readThinkingExpanded(storage)).toBe(true)
+
+    writeThinkingExpanded(false, storage)
+    expect(storage.getItem(THINKING_EXPANDED_STORAGE_KEY)).toBe('false')
+    expect(readThinkingExpanded(storage)).toBe(false)
+
+    writeThinkingExpanded(true, storage)
+    expect(readThinkingExpanded(storage)).toBe(true)
+  })
+})

--- a/web/src/composables/useThinkingPreference.ts
+++ b/web/src/composables/useThinkingPreference.ts
@@ -1,0 +1,43 @@
+import { ref, type Ref } from 'vue'
+
+export const THINKING_EXPANDED_STORAGE_KEY = 'ciao-thinking-expanded'
+
+type PreferenceStorage = Pick<Storage, 'getItem' | 'setItem'>
+
+function defaultStorage(): PreferenceStorage | null {
+  if (typeof localStorage === 'undefined') return null
+  return localStorage
+}
+
+export function readThinkingExpanded(storage: PreferenceStorage | null = defaultStorage()): boolean {
+  if (!storage) return true
+  try {
+    return storage.getItem(THINKING_EXPANDED_STORAGE_KEY) !== 'false'
+  } catch {
+    return true
+  }
+}
+
+export function writeThinkingExpanded(
+  expanded: boolean,
+  storage: PreferenceStorage | null = defaultStorage(),
+): void {
+  if (!storage) return
+  try {
+    storage.setItem(THINKING_EXPANDED_STORAGE_KEY, String(expanded))
+  } catch {
+    // A blocked preference store must not prevent reading the trace.
+  }
+}
+
+export function useThinkingPreference(): {
+  thinkingExpanded: Ref<boolean>
+  toggleThinking: () => void
+} {
+  const thinkingExpanded = ref(readThinkingExpanded())
+  function toggleThinking(): void {
+    thinkingExpanded.value = !thinkingExpanded.value
+    writeThinkingExpanded(thinkingExpanded.value)
+  }
+  return { thinkingExpanded, toggleThinking }
+}

--- a/web/src/lib/chatDrafts.test.ts
+++ b/web/src/lib/chatDrafts.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { readChatDraft, writeChatDraft } from './chatDrafts'
+import {
+  readChatDraft,
+  readSentPromptHistory,
+  recordSentPrompt,
+  writeChatDraft,
+} from './chatDrafts'
 
 class MemoryStorage {
   private values = new Map<string, string>()
@@ -48,5 +53,25 @@ describe('chat drafts', () => {
 
     storage.setItem('ciao-chat-drafts', '{not-json')
     expect(readChatDraft('chat-b', storage)).toBe('')
+  })
+
+  it('keeps a deduplicated, bounded sent-prompt history per chat', () => {
+    const storage = new MemoryStorage()
+
+    for (let i = 0; i < 51; i++) recordSentPrompt('chat-a', `prompt ${i}`, storage)
+    recordSentPrompt('chat-a', 'prompt 20', storage)
+    recordSentPrompt('chat-b', 'other chat', storage)
+
+    expect(readSentPromptHistory('chat-a', storage)).toHaveLength(50)
+    expect(readSentPromptHistory('chat-a', storage)[0]).toBe('prompt 1')
+    expect(readSentPromptHistory('chat-a', storage).at(-1)).toBe('prompt 20')
+    expect(readSentPromptHistory('chat-b', storage)).toEqual(['other chat'])
+  })
+
+  it('ignores malformed history values', () => {
+    const storage = new MemoryStorage()
+    storage.setItem('ciao-chat-sent-prompts', '{"chat-a":["valid",42,null]}')
+
+    expect(readSentPromptHistory('chat-a', storage)).toEqual(['valid'])
   })
 })

--- a/web/src/lib/chatDrafts.ts
+++ b/web/src/lib/chatDrafts.ts
@@ -1,4 +1,6 @@
 const CHAT_DRAFTS_STORAGE_KEY = 'ciao-chat-drafts'
+const CHAT_SENT_PROMPTS_STORAGE_KEY = 'ciao-chat-sent-prompts'
+export const SENT_PROMPT_HISTORY_LIMIT = 50
 
 type DraftStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
 
@@ -19,6 +21,41 @@ function readDrafts(storage: DraftStorage): Record<string, string> {
     )
   } catch {
     return {}
+  }
+}
+
+function readSentPromptHistories(storage: DraftStorage): Record<string, string[]> {
+  try {
+    const parsed = JSON.parse(storage.getItem(CHAT_SENT_PROMPTS_STORAGE_KEY) || '{}')
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {}
+
+    return Object.fromEntries(
+      Object.entries(parsed)
+        .map(([chatId, prompts]) => {
+          if (!Array.isArray(prompts)) return null
+          const uniquePrompts = prompts.filter(
+            (prompt): prompt is string => typeof prompt === 'string' && prompt.length > 0,
+          ).filter((prompt, index, all) => all.indexOf(prompt) === index)
+          return [chatId, uniquePrompts.slice(-SENT_PROMPT_HISTORY_LIMIT)] as const
+        })
+        .filter((entry): entry is readonly [string, string[]] => entry !== null),
+    )
+  } catch {
+    return {}
+  }
+}
+
+function writeSentPromptHistories(
+  storage: DraftStorage,
+  histories: Record<string, string[]>,
+): void {
+  const nonEmptyHistories = Object.fromEntries(
+    Object.entries(histories).filter(([, prompts]) => prompts.length > 0),
+  )
+  if (Object.keys(nonEmptyHistories).length) {
+    storage.setItem(CHAT_SENT_PROMPTS_STORAGE_KEY, JSON.stringify(nonEmptyHistories))
+  } else {
+    storage.removeItem(CHAT_SENT_PROMPTS_STORAGE_KEY)
   }
 }
 
@@ -49,5 +86,33 @@ export function writeChatDraft(
     }
   } catch {
     // Draft persistence must never prevent typing or sending a message.
+  }
+}
+
+/** Return sent prompts from oldest to newest for one chat session. */
+export function readSentPromptHistory(
+  chatId: string | null | undefined,
+  storage: DraftStorage | null = defaultStorage(),
+): string[] {
+  if (!chatId || !storage) return []
+  return readSentPromptHistories(storage)[chatId] || []
+}
+
+/** Add one sent prompt, keeping the session history bounded and deduplicated. */
+export function recordSentPrompt(
+  chatId: string | null | undefined,
+  text: string,
+  storage: DraftStorage | null = defaultStorage(),
+): void {
+  const prompt = text.trim()
+  if (!chatId || !storage || !prompt) return
+
+  try {
+    const history = readSentPromptHistories(storage)
+    const existing = history[chatId] || []
+    history[chatId] = [...existing.filter((entry) => entry !== prompt), prompt].slice(-SENT_PROMPT_HISTORY_LIMIT)
+    writeSentPromptHistories(storage, history)
+  } catch {
+    // History persistence must never prevent sending a message.
   }
 }

--- a/web/src/lib/errorAttribution.test.ts
+++ b/web/src/lib/errorAttribution.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { classifyError } from './errorAttribution'
+
+describe('classifyError', () => {
+  it.each([
+    ['request timed out after 30s', 'timeout'],
+    ['permission denied by policy', 'blocked'],
+    ['HTTP 502 from gateway', 'remote-http'],
+    ['Anthropic quota exceeded', 'provider'],
+    ['something unexpected', 'unknown'],
+  ])('classifies %s as %s', (text, kind) => {
+    expect(classifyError(text).kind).toBe(kind)
+  })
+})

--- a/web/src/lib/errorAttribution.ts
+++ b/web/src/lib/errorAttribution.ts
@@ -1,0 +1,24 @@
+export type ErrorAttributionKind = 'timeout' | 'blocked' | 'remote-http' | 'provider' | 'unknown'
+
+export interface ErrorAttribution {
+  kind: ErrorAttributionKind
+  label: string
+  copy: string
+}
+
+export function classifyError(errorText: string): ErrorAttribution {
+  const text = (errorText || '').toLowerCase()
+  if (/\b(timeout|timed out|deadline exceeded)\b/.test(text)) {
+    return { kind: 'timeout', label: 'Timed out', copy: 'The operation took too long to finish.' }
+  }
+  if (/\b(blocked|permission denied|not allowed|forbidden|approval required|access denied)\b/.test(text)) {
+    return { kind: 'blocked', label: 'Blocked', copy: 'The operation was stopped by a permission or access rule.' }
+  }
+  if (/\b(?:http|status|status code)\s*[45]\d{2}\b|\b[45]\d{2}\s+(?:error|bad gateway|gateway timeout)\b/.test(text)) {
+    return { kind: 'remote-http', label: 'Remote service error', copy: 'A remote service returned an HTTP error.' }
+  }
+  if (/\b(provider|anthropic|claude|ollama|openrouter|codex|model|quota|rate limit|token)\b/.test(text)) {
+    return { kind: 'provider', label: 'Provider error', copy: 'The selected AI provider could not complete the request.' }
+  }
+  return { kind: 'unknown', label: 'Unknown error', copy: 'The operation did not complete.' }
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -673,12 +673,13 @@ export interface SlashCommand {
   name: string
   description: string
   argument_hint: string
-  source: 'project' | 'user' | 'builtin'
+  source: 'project' | 'user' | 'builtin' | 'skill'
   path: string
 }
 
 export interface CommandsResponse {
   commands: SlashCommand[]
+  skills?: SlashCommand[]
 }
 
 // ── Settings agent assets ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The remainder of `feat/memory-state-event-audit`, after #253 merged. Three commits.

- **`feat: improve chat composer and activity UI`** (`052eb76`) — composer and activity-indicator work, plus `chatDrafts`, `useThinkingPreference`, and `errorAttribution` with their tests.
- **`feat: expand composer asset pickers`** (`57eea4e`) — the `@`-mention picker gains more asset kinds, backed by `ciao/web/commands.py` and `ciao/skills_inventory.py` changes.
- **`build(pwa): rebuild static bundle`** (`faf3c8f`) — so the tracked `index.html` matches the source being shipped.

## Testing
- `pytest tests/` — 1828 passed, 1 skipped
- `web/`: `npm run test` (45 files, 376 tests), `npm run lint`, `npx vue-tsc --noEmit` — all clean, Node 26
- Nothing under `desktop/` changed, so the `check-desktop.sh` run that gated `release/v0.7.2` still holds

## Note on CI

**This PR gets no CI.** `ci.yml` triggers on `pull_request: branches: [develop, main]` only, so a PR into a release branch runs zero checks — a green/`CLEAN` mergeable state here means "no checks exist", not "checks passed". The runs above are the only verification. Same was true of #253.

## Still open on the release branch

- `Cmd/Ctrl+Shift+=` likely collides with browser zoom-in on US layouts (that chord *is* Cmd/Ctrl+`+`, and browsers handle zoom above the page), so the PWA may zoom *and* bump the font, while `Cmd+Shift+-` does not. Untouched — picking a replacement chord is a product call.
- `backfill_insights_task` is unbounded (`limit=0` from every caller) and reachable for the first time now that the archive path is fixed.
- `release/v0.7.2` is numbered a patch but now carries several `feat(...)` commits; by the convention in `skills/ciao-release/SKILL.md` that is a minor.
