### PR TITLE
fix(insights): route classifier through the insights timeout

### DIFF
--- a/ciao/insights.py
+++ b/ciao/insights.py
@@ -177,12 +177,14 @@ def _fit_transcript(filtered_jsonl: str) -> tuple[str, int]:
     return "\n".join(kept), len(lines) - len(kept)
 
 
-def _is_context_overflow(exc: Exception) -> bool:
+def is_context_overflow(exc: Exception) -> bool:
     """True for a deterministic oversized-input rejection.
 
     These fail identically on retry, so re-sending only burns another slow
     call plus the retry wait. Matched on message text because the providers
-    surface it as a plain 400 rather than a typed error.
+    surface it as a plain 400 rather than a typed error. Reused by the
+    schedule attention classifier so the two callers classify 400s the
+    same way.
     """
     text = str(exc).lower()
     return "too long" in text or "context window" in text or "context_length_exceeded" in text
@@ -653,7 +655,7 @@ async def _run_model_with_retry(
         ):
             logger.info("Apple FoundationModels is unavailable; not retrying: %s", exc)
             return "", str(exc).strip() or type(exc).__name__
-        if _is_context_overflow(exc):
+        if is_context_overflow(exc):
             logger.error(
                 "Insights input still exceeds the model's context window (%s); "
                 "not retrying. Lower CIAO_INSIGHTS_MAX_INPUT_CHARS (currently %d) "

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -7020,13 +7020,18 @@ class ProjectChatManager:
                 logger.info("Schedule attention classifier %s", note)
             try:
                 from ciao.providers.oneshot import run_oneshot
+                from ciao.insights import _insights_timeout_s, is_context_overflow
 
+                # Same env-tunable budget as the insights job: the slow
+                # Ollama Cloud model measures 214-253s on a successful call,
+                # so a hard 60s window turned tail latency into a guaranteed
+                # TimeoutError and the classifier ran 6/6 in error.
                 text = await run_oneshot(
                     user_prompt,
                     system_prompt=system_prompt,
                     model=model,
                     env=env,
-                    timeout_s=60.0,
+                    timeout_s=_insights_timeout_s(),
                     provider=classifier_provider,
                     cwd=self._config.workspace_root,
                 )
@@ -7044,10 +7049,24 @@ class ProjectChatManager:
             except Exception as exc:  # noqa: BLE001
                 run.status = "error"
                 run.error = (str(exc).strip() or type(exc).__name__)[:1000]
-                logger.exception(
-                    "Schedule attention classifier failed with model %s; keeping chat visible",
-                    model,
-                )
+                # Distinguish a deterministic 400-style overflow from a
+                # transient timeout. The payload is already trimmed to
+                # final_text[-6000:] so an overflow here is rare, but
+                # recording the class lets the job history tell transient
+                # tail-latency from a real context-window problem.
+                if is_context_overflow(exc):
+                    run.extra["context_overflow"] = True
+                    logger.warning(
+                        "Schedule attention classifier hit the context window "
+                        "with model %s; keeping chat visible",
+                        model,
+                    )
+                else:
+                    logger.exception(
+                        "Schedule attention classifier failed with model %s; "
+                        "keeping chat visible",
+                        model,
+                    )
                 return True
 
     def prepare_schedule_chat(

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -741,11 +741,11 @@ def test_context_overflow_is_distinguished_from_a_transient_timeout() -> None:
     overflow = Exception(
         "API Error 400 Message too long: 262183 > 125952 maximum context length"
     )
-    assert insights._is_context_overflow(overflow)
-    assert insights._is_context_overflow(Exception("context_length_exceeded"))
+    assert insights.is_context_overflow(overflow)
+    assert insights.is_context_overflow(Exception("context_length_exceeded"))
     # Transient failures must stay retryable.
-    assert not insights._is_context_overflow(asyncio.TimeoutError())
-    assert not insights._is_context_overflow(Exception("429 rate limit"))
+    assert not insights.is_context_overflow(asyncio.TimeoutError())
+    assert not insights.is_context_overflow(Exception("429 rate limit"))
 
 
 def test_oversized_input_is_not_retried(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_schedule_delivery_modes.py
+++ b/tests/test_schedule_delivery_modes.py
@@ -214,3 +214,54 @@ async def test_schedule_attention_classifier_records_bare_timeout_type(
     row = _job_rows(tmp_path)[0]
     assert row["status"] == "error"
     assert row["error"] == "TimeoutError"
+
+
+async def test_schedule_attention_classifier_uses_insights_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The classifier shares the insights job's env-tunable budget.
+
+    The slow Ollama Cloud model measures 214-253s on a successful call;
+    a hard 60s window turns tail latency into a guaranteed TimeoutError.
+    """
+    captured: dict[str, object] = {}
+
+    async def fake_oneshot(*args, **kwargs):
+        captured["timeout_s"] = kwargs["timeout_s"]
+        return '{"needs_user": false, "reason": "routine"}'
+
+    monkeypatch.setattr("ciao.providers.oneshot.run_oneshot", fake_oneshot)
+    monkeypatch.setenv("CIAO_INSIGHTS_TIMEOUT_S", "900")
+
+    needs_user = await _manager_for_classifier()._schedule_run_needs_user(
+        _entry(), ScheduleRunOutcome(completed=True, final_text="done")
+    )
+
+    assert needs_user is False
+    assert captured["timeout_s"] == 900.0
+
+
+async def test_schedule_attention_classifier_records_context_overflow(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 400-style overflow is recorded on the run, not as a generic error.
+
+    The classifier payload is already trimmed to final_text[-6000:], so an
+    overflow here is rare, but the run should still surface the failure
+    class so the Automation page can tell a context-window problem from a
+    transient timeout.
+    """
+    async def fake_oneshot(*args, **kwargs):
+        raise RuntimeError("API Error 400 Message too long: 9999 > 4096")
+
+    monkeypatch.setattr("ciao.providers.oneshot.run_oneshot", fake_oneshot)
+
+    needs_user = await _manager_for_classifier()._schedule_run_needs_user(
+        _entry(), ScheduleRunOutcome(completed=True, final_text="done")
+    )
+
+    # Conservative: keep the chat visible on classifier failure.
+    assert needs_user is True
+    row = _job_rows(tmp_path)[0]
+    assert row["status"] == "error"
+    assert row["extra"]["context_overflow"] is True


### PR DESCRIPTION
Fixes #248

The schedule attention classifier in ciao/web/project_chats.py still called run_oneshot with a hardcoded 60s timeout after the prior fix bumped the insights path to 600s. The slow Ollama Cloud model that drove #248 measured 214-253s on a successful call, so the classifier's 60s window turned every run into a TimeoutError and the job ran 6/6 in error. The classifier now reuses the same CIAO_INSIGHTS_TIMEOUT_S budget the insights job uses.

is_context_overflow is promoted from a module-private helper to a public one so the classifier can share the same matching logic without duplicating the substrings. test_insights.py is updated to the new name.

Two new tests in test_schedule_delivery_modes.py assert:
- the classifier picks up the env-tunable budget (overriding via CIAO_INSIGHTS_TIMEOUT_S), so a slow backend stops looking like a guaranteed TimeoutError
- a 400-style overflow records context_overflow=True on the run, and the conservative default (keep the chat visible) still holds

Full suite: 1879 passed, 1 skipped (the two pre-existing desktop-app install failures in test_cli.py are unrelated to this change). Mypy clean on the touched files.

Diff: 4 files, +84 / -12.