### PR TITLE
style(desktop): apply rustfmt to the notification imports

### DIFF
--- a/desktop/src-tauri/src/native_notifications.rs
+++ b/desktop/src-tauri/src/native_notifications.rs
@@ -1,4 +1,4 @@
-use mac_usernotifications::{close_delivered, get_delivered_notification_ids, Notification};
+use mac_usernotifications::{Notification, close_delivered, get_delivered_notification_ids};
 use objc2::{AnyThread, define_class, rc::Retained};
 use objc2_foundation::{NSObject, NSObjectProtocol};
 use objc2_user_notifications::{


### PR DESCRIPTION
`develop` is currently red: the `Check desktop Rust formatting` step (`cargo fmt --check`) fails on `desktop/src-tauri/src/native_notifications.rs:1`. Edition-2024 import sorting puts `Notification` ahead of the lowercase items.

Introduced by `fac4639 feat: sync notification clears across devices`, which was pushed directly to `develop`, so no PR CI ran on it beforehand.

Formatting only — one line, no behaviour change. I scanned every other file under `desktop/src-tauri/src/` with `rustfmt --edition 2024 --check`; this was the only one affected.

This also unblocks the other open PRs: because PR CI runs against the merge result, every one of them currently inherits this failure from `develop`.