### PR TITLE
fix(mcp): validate delegate_spawn model against configured models

### DIFF
--- a/ciao/control_plane.py
+++ b/ciao/control_plane.py
@@ -24,7 +24,7 @@ from ciao.fts_search import get_db_path, index_vault, init_db, search_vault
 from ciao.loops import publish_loops_changed
 from ciao.memory_tool import resolve_region
 from ciao.models import ControlSurface
-from ciao.web.project_chats import _MAX_ACTIVE_DELEGATES
+from ciao.web.project_chats import UnknownModelError, _MAX_ACTIVE_DELEGATES
 from ciao.schedules import ScheduleEntry, compute_next_run
 
 logger = logging.getLogger(__name__)
@@ -794,7 +794,11 @@ class CiaoControlPlane:
                 spawned_from_chat_id=parent.chat_id,
                 delegation_id=delegation_id.strip(),
             )
-        except ValueError as exc:
+        except UnknownModelError as exc:
+            # Only the model failure is a model problem; an unknown provider
+            # or bucket raises ValueError before model validation and must
+            # keep its own identity at the MCP boundary (invalid_request)
+            # instead of being relabeled invalid_model (#259).
             raise ControlPlaneError("invalid_model", str(exc)) from exc
         # Same start/queue split as chat_send: a brand-new chat is never
         # streaming, so this normally starts immediately.

--- a/ciao/control_plane.py
+++ b/ciao/control_plane.py
@@ -783,16 +783,19 @@ class CiaoControlPlane:
                 f"spawning another.",
             )
         project = self._resolve_project(principal, project_id)
-        chat = self.pcm.create_chat(
-            project.project_id,
-            title=title.strip() or "Delegate",
-            provider=provider,
-            model=model,
-            model_bucket=model_bucket,
-            mode=mode,
-            spawned_from_chat_id=parent.chat_id,
-            delegation_id=delegation_id.strip(),
-        )
+        try:
+            chat = self.pcm.create_chat(
+                project.project_id,
+                title=title.strip() or "Delegate",
+                provider=provider,
+                model=model,
+                model_bucket=model_bucket,
+                mode=mode,
+                spawned_from_chat_id=parent.chat_id,
+                delegation_id=delegation_id.strip(),
+            )
+        except ValueError as exc:
+            raise ControlPlaneError("invalid_model", str(exc)) from exc
         # Same start/queue split as chat_send: a brand-new chat is never
         # streaming, so this normally starts immediately.
         if self.pcm.queue_message(chat.chat_id, prompt.strip()):

--- a/ciao/mcp_server.py
+++ b/ciao/mcp_server.py
@@ -1168,7 +1168,11 @@ class CiaoMcpService:
                     "done" means.
                 title: Short sidebar label, e.g. "Fix #238 NSIRD drop".
                 model: Model for the delegate, e.g. a cheaper or specialized
-                    one. Omit to inherit the workspace default.
+                    one. Must be in the configured model set for the resolved
+                    provider (Ollama local/cloud, OpenRouter, or Anthropic
+                    tier alias). Unknown ids are rejected with `invalid_model`
+                    and a list of valid alternatives. Omit to inherit the
+                    workspace default.
                 delegation_id: Shared tag for delegates dispatched as one
                     batch, so their completion reports group together.
             """

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -4061,12 +4061,12 @@ class ProjectChatManager:
 
         if effective.startswith("custom:"):
             provider_id = effective.split(":", 1)[1]
-            target = getattr(self._config, "custom_routing", {}).get(provider_id, {}).get(
-                canonical_tier(model), model
-            )
-            if target and target != model:
-                return target
-            return canonical_tier(model) if is_tier(model) else (target or model)
+            custom_target = getattr(self._config, "custom_routing", {}).get(
+                provider_id, {}
+            ).get(canonical_tier(model), model)
+            if custom_target and custom_target != model:
+                return cast(str, custom_target)
+            return canonical_tier(model) if is_tier(model) else custom_target
 
         if not self._bucket_routes_to_ollama(effective):
             return canonical_tier(model) if is_tier(model) else model
@@ -7731,7 +7731,7 @@ class ProjectChatManager:
                 raise ValueError("Read-aloud is macOS-only.")
             raise ValueError(
                 "Read-aloud is unavailable. Install the desktop app with "
-                "`ciao desktop install`."
+                "the Ciaobot one-line installer."
             )
         try:
             speaker = SystemSpeaker(

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -93,6 +93,7 @@ from ciao.providers.codex import (
 )
 from ciao.providers.routing import intended_backend, routing_env_for_model
 from ciao.custom_providers import (
+    encode_model,
     env_for_model as custom_env_for_model,
     load_custom_providers,
     provider_for_model,
@@ -4085,8 +4086,17 @@ class ProjectChatManager:
             return
         if provider == "codex":
             return
-        if provider_for_model(self._config, model) is not None:
-            return
+        custom = provider_for_model(self._config, model)
+        if custom is not None:
+            # A provider with an explicit model list must be used with one
+            # of its members, else the typo reaches the endpoint on the
+            # first turn (#259). An empty list means no catalog to check
+            # against (e.g. an LM Studio endpoint serving dynamic models),
+            # so any id for that provider stays valid.
+            if not custom.models or model in {
+                encode_model(custom.id, m) for m in custom.models
+            }:
+                return
         if is_tier(model):
             return
         # Ollama: membership in the local daemon list, the cloud allowlist /

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -4145,20 +4145,28 @@ class ProjectChatManager:
             )
         ):
             return
-        # OpenRouter: the statically configured models and tier targets stay
-        # valid even when catalog discovery failed at startup and never
-        # merged them into claude_models (#259). Tier targets are gated on
-        # ``openrouter.available`` so default values like
-        # ``anthropic/claude-sonnet-latest`` do not reach a Claude provider
-        # with no OpenRouter routing overrides when no API key is set.
-        allowed = list(self._config.claude_models)
-        allowed += list(self._config.openrouter.models)
-        if self._config.openrouter.available:
+        # Fallback set: ``claude_models`` (filtered to drop Ollama cloud-shaped
+        # entries when no cloud API key is set, since ``CiaoConfig.from_env``
+        # merges ``CIAO_OLLAMA_MODELS`` into the picker and lets a
+        # cloud-shaped id sneak in here even when the earlier Ollama checks
+        # rejected it) plus the OpenRouter static allowlist and tier
+        # targets, both gated on ``openrouter.available`` (#259).
+        openrouter = self._config.openrouter
+        claude_models = [
+            m
+            for m in self._config.claude_models
+            if cloud_available
+            or is_local_ollama_model(m, ollama)
+            or ":" not in m
+        ]
+        allowed = list(claude_models)
+        if openrouter.available:
+            allowed += list(openrouter.models)
             allowed += [
-                self._config.openrouter.haiku_model,
-                self._config.openrouter.sonnet_model,
-                self._config.openrouter.opus_model,
-                self._config.openrouter.fable_model,
+                openrouter.haiku_model,
+                openrouter.sonnet_model,
+                openrouter.opus_model,
+                openrouter.fable_model,
             ]
         if model in allowed:
             return

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -4073,18 +4073,18 @@ class ProjectChatManager:
         A valid id is therefore either a configured id, a tier alias
         (``haiku``/``sonnet``/``opus``/``fable``) that ``_resolve_claude_model``
         expands at dispatch time, an Ollama model that is in the local
-        daemon list, the cloud allowlist / discovered catalog, or the
-        configured tier targets, an OpenRouter model from the static
-        allowlist or tier targets (valid even when catalog discovery failed
-        and never merged them into ``claude_models``), or a
-        ``custom:<id>:<model>`` id routed through a configured custom
-        provider. Codex is skipped because its catalog is async and the
-        Codex CLI already rejects unknown ids with a clear error at the
-        first turn.
+        daemon list, the cloud allowlist / discovered catalog, or a
+        configured tier target whose backend is actually available, an
+        OpenRouter model from the static allowlist or tier targets (valid
+        even when catalog discovery failed and never merged them into
+        ``claude_models``), or a ``custom:<id>:<model>`` id routed through
+        a configured custom provider. Native Codex ids are skipped because
+        the catalog is async and the Codex CLI already rejects unknown ids
+        with a clear error at the first turn; ``custom:``-prefixed ids
+        still flow through the custom-provider membership check before
+        that exemption fires.
         """
         if not model:
-            return
-        if provider == "codex":
             return
         custom = provider_for_model(self._config, model)
         if custom is not None:
@@ -4092,30 +4092,42 @@ class ProjectChatManager:
             # of its members, else the typo reaches the endpoint on the
             # first turn (#259). An empty list means no catalog to check
             # against (e.g. an LM Studio endpoint serving dynamic models),
-            # so any id for that provider stays valid.
+            # so any id for that provider stays valid. Custom Codex models
+            # are checked here too, so a codex-routed typo never bypasses
+            # this validator.
             if not custom.models or model in {
                 encode_model(custom.id, m) for m in custom.models
             }:
                 return
+        if provider == "codex":
+            return
         if is_tier(model):
             return
         # Ollama: membership in the local daemon list, the cloud allowlist /
-        # discovered catalog, or the configured tier targets. Not the routing
-        # shape predicate (``is_ollama_model``), which accepts any
-        # ``:tag``-shaped id when cloud is configured and would let a typo
-        # through to a chat that fails on its first turn (#259).
+        # discovered catalog, or a configured tier target whose backend is
+        # actually available. Default tier targets like ``minimax-m3:cloud``
+        # are filled in even when no Ollama backend is configured, so
+        # accepting them unconditionally lets the id reach a Claude
+        # provider with no Ollama routing overrides and fail on its first
+        # turn (#259).
         ollama = self._config.ollama
+        local_available = bool(ollama.local_models)
+        cloud_available = bool(ollama.api_key) and ollama.api_key != "ollama"
+        backend_available = local_available or cloud_available
         if (
             is_local_ollama_model(model, ollama)
             or model in ollama.models
-            or model
-            in {
-                ollama.haiku_model,
-                ollama.sonnet_model,
-                ollama.opus_model,
-                ollama.fable_model,
-                ollama.title_model,
-            }
+            or (
+                backend_available
+                and model
+                in {
+                    ollama.haiku_model,
+                    ollama.sonnet_model,
+                    ollama.opus_model,
+                    ollama.fable_model,
+                    ollama.title_model,
+                }
+            )
         ):
             return
         # OpenRouter: the statically configured models and tier targets stay

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -1719,20 +1719,27 @@ class ProjectChatManager:
                 f"To begin, tell me: **What is your name, and what is your primary focus (work/personal) right now?**"
             )
 
-        # A system bootstrap chat must always be creatable, so it uses a
-        # guaranteed-valid tier alias rather than the workspace default: a
-        # stale hand-edited default would otherwise crash the server at
-        # startup instead of surfacing as a create_chat error the user can
-        # fix in Settings (#259).
-        chat = self.create_chat(
-            project_id,
-            title=title,
-            model="haiku",
-            # The bootstrap chat must not inherit a stale workspace routing
-            # bucket: its tier alias is intentionally guaranteed-valid so a
-            # removed backend credential cannot prevent startup.
-            model_bucket="work",
-        )
+        # Prefer the workspace's configured routing bucket so a wizard-selected
+        # Ollama/OpenRouter install keeps using that backend for onboarding.
+        # Use the haiku tier alias (valid after resolve) and only fall back to
+        # the Anthropic ``work`` bucket when the preferred route fails
+        # validation — e.g. a stale hand-edited credential that would otherwise
+        # crash startup (#259).
+        preferred_bucket = self._effective_bucket("", project_id)
+        try:
+            chat = self.create_chat(
+                project_id,
+                title=title,
+                model="haiku",
+                model_bucket=preferred_bucket,
+            )
+        except UnknownModelError:
+            chat = self.create_chat(
+                project_id,
+                title=title,
+                model="haiku",
+                model_bucket="work",
+            )
         chat.handover_context_pending = True
         chat.handover_messages = [
             {"role": "user", "content": user_msg},

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -35,6 +35,17 @@ class RestartDrainingError(RuntimeError):
     def __init__(self, message: str = RESTART_DRAIN_MESSAGE) -> None:
         super().__init__(message)
 
+
+class UnknownModelError(ValueError):
+    """A model id that is not in the configured set.
+
+    Raised by ``ProjectChatManager._validate_configured_model``. Distinct
+    from the other ``ValueError``s ``create_chat`` raises (unknown provider,
+    bucket, control surface) so the MCP delegate boundary can translate only
+    the model failure to ``invalid_model`` and leave the rest as
+    ``invalid_request`` (#259).
+    """
+
 try:  # pragma: no cover - Ciaobot targets Unix; fallback keeps imports portable.
     import fcntl
 except ImportError:  # pragma: no cover
@@ -1707,10 +1718,15 @@ class ProjectChatManager:
                 f"To begin, tell me: **What is your name, and what is your primary focus (work/personal) right now?**"
             )
 
+        # A system bootstrap chat must always be creatable, so it uses a
+        # guaranteed-valid tier alias rather than the workspace default: a
+        # stale hand-edited default would otherwise crash the server at
+        # startup instead of surfacing as a create_chat error the user can
+        # fix in Settings (#259).
         chat = self.create_chat(
             project_id,
             title=title,
-            model=self._config.claude_default_model,
+            model="haiku",
         )
         chat.handover_context_pending = True
         chat.handover_messages = [
@@ -2788,11 +2804,8 @@ class ProjectChatManager:
             raise ValueError(f"Unknown model bucket '{model_bucket}'")
         if control_surface not in {None, "", "legacy", "mcp", "auto"}:
             raise ValueError(f"Unknown control surface '{control_surface}'")
-        # Sweep any other empty chats before creating a new one. Opening a
-        # fresh "New Chat" signals the user has moved on from whatever they
-        # had open and never sent, so we don't let empty shells pile up.
-        self._cleanup_empty_chats()
-        cid = f"chat-{_uuid8()}"
+        # Resolve the effective model/provider before any side effects, so a
+        # rejected model can't leave unrelated empty chats deleted (#259).
         # Per-workspace default: personal projects can default to Ollama
         # models, work to Anthropic, etc. Explicit ``model`` arg wins.
         project = self._projects.get(project_id)
@@ -2803,7 +2816,16 @@ class ProjectChatManager:
         if not chat_provider:
             chat_provider = self._config.default_provider_for_workspace(workspace)
         self._validate_custom_model_runner(chat_model, chat_provider)
-        self._validate_configured_model(model, chat_provider)
+        # Validate the effective model (the workspace default when ``model``
+        # is omitted), not just the explicit arg, so a stale workspace
+        # default can't create a delegate that fails on its first turn
+        # (#259).
+        self._validate_configured_model(chat_model, chat_provider)
+        # Sweep any other empty chats before creating a new one. Opening a
+        # fresh "New Chat" signals the user has moved on from whatever they
+        # had open and never sent, so we don't let empty shells pile up.
+        self._cleanup_empty_chats()
+        cid = f"chat-{_uuid8()}"
         # Claude chats record the bucket explicitly: the workspace only
         # preselects (personal → "personal"), but an explicit picker choice
         # wins and survives project moves. Personal-bucket alias defaults
@@ -4071,7 +4093,7 @@ class ProjectChatManager:
         if model in allowed:
             return
         sample = ", ".join(allowed[:8]) if allowed else "(none configured)"
-        raise ValueError(
+        raise UnknownModelError(
             f"Unknown model '{model}' for provider '{provider or 'default'}' "
             f"(configured models: {sample})"
         )

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -3300,8 +3300,19 @@ class ProjectChatManager:
         clean_model = (model or "").strip()
         if not clean_model:
             raise ValueError("Model is required")
+        if not self._model_bucket_allowed(model_bucket):
+            raise ValueError(f"Unknown model bucket '{model_bucket}'")
         if self._broker.get(chat_id) is not None:
             raise ValueError("Cannot hand over while a turn is running")
+
+        target_bucket = model_bucket if provider == "claude" else ""
+        resolved_model, effective_bucket = self._resolve_and_validate_chat_model(
+            clean_model,
+            provider,
+            target_bucket,
+            chat.project_id,
+        )
+
         self._revoke_mcp_chat(chat_id)
 
         old_provider = chat.provider
@@ -3312,23 +3323,19 @@ class ProjectChatManager:
                 old_provider=old_provider,
                 old_model=old_model,
                 new_provider=provider,
-                new_model=clean_model,
+                new_model=resolved_model,
             )
         )
-        if not self._model_bucket_allowed(model_bucket):
-            raise ValueError(f"Unknown model bucket '{model_bucket}'")
         chat.handover_messages = rows
         chat.handover_context_pending = True
         chat.provider = provider
-        chat.model = clean_model
-        # Bucket only applies to Claude; explicit choice wins, otherwise
-        # the workspace preselects on the next resolution ("" = auto).
-        chat.model_bucket = model_bucket if provider == "claude" else ""
+        chat.model = resolved_model
+        chat.model_bucket = effective_bucket
         # Thinking levels are provider-native and don't carry across, except
         # that the Codex Fable preset is defined as Sol with Ultra effort.
         chat.thinking_level = (
             CODEX_FABLE_THINKING_LEVEL
-            if provider == "codex" and canonical_tier(clean_model) == "fable"
+            if provider == "codex" and canonical_tier(resolved_model) == "fable"
             else ""
         )
         chat.session_id = ""
@@ -4037,7 +4044,7 @@ class ProjectChatManager:
 
     def _resolve_claude_model(self, model: str, bucket: str, project_id: str) -> str:
         """Resolve picker aliases to Ollama, OpenRouter, or custom-provider models."""
-        from ciao.model_tiers import tier_model
+        from ciao.model_tiers import canonical_tier, is_tier, tier_model
 
         effective = self._effective_bucket(bucket, project_id)
         if effective == "openrouter":
@@ -4050,17 +4057,20 @@ class ProjectChatManager:
             )
             if target != model:
                 return target
-            return model
+            return canonical_tier(model) if is_tier(model) else model
 
         if effective.startswith("custom:"):
             provider_id = effective.split(":", 1)[1]
             target = getattr(self._config, "custom_routing", {}).get(provider_id, {}).get(
                 canonical_tier(model), model
             )
-            return target or model
+            if target and target != model:
+                return target
+            return canonical_tier(model) if is_tier(model) else (target or model)
 
         if not self._bucket_routes_to_ollama(effective):
-            return model
+            return canonical_tier(model) if is_tier(model) else model
+
         target = tier_model(
             model,
             haiku=self._config.ollama.haiku_model,
@@ -4071,17 +4081,20 @@ class ProjectChatManager:
         if effective == "personal" and not is_ollama_model(
             target, self._config.ollama
         ):
-            # ``personal`` is the legacy workspace fallback, not an explicit
+            # personal is the legacy workspace fallback, not an explicit
             # configured backend. Preserve its historical Anthropic alias
-            # fallback when no Ollama backend is present; explicit ``ollama``
+            # fallback when no Ollama backend is present; explicit ollama
             # workspace buckets still return the target so validation rejects
             # a stale route before chat creation (#259).
-            return model
+            return canonical_tier(model) if is_tier(model) else model
+
         # Return the configured target even when Ollama is unavailable. The
         # validator must see the effective routed id so it can reject a stale
         # bucket instead of accepting the bare tier alias and failing later
         # when the provider starts (#259).
-        return target or model
+        if target and target != model:
+            return target
+        return canonical_tier(model) if is_tier(model) else (target or model)
 
     def _resolve_and_validate_chat_model(
         self,
@@ -4094,13 +4107,17 @@ class ProjectChatManager:
     ) -> tuple[str, str]:
         """Resolve a chat model through its effective bucket, then validate it.
 
-        The order matters: aliases such as ``opus`` can resolve to an
+        The order matters: aliases such as opus can resolve to an
         unavailable OpenRouter, Ollama, or custom-provider target. Validating
         the alias first would accept the request even though the model that
         the provider will actually run is invalid.
         """
+        from ciao.model_tiers import canonical_tier, is_tier
+
         effective_bucket = ""
-        resolved_model = model
+        resolved_model = (model or "").strip()
+        if is_tier(resolved_model):
+            resolved_model = canonical_tier(resolved_model)
         if provider == "claude":
             effective_bucket = self._effective_bucket(model_bucket or "", project_id)
             if resolve_model:

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -4071,9 +4071,11 @@ class ProjectChatManager:
         ``refresh_openrouter_models``, and ``refresh_cloud_ollama_models``.
         A valid id is therefore either a configured id, a tier alias
         (``haiku``/``sonnet``/``opus``/``fable``) that ``_resolve_claude_model``
-        expands at dispatch time, a model that ``is_ollama_model`` recognises
-        (covers the local-daemon list and the cloud ``:tag``-shaped ids
-        without forcing callers to pre-merge the two sets), or a
+        expands at dispatch time, an Ollama model that is in the local
+        daemon list, the cloud allowlist / discovered catalog, or the
+        configured tier targets, an OpenRouter model from the static
+        allowlist or tier targets (valid even when catalog discovery failed
+        and never merged them into ``claude_models``), or a
         ``custom:<id>:<model>`` id routed through a configured custom
         provider. Codex is skipped because its catalog is async and the
         Codex CLI already rejects unknown ids with a clear error at the
@@ -4087,9 +4089,36 @@ class ProjectChatManager:
             return
         if is_tier(model):
             return
-        if is_ollama_model(model, self._config.ollama):
+        # Ollama: membership in the local daemon list, the cloud allowlist /
+        # discovered catalog, or the configured tier targets. Not the routing
+        # shape predicate (``is_ollama_model``), which accepts any
+        # ``:tag``-shaped id when cloud is configured and would let a typo
+        # through to a chat that fails on its first turn (#259).
+        ollama = self._config.ollama
+        if (
+            is_local_ollama_model(model, ollama)
+            or model in ollama.models
+            or model
+            in {
+                ollama.haiku_model,
+                ollama.sonnet_model,
+                ollama.opus_model,
+                ollama.fable_model,
+                ollama.title_model,
+            }
+        ):
             return
+        # OpenRouter: the statically configured models and tier targets stay
+        # valid even when catalog discovery failed at startup and never
+        # merged them into claude_models (#259).
         allowed = list(self._config.claude_models)
+        allowed += list(self._config.openrouter.models)
+        allowed += [
+            self._config.openrouter.haiku_model,
+            self._config.openrouter.sonnet_model,
+            self._config.openrouter.opus_model,
+            self._config.openrouter.fable_model,
+        ]
         if model in allowed:
             return
         sample = ", ".join(allowed[:8]) if allowed else "(none configured)"

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -2820,12 +2820,6 @@ class ProjectChatManager:
         chat_provider = provider
         if not chat_provider:
             chat_provider = self._config.default_provider_for_workspace(workspace)
-        self._validate_custom_model_runner(chat_model, chat_provider)
-        # Validate the effective model (the workspace default when ``model``
-        # is omitted), not just the explicit arg, so a stale workspace
-        # default can't create a delegate that fails on its first turn
-        # (#259).
-        self._validate_configured_model(chat_model, chat_provider)
         # Claude chats record the bucket explicitly: the workspace only
         # preselects (personal → "personal"), but an explicit picker choice
         # wins and survives project moves. Personal-bucket alias defaults
@@ -2834,24 +2828,18 @@ class ProjectChatManager:
         chat_bucket = ""
         if chat_provider == "claude":
             chat_bucket = self._effective_bucket(model_bucket or "", project_id)
-            if (
-                self._bucket_routes_to_ollama(chat_bucket)
-                or chat_bucket == "openrouter"
-            ) and (
-                model is None
-                or model_bucket is not None
-                or chat_bucket == "openrouter"
-            ):
-                chat_model = self._resolve_claude_model(
-                    chat_model, chat_bucket, project_id
-                )
-            # The workspace bucket can be persisted independently of backend
-            # credentials. Revalidate after resolving a tier alias so a
-            # stale OpenRouter bucket cannot turn ``opus`` into an
-            # unavailable ``owner/model`` id after the pre-resolution tier
-            # check above (#259).
-            self._validate_custom_model_runner(chat_model, chat_provider)
-            self._validate_configured_model(chat_model, chat_provider)
+        resolve_model = not (
+            model is not None
+            and model_bucket is None
+            and chat_bucket == "personal"
+        )
+        chat_model, _ = self._resolve_and_validate_chat_model(
+            chat_model,
+            chat_provider,
+            chat_bucket,
+            project_id,
+            resolve_model=resolve_model,
+        )
         # Sweep any other empty chats only after all model and routing-bucket
         # validation has succeeded. Opening a fresh "New Chat" signals the
         # user has moved on from whatever they had open and never sent, so we
@@ -2972,14 +2960,7 @@ class ProjectChatManager:
         )
         if provider is not None and provider not in supported_providers():
             raise ValueError(f"Unknown provider '{provider}'")
-        self._validate_custom_model_runner(model or chat.model, provider or chat.provider)
-        # Validate the model id we'll end up with against the provider we'll
-        # end up on, even when only one of the two is being changed.
         target_provider = provider or chat.provider
-        if model is not None:
-            self._validate_configured_model(model, target_provider)
-        elif provider is not None:
-            self._validate_configured_model(chat.model, target_provider)
         if not self._model_bucket_allowed(model_bucket):
             raise ValueError(f"Unknown model bucket '{model_bucket}'")
         if thinking_level is not None:
@@ -2992,7 +2973,8 @@ class ProjectChatManager:
                     f"Unknown thinking level '{thinking_level}' for provider "
                     f"'{target_provider}' (allowed: {', '.join(allowed)})"
                 )
-        moved_from: str | None = None
+
+        target_project_id = project_id if project_id is not None else chat.project_id
         if project_id is not None and project_id != chat.project_id:
             if chat.archived:
                 raise ValueError("Cannot move an archived chat")
@@ -3005,12 +2987,38 @@ class ProjectChatManager:
                     "Cannot move chat across workspaces "
                     f"({current.workspace} → {target.workspace})"
                 )
+
+        changes_model = (
+            model is not None
+            or provider is not None
+            or model_bucket is not None
+        )
+        new_model = model if model is not None else chat.model
+        requested_bucket = (
+            model_bucket if model_bucket is not None else chat.model_bucket
+        )
+        effective_bucket = ""
+        if changes_model:
+            resolve_model = not (
+                model is not None
+                and model_bucket is None
+                and requested_bucket == "personal"
+            )
+            new_model, effective_bucket = self._resolve_and_validate_chat_model(
+                new_model,
+                target_provider,
+                requested_bucket,
+                target_project_id,
+                resolve_model=resolve_model,
+            )
+
+        moved_from: str | None = None
+        if project_id is not None and project_id != chat.project_id:
             moved_from = chat.project_id
             chat.project_id = project_id
         if title is not None:
             chat.title = title
-        if model is not None or provider is not None or model_bucket is not None:
-            new_model = model if model is not None else chat.model
+        if changes_model:
             new_provider = provider if provider is not None else chat.provider
             new_bucket = model_bucket if model_bucket is not None else chat.model_bucket
             # Cross-provider switches mid-chat would silently break: the
@@ -3030,7 +3038,7 @@ class ProjectChatManager:
                 chat.provider, chat.model, new_provider, new_model,
                 project_id=chat.project_id,
                 old_bucket=chat.model_bucket,
-                new_bucket=new_bucket,
+                new_bucket=effective_bucket or new_bucket,
             ):
                 raise ValueError(
                     "Can't switch providers or model backends once a chat has "
@@ -4060,9 +4068,48 @@ class ProjectChatManager:
             opus=self._config.ollama.opus_model,
             fable=self._config.ollama.fable_model,
         )
-        if target and is_ollama_model(target, self._config.ollama):
-            return target
-        return model
+        if effective == "personal" and not is_ollama_model(
+            target, self._config.ollama
+        ):
+            # ``personal`` is the legacy workspace fallback, not an explicit
+            # configured backend. Preserve its historical Anthropic alias
+            # fallback when no Ollama backend is present; explicit ``ollama``
+            # workspace buckets still return the target so validation rejects
+            # a stale route before chat creation (#259).
+            return model
+        # Return the configured target even when Ollama is unavailable. The
+        # validator must see the effective routed id so it can reject a stale
+        # bucket instead of accepting the bare tier alias and failing later
+        # when the provider starts (#259).
+        return target or model
+
+    def _resolve_and_validate_chat_model(
+        self,
+        model: str,
+        provider: str,
+        model_bucket: str | None,
+        project_id: str,
+        *,
+        resolve_model: bool = True,
+    ) -> tuple[str, str]:
+        """Resolve a chat model through its effective bucket, then validate it.
+
+        The order matters: aliases such as ``opus`` can resolve to an
+        unavailable OpenRouter, Ollama, or custom-provider target. Validating
+        the alias first would accept the request even though the model that
+        the provider will actually run is invalid.
+        """
+        effective_bucket = ""
+        resolved_model = model
+        if provider == "claude":
+            effective_bucket = self._effective_bucket(model_bucket or "", project_id)
+            if resolve_model:
+                resolved_model = self._resolve_claude_model(
+                    resolved_model, effective_bucket, project_id
+                )
+        self._validate_custom_model_runner(resolved_model, provider)
+        self._validate_configured_model(resolved_model, provider)
+        return resolved_model, effective_bucket
 
     def _runtime_model_for_chat(self, chat: ChatInfo) -> str:
         """Resolve the model the provider should actually run for a chat."""

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -7731,7 +7731,7 @@ class ProjectChatManager:
                 raise ValueError("Read-aloud is macOS-only.")
             raise ValueError(
                 "Read-aloud is unavailable. Install the desktop app with "
-                "the Ciaobot one-line installer."
+                "`ciao desktop install`."
             )
         try:
             speaker = SystemSpeaker(

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -2839,6 +2839,13 @@ class ProjectChatManager:
                 chat_model = self._resolve_claude_model(
                     chat_model, chat_bucket, project_id
                 )
+            # The workspace bucket can be persisted independently of backend
+            # credentials. Revalidate after resolving a tier alias so a
+            # stale OpenRouter bucket cannot turn ``opus`` into an
+            # unavailable ``owner/model`` id after the pre-resolution tier
+            # check above (#259).
+            self._validate_custom_model_runner(chat_model, chat_provider)
+            self._validate_configured_model(chat_model, chat_provider)
         chat = ChatInfo(
             chat_id=cid,
             project_id=project_id,

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -86,7 +86,7 @@ from ciao.providers.ollama import (
     is_ollama_model,
     vision_support_ollama,
 )
-from ciao.providers.openrouter import vision_support_openrouter
+from ciao.providers.openrouter import is_openrouter_model, vision_support_openrouter
 from ciao.providers.codex import (
     CodexProvider,
     codex_collab_tree_counts,
@@ -4126,23 +4126,18 @@ class ProjectChatManager:
         # API key so an ``CIAO_OLLAMA_MODELS`` allowlist entry does not
         # sneak through when no Ollama backend is actually configured.
         ollama = self._config.ollama
-        local_available = bool(ollama.local_models)
         cloud_available = bool(ollama.api_key) and ollama.api_key != "ollama"
-        backend_available = local_available or cloud_available
+        ollama_tier_targets = {
+            ollama.haiku_model,
+            ollama.sonnet_model,
+            ollama.opus_model,
+            ollama.fable_model,
+            ollama.title_model,
+        }
         if (
             is_local_ollama_model(model, ollama)
             or (cloud_available and model in ollama.models)
-            or (
-                backend_available
-                and model
-                in {
-                    ollama.haiku_model,
-                    ollama.sonnet_model,
-                    ollama.opus_model,
-                    ollama.fable_model,
-                    ollama.title_model,
-                }
-            )
+            or (cloud_available and model in ollama_tier_targets)
         ):
             return
         # Fallback set: ``claude_models`` (filtered to drop Ollama cloud-shaped
@@ -4155,9 +4150,12 @@ class ProjectChatManager:
         claude_models = [
             m
             for m in self._config.claude_models
-            if cloud_available
-            or is_local_ollama_model(m, ollama)
-            or ":" not in m
+            if (openrouter.available or not is_openrouter_model(m, openrouter))
+            and (
+                cloud_available
+                or is_local_ollama_model(m, ollama)
+                or ":" not in m
+            )
         ]
         allowed = list(claude_models)
         if openrouter.available:

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -1728,6 +1728,10 @@ class ProjectChatManager:
             project_id,
             title=title,
             model="haiku",
+            # The bootstrap chat must not inherit a stale workspace routing
+            # bucket: its tier alias is intentionally guaranteed-valid so a
+            # removed backend credential cannot prevent startup.
+            model_bucket="work",
         )
         chat.handover_context_pending = True
         chat.handover_messages = [
@@ -2831,8 +2835,12 @@ class ProjectChatManager:
         if chat_provider == "claude":
             chat_bucket = self._effective_bucket(model_bucket or "", project_id)
             if (
-                (self._bucket_routes_to_ollama(chat_bucket) or chat_bucket == "openrouter")
-                and (model is None or model_bucket is not None)
+                self._bucket_routes_to_ollama(chat_bucket)
+                or chat_bucket == "openrouter"
+            ) and (
+                model is None
+                or model_bucket is not None
+                or chat_bucket == "openrouter"
             ):
                 chat_model = self._resolve_claude_model(
                     chat_model, chat_bucket, project_id

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -4099,6 +4099,14 @@ class ProjectChatManager:
                 encode_model(custom.id, m) for m in custom.models
             }:
                 return
+        elif model.startswith("custom:"):
+            # A ``custom:``-prefixed id whose provider was deleted or never
+            # configured would otherwise fall through to the native Codex
+            # exemption, sending the encoded id to the Codex CLI and
+            # failing on its first turn. Reject up front (#259).
+            raise UnknownModelError(
+                f"Unknown custom model '{model}' (provider not registered)"
+            )
         if provider == "codex" and custom is None:
             # Exempt only native Codex ids (no ``custom:`` prefix): the
             # catalog is async and the Codex CLI rejects unknown ids with a
@@ -4114,14 +4122,16 @@ class ProjectChatManager:
         # are filled in even when no Ollama backend is configured, so
         # accepting them unconditionally lets the id reach a Claude
         # provider with no Ollama routing overrides and fail on its first
-        # turn (#259).
+        # turn (#259). Cloud catalog membership is gated on a real cloud
+        # API key so an ``CIAO_OLLAMA_MODELS`` allowlist entry does not
+        # sneak through when no Ollama backend is actually configured.
         ollama = self._config.ollama
         local_available = bool(ollama.local_models)
         cloud_available = bool(ollama.api_key) and ollama.api_key != "ollama"
         backend_available = local_available or cloud_available
         if (
             is_local_ollama_model(model, ollama)
-            or model in ollama.models
+            or (cloud_available and model in ollama.models)
             or (
                 backend_available
                 and model
@@ -4137,15 +4147,19 @@ class ProjectChatManager:
             return
         # OpenRouter: the statically configured models and tier targets stay
         # valid even when catalog discovery failed at startup and never
-        # merged them into claude_models (#259).
+        # merged them into claude_models (#259). Tier targets are gated on
+        # ``openrouter.available`` so default values like
+        # ``anthropic/claude-sonnet-latest`` do not reach a Claude provider
+        # with no OpenRouter routing overrides when no API key is set.
         allowed = list(self._config.claude_models)
         allowed += list(self._config.openrouter.models)
-        allowed += [
-            self._config.openrouter.haiku_model,
-            self._config.openrouter.sonnet_model,
-            self._config.openrouter.opus_model,
-            self._config.openrouter.fable_model,
-        ]
+        if self._config.openrouter.available:
+            allowed += [
+                self._config.openrouter.haiku_model,
+                self._config.openrouter.sonnet_model,
+                self._config.openrouter.opus_model,
+                self._config.openrouter.fable_model,
+            ]
         if model in allowed:
             return
         sample = ", ".join(allowed[:8]) if allowed else "(none configured)"

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -2822,11 +2822,6 @@ class ProjectChatManager:
         # default can't create a delegate that fails on its first turn
         # (#259).
         self._validate_configured_model(chat_model, chat_provider)
-        # Sweep any other empty chats before creating a new one. Opening a
-        # fresh "New Chat" signals the user has moved on from whatever they
-        # had open and never sent, so we don't let empty shells pile up.
-        self._cleanup_empty_chats()
-        cid = f"chat-{_uuid8()}"
         # Claude chats record the bucket explicitly: the workspace only
         # preselects (personal → "personal"), but an explicit picker choice
         # wins and survives project moves. Personal-bucket alias defaults
@@ -2835,7 +2830,10 @@ class ProjectChatManager:
         chat_bucket = ""
         if chat_provider == "claude":
             chat_bucket = self._effective_bucket(model_bucket or "", project_id)
-            if (self._bucket_routes_to_ollama(chat_bucket) or chat_bucket == "openrouter") and model is None:
+            if (
+                (self._bucket_routes_to_ollama(chat_bucket) or chat_bucket == "openrouter")
+                and (model is None or model_bucket is not None)
+            ):
                 chat_model = self._resolve_claude_model(
                     chat_model, chat_bucket, project_id
                 )
@@ -2846,6 +2844,13 @@ class ProjectChatManager:
             # check above (#259).
             self._validate_custom_model_runner(chat_model, chat_provider)
             self._validate_configured_model(chat_model, chat_provider)
+        # Sweep any other empty chats only after all model and routing-bucket
+        # validation has succeeded. Opening a fresh "New Chat" signals the
+        # user has moved on from whatever they had open and never sent, so we
+        # don't let empty shells pile up; a rejected request must not delete
+        # those drafts as a side effect (#259).
+        self._cleanup_empty_chats()
+        cid = f"chat-{_uuid8()}"
         chat = ChatInfo(
             chat_id=cid,
             project_id=project_id,

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -4099,7 +4099,12 @@ class ProjectChatManager:
                 encode_model(custom.id, m) for m in custom.models
             }:
                 return
-        if provider == "codex":
+        if provider == "codex" and custom is None:
+            # Exempt only native Codex ids (no ``custom:`` prefix): the
+            # catalog is async and the Codex CLI rejects unknown ids with a
+            # clear error at the first turn. A rejected custom id must not
+            # be rescued by this exemption, else the typo reaches the
+            # endpoint anyway (#259).
             return
         if is_tier(model):
             return

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -65,6 +65,7 @@ from ciao.model_tiers import (
     CODEX_FABLE_THINKING_LEVEL,
     canonical_tier,
     is_capability_error,
+    is_tier,
     model_supports_vision,
     model_vision_ambiguous,
     next_tier_for_failure,
@@ -2802,6 +2803,7 @@ class ProjectChatManager:
         if not chat_provider:
             chat_provider = self._config.default_provider_for_workspace(workspace)
         self._validate_custom_model_runner(chat_model, chat_provider)
+        self._validate_configured_model(model, chat_provider)
         # Claude chats record the bucket explicitly: the workspace only
         # preselects (personal → "personal"), but an explicit picker choice
         # wins and survives project moves. Personal-bucket alias defaults
@@ -2928,6 +2930,13 @@ class ProjectChatManager:
         if provider is not None and provider not in supported_providers():
             raise ValueError(f"Unknown provider '{provider}'")
         self._validate_custom_model_runner(model or chat.model, provider or chat.provider)
+        # Validate the model id we'll end up with against the provider we'll
+        # end up on, even when only one of the two is being changed.
+        target_provider = provider or chat.provider
+        if model is not None:
+            self._validate_configured_model(model, target_provider)
+        elif provider is not None:
+            self._validate_configured_model(chat.model, target_provider)
         if not self._model_bucket_allowed(model_bucket):
             raise ValueError(f"Unknown model bucket '{model_bucket}'")
         if thinking_level is not None:
@@ -4029,6 +4038,43 @@ class ProjectChatManager:
             raise ValueError(
                 f"Custom provider '{custom.name}' must be used with {custom.runner}"
             )
+
+    def _validate_configured_model(
+        self, model: str | None, provider: str | None
+    ) -> None:
+        """Reject a free-text model id that is not in the configured set.
+
+        ``claude_models`` is the single source of truth populated at startup
+        and on Settings → Models from ``refresh_local_ollama_models``,
+        ``refresh_openrouter_models``, and ``refresh_cloud_ollama_models``.
+        A valid id is therefore either a configured id, a tier alias
+        (``haiku``/``sonnet``/``opus``/``fable``) that ``_resolve_claude_model``
+        expands at dispatch time, a model that ``is_ollama_model`` recognises
+        (covers the local-daemon list and the cloud ``:tag``-shaped ids
+        without forcing callers to pre-merge the two sets), or a
+        ``custom:<id>:<model>`` id routed through a configured custom
+        provider. Codex is skipped because its catalog is async and the
+        Codex CLI already rejects unknown ids with a clear error at the
+        first turn.
+        """
+        if not model:
+            return
+        if provider == "codex":
+            return
+        if provider_for_model(self._config, model) is not None:
+            return
+        if is_tier(model):
+            return
+        if is_ollama_model(model, self._config.ollama):
+            return
+        allowed = list(self._config.claude_models)
+        if model in allowed:
+            return
+        sample = ", ".join(allowed[:8]) if allowed else "(none configured)"
+        raise ValueError(
+            f"Unknown model '{model}' for provider '{provider or 'default'}' "
+            f"(configured models: {sample})"
+        )
 
     def _thinking_level_for_chat(self, chat: ChatInfo) -> str:
         """Return the chat's thinking level, or "" when stale.

--- a/tests/test_chat_handover.py
+++ b/tests/test_chat_handover.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from ciao.config import CiaoConfig
+from ciao.providers.ollama import OllamaSettings
 from ciao.sessions import StateStore
 from ciao.transcripts import TranscriptStore
 from ciao.web.project_chats import ProjectChatManager
@@ -17,6 +19,7 @@ def _make_manager(tmp_path: Path) -> ProjectChatManager:
         workspace_root=tmp_path,
         state_path=runtime / "state.json",
         media_root=runtime / "media",
+        ollama=OllamaSettings(api_key="sk-ollama", models=("kimi-k2.7-code:cloud",)),
     )
     state = StateStore(config.state_path, tmp_path, config.media_root)
     transcripts = TranscriptStore(runtime, tmp_path / "transcripts")
@@ -124,3 +127,26 @@ def test_handover_messages_are_injected_into_next_prompt_once(tmp_path: Path) ->
     assert after.handover_context_pending is False
     assert "[Provider handover messages]" not in pcm._build_prompt_prefix(after)
     assert after.handover_messages
+
+
+def test_handover_chat_validates_and_canonicalizes_model(tmp_path: Path) -> None:
+    pcm = _make_manager(tmp_path)
+    project = pcm.create_project("handover", workspace="personal")
+    chat = pcm.create_chat(project.project_id, model="opus", provider="claude", model_bucket="work")
+
+    updated = pcm.handover_chat(
+        chat.chat_id,
+        provider="claude",
+        model=" Sonnet ",
+        model_bucket="work",
+    )
+    assert updated is not None
+    assert updated.model == "sonnet"
+
+    with pytest.raises(ValueError, match="Unknown custom model"):
+        pcm.handover_chat(
+            chat.chat_id,
+            provider="claude",
+            model="custom:missing:foo",
+        )
+    assert pcm.get_chat(chat.chat_id).model == "sonnet"

--- a/tests/test_delegates.py
+++ b/tests/test_delegates.py
@@ -800,6 +800,23 @@ def test_create_chat_accepts_statically_configured_openrouter_model(
     assert chat.model == "meta-llama/llama-4-maverick"
 
 
+def test_create_chat_rejects_openrouter_id_in_fallback_without_api_key(
+    tmp_path: Path,
+) -> None:
+    """An OpenRouter-shaped fallback id requires OpenRouter credentials."""
+    from ciao.providers.openrouter import OpenRouterSettings
+
+    manager = _make_manager(
+        tmp_path,
+        claude_models=["opus", "sonnet", "haiku", "vendor/model"],
+        openrouter=OpenRouterSettings(api_key=""),
+    )
+    project = manager.create_project("Delegates", workspace="work")
+
+    with pytest.raises(ValueError, match="Unknown model 'vendor/model'"):
+        manager.create_chat(project.project_id, model="vendor/model")
+
+
 def _write_custom_provider(
     tmp_path: Path, *, provider_id: str, models: list[str], runner: str = "claude"
 ) -> None:
@@ -900,6 +917,26 @@ def test_create_chat_accepts_ollama_tier_target_with_backend(
 
     chat = manager.create_chat(project.project_id, model="kimi-k2.7-code:cloud")
     assert chat.model == "kimi-k2.7-code:cloud"
+
+
+def test_create_chat_rejects_cloud_ollama_tier_with_only_local_backend(
+    tmp_path: Path,
+) -> None:
+    """A local daemon must not make cloud-only tier targets valid."""
+    from ciao.providers.ollama import OllamaSettings
+
+    manager = _make_manager(
+        tmp_path,
+        ollama=OllamaSettings(
+            api_key="",
+            local_models=("llama3.1:latest",),
+            opus_model="minimax-m3:cloud",
+        ),
+    )
+    project = manager.create_project("Delegates", workspace="work")
+
+    with pytest.raises(ValueError, match="Unknown model 'minimax-m3:cloud'"):
+        manager.create_chat(project.project_id, model="minimax-m3:cloud")
 
 
 def test_create_chat_rejects_unmatched_custom_codex_model(tmp_path: Path) -> None:

--- a/tests/test_delegates.py
+++ b/tests/test_delegates.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -797,3 +798,57 @@ def test_create_chat_accepts_statically_configured_openrouter_model(
         project.project_id, model="meta-llama/llama-4-maverick"
     )
     assert chat.model == "meta-llama/llama-4-maverick"
+
+
+def _write_custom_provider(tmp_path: Path, *, provider_id: str, models: list[str]) -> None:
+    """Register a custom provider in the worktree config's tracked file."""
+    path = tmp_path / ".ciao" / "custom_providers.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({
+            "providers": [{
+                "id": provider_id,
+                "name": provider_id,
+                "url": "http://localhost:1234/v1",
+                "runner": "claude",
+                "models": models,
+            }]
+        }),
+        encoding="utf-8",
+    )
+
+
+def test_create_chat_custom_provider_requires_member_model(tmp_path: Path) -> None:
+    """A ``custom:<id>:<model>`` id must name one of the provider's models.
+
+    ``provider_for_model`` only verifies the provider id exists; the
+    validator must also check the encoded model against the provider's
+    configured list, else the typo reaches the endpoint on the first
+    turn (#259).
+    """
+    _write_custom_provider(tmp_path, provider_id="lm-studio", models=["qwen2.5-coder"])
+    manager = _make_manager(tmp_path)
+    project = manager.create_project("Delegates", workspace="work")
+
+    with pytest.raises(ValueError, match="Unknown model 'custom:lm-studio:typo'"):
+        manager.create_chat(project.project_id, model="custom:lm-studio:typo")
+
+    chat = manager.create_chat(project.project_id, model="custom:lm-studio:qwen2.5-coder")
+    assert chat.model == "custom:lm-studio:qwen2.5-coder"
+
+
+def test_create_chat_custom_provider_without_model_list_accepts_any(
+    tmp_path: Path,
+) -> None:
+    """An empty custom-provider model list means no catalog to check.
+
+    Endpoints like LM Studio serve dynamic model names, so an operator
+    may configure a provider without enumerating models; any id for that
+    provider stays valid (#259).
+    """
+    _write_custom_provider(tmp_path, provider_id="lm-studio", models=[])
+    manager = _make_manager(tmp_path)
+    project = manager.create_project("Delegates", workspace="work")
+
+    chat = manager.create_chat(project.project_id, model="custom:lm-studio:anything")
+    assert chat.model == "custom:lm-studio:anything"

--- a/tests/test_delegates.py
+++ b/tests/test_delegates.py
@@ -852,3 +852,70 @@ def test_create_chat_custom_provider_without_model_list_accepts_any(
 
     chat = manager.create_chat(project.project_id, model="custom:lm-studio:anything")
     assert chat.model == "custom:lm-studio:anything"
+
+
+def test_create_chat_rejects_ollama_tier_target_without_backend(
+    tmp_path: Path,
+) -> None:
+    """A default Ollama tier target must not pass when no backend is available.
+
+    Default tier targets like ``minimax-m3:cloud`` are filled in even when
+    no Ollama backend is configured; accepting them unconditionally would
+    let the id reach a Claude provider with no Ollama routing overrides
+    and fail on its first turn (#259).
+    """
+    from ciao.providers.ollama import OllamaSettings
+
+    manager = _make_manager(
+        tmp_path,
+        ollama=OllamaSettings(
+            # No cloud key, no local daemon: no Ollama backend at all.
+            api_key="",
+            models=(),
+        ),
+    )
+    project = manager.create_project("Delegates", workspace="work")
+
+    with pytest.raises(ValueError, match="Unknown model 'minimax-m3:cloud'"):
+        manager.create_chat(project.project_id, model="minimax-m3:cloud")
+
+
+def test_create_chat_accepts_ollama_tier_target_with_backend(
+    tmp_path: Path,
+) -> None:
+    """A tier target is valid when the corresponding backend is available."""
+    from ciao.providers.ollama import OllamaSettings
+
+    manager = _make_manager(
+        tmp_path,
+        ollama=OllamaSettings(
+            api_key="test-key",
+            models=("kimi-k2.7-code:cloud",),
+            sonnet_model="kimi-k2.7-code:cloud",
+        ),
+    )
+    project = manager.create_project("Delegates", workspace="work")
+
+    chat = manager.create_chat(project.project_id, model="kimi-k2.7-code:cloud")
+    assert chat.model == "kimi-k2.7-code:cloud"
+
+
+def test_create_chat_rejects_unmatched_custom_codex_model(tmp_path: Path) -> None:
+    """Custom Codex models still need their provider's membership check.
+
+    The native Codex exemption must not bypass ``provider_for_model``'s
+    enumeration, else ``custom:my-provider:typo`` against a codex-routed
+    provider configured for a different model passes validation and the
+    typo reaches the endpoint on its first turn (#259).
+    """
+    _write_custom_provider(
+        tmp_path, provider_id="my-codex", models=["gpt-5.6"]
+    )
+    manager = _make_manager(tmp_path)
+    project = manager.create_project("Delegates", workspace="work")
+
+    with pytest.raises(ValueError, match="Unknown model 'custom:my-codex:typo'"):
+        manager.create_chat(project.project_id, model="custom:my-codex:typo")
+
+    chat = manager.create_chat(project.project_id, model="custom:my-codex:gpt-5.6")
+    assert chat.model == "custom:my-codex:gpt-5.6"

--- a/tests/test_delegates.py
+++ b/tests/test_delegates.py
@@ -743,3 +743,57 @@ def test_delegate_spawn_preserves_non_model_errors(tmp_path: Path) -> None:
         )
     assert not isinstance(excinfo.value, ControlPlaneError)
     assert "Unknown provider 'bogus'" in str(excinfo.value)
+
+
+def test_create_chat_rejects_unknown_ollama_cloud_model(tmp_path: Path) -> None:
+    """A ``:tag``-shaped id not in the Ollama catalog must be rejected.
+
+    The routing shape predicate (``is_ollama_model``) accepts any
+    ``:tag``-shaped id when cloud is configured; validation must check
+    catalog membership instead so a typo can't create a chat that fails
+    on its first turn (#259).
+    """
+    from ciao.providers.ollama import OllamaSettings
+
+    manager = _make_manager(
+        tmp_path,
+        ollama=OllamaSettings(
+            api_key="test-key",
+            models=("kimi-k2.7-code:cloud", "minimax-m3:cloud"),
+        ),
+    )
+    project = manager.create_project("Delegates", workspace="work")
+
+    with pytest.raises(ValueError, match="Unknown model 'typo-does-not-exist:cloud'"):
+        manager.create_chat(project.project_id, model="typo-does-not-exist:cloud")
+
+    # A catalog member passes.
+    chat = manager.create_chat(project.project_id, model="minimax-m3:cloud")
+    assert chat.model == "minimax-m3:cloud"
+
+
+def test_create_chat_accepts_statically_configured_openrouter_model(
+    tmp_path: Path,
+) -> None:
+    """A statically configured OpenRouter model stays valid without discovery.
+
+    ``CIAO_OPENROUTER_MODELS`` models live in ``config.openrouter.models``
+    but are only merged into ``claude_models`` when catalog discovery
+    succeeds; the validator must accept them directly so a catalog outage
+    doesn't block OpenRouter chat creation (#259).
+    """
+    from ciao.providers.openrouter import OpenRouterSettings
+
+    manager = _make_manager(
+        tmp_path,
+        openrouter=OpenRouterSettings(
+            api_key="test-key",
+            models=("anthropic/claude-sonnet-latest", "meta-llama/llama-4-maverick"),
+        ),
+    )
+    project = manager.create_project("Delegates", workspace="work")
+
+    chat = manager.create_chat(
+        project.project_id, model="meta-llama/llama-4-maverick"
+    )
+    assert chat.model == "meta-llama/llama-4-maverick"

--- a/tests/test_delegates.py
+++ b/tests/test_delegates.py
@@ -939,3 +939,111 @@ def test_create_chat_codex_exemption_only_for_native_ids(tmp_path: Path) -> None
 
     chat = manager.create_chat(project.project_id, provider="codex", model="gpt-5.6")
     assert chat.model == "gpt-5.6"
+
+
+def test_create_chat_rejects_unregistered_custom_id(tmp_path: Path) -> None:
+    """A ``custom:``-prefixed id with no registered provider must be rejected.
+
+    Without this guard, ``provider_for_model`` returns ``None`` for an
+    unregistered provider, and the native Codex exemption would rescue
+    the bogus id and forward it to the Codex CLI on its first turn (#259).
+    """
+    manager = _make_manager(tmp_path)
+    project = manager.create_project("Delegates", workspace="work")
+
+    with pytest.raises(ValueError, match="Unknown custom model 'custom:missing:foo'"):
+        manager.create_chat(
+            project.project_id, provider="codex", model="custom:missing:foo"
+        )
+
+    # Same id on the default Claude path is also rejected: it cannot be
+    # routed to anything.
+    with pytest.raises(ValueError, match="Unknown custom model 'custom:missing:foo'"):
+        manager.create_chat(project.project_id, model="custom:missing:foo")
+
+
+def test_create_chat_rejects_ollama_cloud_entry_without_cloud_key(
+    tmp_path: Path,
+) -> None:
+    """Cloud catalog membership requires a real cloud API key.
+
+    ``CIAO_OLLAMA_MODELS`` may list cloud-shaped ids regardless of whether
+    a key is configured. Without ``cloud_available`` the id would skip the
+    routing override and reach the Claude provider on its first turn (#259).
+    """
+    from ciao.providers.ollama import OllamaSettings
+
+    manager = _make_manager(
+        tmp_path,
+        ollama=OllamaSettings(
+            api_key="",  # no cloud key
+            models=("minimax-m3:cloud",),
+        ),
+    )
+    project = manager.create_project("Delegates", workspace="work")
+
+    with pytest.raises(ValueError, match="Unknown model 'minimax-m3:cloud'"):
+        manager.create_chat(project.project_id, model="minimax-m3:cloud")
+
+
+def test_create_chat_accepts_ollama_cloud_entry_with_cloud_key(
+    tmp_path: Path,
+) -> None:
+    """A cloud catalog entry is valid when the cloud API key is configured."""
+    from ciao.providers.ollama import OllamaSettings
+
+    manager = _make_manager(
+        tmp_path,
+        ollama=OllamaSettings(
+            api_key="test-key",
+            models=("minimax-m3:cloud",),
+        ),
+    )
+    project = manager.create_project("Delegates", workspace="work")
+
+    chat = manager.create_chat(project.project_id, model="minimax-m3:cloud")
+    assert chat.model == "minimax-m3:cloud"
+
+
+def test_create_chat_rejects_openrouter_tier_target_without_api_key(
+    tmp_path: Path,
+) -> None:
+    """OpenRouter tier targets require a configured API key.
+
+    Tier defaults like ``anthropic/claude-sonnet-latest`` are filled in
+    even when no ``OPENROUTER_API_KEY`` is set. Without ``openrouter.available``
+    the id would pass validation and reach the Claude provider, where
+    Anthropic would reject the ``owner/model`` shape on its first turn (#259).
+    """
+    from ciao.providers.openrouter import OpenRouterSettings
+
+    manager = _make_manager(
+        tmp_path,
+        openrouter=OpenRouterSettings(api_key=""),
+    )
+    project = manager.create_project("Delegates", workspace="work")
+
+    with pytest.raises(
+        ValueError, match="Unknown model 'anthropic/claude-sonnet-latest'"
+    ):
+        manager.create_chat(
+            project.project_id, model="anthropic/claude-sonnet-latest"
+        )
+
+
+def test_create_chat_accepts_openrouter_tier_target_with_api_key(
+    tmp_path: Path,
+) -> None:
+    """An OpenRouter tier target is valid when an API key is configured."""
+    from ciao.providers.openrouter import OpenRouterSettings
+
+    manager = _make_manager(
+        tmp_path,
+        openrouter=OpenRouterSettings(api_key="test-key"),
+    )
+    project = manager.create_project("Delegates", workspace="work")
+
+    chat = manager.create_chat(
+        project.project_id, model="anthropic/claude-sonnet-latest"
+    )
+    assert chat.model == "anthropic/claude-sonnet-latest"

--- a/tests/test_delegates.py
+++ b/tests/test_delegates.py
@@ -628,3 +628,62 @@ def test_delegate_spawn_rejects_an_empty_prompt(tmp_path: Path) -> None:
         )
 
     assert excinfo.value.code == "empty_prompt"
+
+
+def test_delegate_spawn_rejects_an_unconfigured_model(tmp_path: Path) -> None:
+    """Issue #259: free-text model ids must be validated at dispatch time.
+
+    ``claude_models`` defaults to ``["opus", "sonnet", "haiku"]``; an unknown
+    id like ``deepseek-coder`` must surface as a clear ``invalid_model``
+    error so the caller can correct the dispatch, instead of opening a chat
+    that silently fails on its first turn.
+    """
+    manager = _make_manager(tmp_path)
+    project = manager.create_project("Delegates", workspace="work")
+    parent = manager.create_chat(project.project_id, title="Supervisor")
+    manager.active_chat_ids = lambda: []  # type: ignore[method-assign]
+    plane = _control_plane(manager)
+
+    with pytest.raises(ControlPlaneError) as excinfo:
+        plane.delegate_spawn(
+            _principal(parent.chat_id, project.project_id),
+            prompt="do the thing",
+            model="deepseek-coder",
+        )
+
+    assert excinfo.value.code == "invalid_model"
+    assert "deepseek-coder" in str(excinfo.value)
+    # The error names valid alternatives so the agent can self-correct.
+    assert "opus" in str(excinfo.value)
+    assert "sonnet" in str(excinfo.value)
+    assert "haiku" in str(excinfo.value)
+
+
+def test_delegate_spawn_accepts_a_configured_model(tmp_path: Path) -> None:
+    """A model id that is in the configured set must pass through cleanly."""
+    manager = _make_manager(tmp_path)
+    project = manager.create_project("Delegates", workspace="work")
+    parent = manager.create_chat(project.project_id, title="Supervisor")
+    manager.active_chat_ids = lambda: []  # type: ignore[method-assign]
+    # Stub queue_message so delegate_spawn doesn't fall into the stream
+    # path (which needs a live event loop in this sync test).
+    manager.queue_message = lambda chat_id, text: True  # type: ignore[method-assign]
+    plane = _control_plane(manager)
+
+    result = plane.delegate_spawn(
+        _principal(parent.chat_id, project.project_id),
+        prompt="do the thing",
+        model="haiku",
+    )
+
+    assert result["ok"] is True
+    assert result["data"]["model"] == "haiku"
+
+
+def test_create_chat_rejects_an_unconfigured_model(tmp_path: Path) -> None:
+    """The validator runs on every ``create_chat`` path, not just delegates."""
+    manager = _make_manager(tmp_path)
+    project = manager.create_project("Delegates", workspace="work")
+
+    with pytest.raises(ValueError, match="Unknown model 'deepseek-coder'"):
+        manager.create_chat(project.project_id, model="deepseek-coder")

--- a/tests/test_delegates.py
+++ b/tests/test_delegates.py
@@ -800,7 +800,9 @@ def test_create_chat_accepts_statically_configured_openrouter_model(
     assert chat.model == "meta-llama/llama-4-maverick"
 
 
-def _write_custom_provider(tmp_path: Path, *, provider_id: str, models: list[str]) -> None:
+def _write_custom_provider(
+    tmp_path: Path, *, provider_id: str, models: list[str], runner: str = "claude"
+) -> None:
     """Register a custom provider in the worktree config's tracked file."""
     path = tmp_path / ".ciao" / "custom_providers.json"
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -810,7 +812,7 @@ def _write_custom_provider(tmp_path: Path, *, provider_id: str, models: list[str
                 "id": provider_id,
                 "name": provider_id,
                 "url": "http://localhost:1234/v1",
-                "runner": "claude",
+                "runner": runner,
                 "models": models,
             }]
         }),
@@ -909,13 +911,31 @@ def test_create_chat_rejects_unmatched_custom_codex_model(tmp_path: Path) -> Non
     typo reaches the endpoint on its first turn (#259).
     """
     _write_custom_provider(
-        tmp_path, provider_id="my-codex", models=["gpt-5.6"]
+        tmp_path, provider_id="my-codex", models=["gpt-5.6"], runner="codex"
     )
     manager = _make_manager(tmp_path)
     project = manager.create_project("Delegates", workspace="work")
 
     with pytest.raises(ValueError, match="Unknown model 'custom:my-codex:typo'"):
-        manager.create_chat(project.project_id, model="custom:my-codex:typo")
+        manager.create_chat(
+            project.project_id, provider="codex", model="custom:my-codex:typo"
+        )
 
-    chat = manager.create_chat(project.project_id, model="custom:my-codex:gpt-5.6")
+    chat = manager.create_chat(
+        project.project_id, provider="codex", model="custom:my-codex:gpt-5.6"
+    )
     assert chat.model == "custom:my-codex:gpt-5.6"
+
+
+def test_create_chat_codex_exemption_only_for_native_ids(tmp_path: Path) -> None:
+    """A bare id on the codex provider stays exempt.
+
+    The native Codex catalog is async, so plain ids pass through to the
+    Codex CLI, which rejects unknown ones with a clear error at the first
+    turn (#259).
+    """
+    manager = _make_manager(tmp_path)
+    project = manager.create_project("Delegates", workspace="work")
+
+    chat = manager.create_chat(project.project_id, provider="codex", model="gpt-5.6")
+    assert chat.model == "gpt-5.6"

--- a/tests/test_delegates.py
+++ b/tests/test_delegates.py
@@ -1047,3 +1047,94 @@ def test_create_chat_accepts_openrouter_tier_target_with_api_key(
         project.project_id, model="anthropic/claude-sonnet-latest"
     )
     assert chat.model == "anthropic/claude-sonnet-latest"
+
+
+def test_create_chat_rejects_ollama_cloud_id_in_claude_models_without_cloud_key(
+    tmp_path: Path,
+) -> None:
+    """An Ollama-shaped id in ``claude_models`` is gated on cloud availability.
+
+    ``CiaoConfig.from_env()`` merges ``CIAO_OLLAMA_MODELS`` into
+    ``claude_models``, so a cloud id can land in that fallback set even
+    when no cloud API key is set. The validator must filter the set down
+    to entries the configured backend can actually serve, otherwise the
+    id reaches a Claude provider and fails on its first turn (#259).
+    """
+    from ciao.providers.ollama import OllamaSettings
+
+    manager = _make_manager(
+        tmp_path,
+        ollama=OllamaSettings(api_key=""),
+        claude_models=["opus", "sonnet", "haiku", "minimax-m3:cloud"],
+    )
+    project = manager.create_project("Delegates", workspace="work")
+
+    with pytest.raises(ValueError, match="Unknown model 'minimax-m3:cloud'"):
+        manager.create_chat(project.project_id, model="minimax-m3:cloud")
+
+
+def test_create_chat_accepts_ollama_cloud_id_in_claude_models_with_cloud_key(
+    tmp_path: Path,
+) -> None:
+    """A cloud id in ``claude_models`` stays valid when the cloud key is set."""
+    from ciao.providers.ollama import OllamaSettings
+
+    manager = _make_manager(
+        tmp_path,
+        ollama=OllamaSettings(api_key="test-key"),
+        claude_models=["opus", "sonnet", "haiku", "minimax-m3:cloud"],
+    )
+    project = manager.create_project("Delegates", workspace="work")
+
+    chat = manager.create_chat(project.project_id, model="minimax-m3:cloud")
+    assert chat.model == "minimax-m3:cloud"
+
+
+def test_create_chat_rejects_openrouter_static_model_without_api_key(
+    tmp_path: Path,
+) -> None:
+    """An OpenRouter static allowlist entry is gated on credential availability.
+
+    ``CIAO_OPENROUTER_MODELS`` populates ``openrouter.models`` even when
+    no ``OPENROUTER_API_KEY`` is set; ``openrouter_env_for_model`` returns
+    no overrides in that case, so the ``owner/model`` id would fail at
+    the Anthropic endpoint on its first turn (#259).
+    """
+    from ciao.providers.openrouter import OpenRouterSettings
+
+    manager = _make_manager(
+        tmp_path,
+        openrouter=OpenRouterSettings(
+            api_key="",
+            models=("meta-llama/llama-4-maverick",),
+        ),
+    )
+    project = manager.create_project("Delegates", workspace="work")
+
+    with pytest.raises(
+        ValueError, match="Unknown model 'meta-llama/llama-4-maverick'"
+    ):
+        manager.create_chat(
+            project.project_id, model="meta-llama/llama-4-maverick"
+        )
+
+
+def test_create_chat_accepts_openrouter_static_model_with_api_key(
+    tmp_path: Path,
+) -> None:
+    """A static OpenRouter model is valid when the API key is configured."""
+    from ciao.providers.openrouter import OpenRouterSettings
+
+    manager = _make_manager(
+        tmp_path,
+        openrouter=OpenRouterSettings(
+            api_key="test-key",
+            models=("meta-llama/llama-4-maverick",),
+        ),
+    )
+    project = manager.create_project("Delegates", workspace="work")
+
+    chat = manager.create_chat(
+        project.project_id, model="meta-llama/llama-4-maverick"
+    )
+    assert chat.model == "meta-llama/llama-4-maverick"

--- a/tests/test_delegates.py
+++ b/tests/test_delegates.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from ciao.config import CiaoConfig
+from ciao.config import CiaoConfig, WorkspaceConfig
 from ciao.control_plane import CiaoControlPlane, ControlPlaneError, McpPrincipal
 from ciao.sessions import StateStore
 from ciao.transcripts import TranscriptStore
@@ -705,6 +705,27 @@ def test_create_chat_validates_the_workspace_default_model(tmp_path: Path) -> No
         manager.create_chat(project.project_id, title="New Chat")
 
 
+def test_create_chat_validates_an_inherited_ollama_alias(tmp_path: Path) -> None:
+    """An inherited Ollama bucket must validate the resolved tier target."""
+    from ciao.providers.ollama import OllamaSettings
+
+    manager = _make_manager(
+        tmp_path,
+        ollama=OllamaSettings(api_key="", models=()),
+        workspaces={
+            "client": WorkspaceConfig(
+                name="client",
+                vault_root="vaults/client",
+                model_bucket="ollama",
+            )
+        },
+    )
+    project = manager.create_project("Delegates", workspace="client")
+
+    with pytest.raises(ValueError, match="Unknown model 'minimax-m3:cloud'"):
+        manager.create_chat(project.project_id, model="opus")
+
+
 def test_create_chat_invalid_model_does_not_cleanup_empty_chats(
     tmp_path: Path,
 ) -> None:
@@ -871,6 +892,36 @@ def test_create_chat_custom_provider_without_model_list_accepts_any(
 
     chat = manager.create_chat(project.project_id, model="custom:lm-studio:anything")
     assert chat.model == "custom:lm-studio:anything"
+
+
+def test_create_chat_validates_custom_bucket_alias_target(tmp_path: Path) -> None:
+    """Custom routing buckets must validate their resolved tier target."""
+    _write_custom_provider(tmp_path, provider_id="lm-studio", models=["qwen2.5-coder"])
+    manager = _make_manager(
+        tmp_path,
+        custom_routing={
+            "lm-studio": {"opus": "custom:lm-studio:removed-model"},
+        },
+        workspaces={
+            "client": WorkspaceConfig(
+                name="client",
+                vault_root="vaults/client",
+                model_bucket="custom:lm-studio",
+            )
+        },
+    )
+    project = manager.create_project("Delegates", workspace="client")
+
+    with pytest.raises(
+        ValueError, match="Unknown model 'custom:lm-studio:removed-model'"
+    ):
+        manager.create_chat(project.project_id, model="opus")
+
+    manager._config.custom_routing = {
+        "lm-studio": {"opus": "custom:lm-studio:qwen2.5-coder"},
+    }
+    chat = manager.create_chat(project.project_id, model="opus")
+    assert chat.model == "custom:lm-studio:qwen2.5-coder"
 
 
 def test_create_chat_rejects_ollama_tier_target_without_backend(

--- a/tests/test_delegates.py
+++ b/tests/test_delegates.py
@@ -18,7 +18,7 @@ from ciao.web.project_chats import (
 )
 
 
-def _make_manager(tmp_path: Path) -> ProjectChatManager:
+def _make_manager(tmp_path: Path, **config_kwargs: object) -> ProjectChatManager:
     runtime = tmp_path / ".runtime"
     runtime.mkdir(parents=True, exist_ok=True)
     config = CiaoConfig(
@@ -26,6 +26,7 @@ def _make_manager(tmp_path: Path) -> ProjectChatManager:
         workspace_root=tmp_path,
         state_path=runtime / "state.json",
         media_root=runtime / "media",
+        **config_kwargs,
     )
     return ProjectChatManager(
         config,
@@ -687,3 +688,58 @@ def test_create_chat_rejects_an_unconfigured_model(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="Unknown model 'deepseek-coder'"):
         manager.create_chat(project.project_id, model="deepseek-coder")
+
+
+def test_create_chat_validates_the_workspace_default_model(tmp_path: Path) -> None:
+    """A stale workspace default must be rejected, not silently accepted.
+
+    When ``model`` is omitted, ``chat_model`` resolves to the workspace
+    default; validating only the explicit arg let an invalid default create
+    a delegate that fails on its first turn (#259).
+    """
+    manager = _make_manager(tmp_path, claude_default_model="deepseek-coder")
+    project = manager.create_project("Delegates", workspace="work")
+
+    with pytest.raises(ValueError, match="Unknown model 'deepseek-coder'"):
+        manager.create_chat(project.project_id, title="New Chat")
+
+
+def test_create_chat_invalid_model_does_not_cleanup_empty_chats(
+    tmp_path: Path,
+) -> None:
+    """A rejected model must not delete unrelated empty chats (#259).
+
+    Validation runs before ``_cleanup_empty_chats``, so a failed create
+    request leaves other abandoned drafts untouched.
+    """
+    manager = _make_manager(tmp_path)
+    project = manager.create_project("Delegates", workspace="work")
+    empty = manager.create_chat(project.project_id, title="New Chat")
+
+    with pytest.raises(ValueError, match="Unknown model 'deepseek-coder'"):
+        manager.create_chat(project.project_id, title="New Chat", model="deepseek-coder")
+
+    assert empty.chat_id in manager._chats
+
+
+def test_delegate_spawn_preserves_non_model_errors(tmp_path: Path) -> None:
+    """An unknown provider must not be relabeled as ``invalid_model`` (#259).
+
+    Only the specific unknown-model failure translates to ``invalid_model``;
+    other ``create_chat`` rejections keep their own identity so the MCP
+    boundary reports them as ``invalid_request``.
+    """
+    manager = _make_manager(tmp_path)
+    project = manager.create_project("Delegates", workspace="work")
+    parent = manager.create_chat(project.project_id, title="Supervisor")
+    manager.active_chat_ids = lambda: []  # type: ignore[method-assign]
+    plane = _control_plane(manager)
+
+    with pytest.raises(ValueError) as excinfo:
+        plane.delegate_spawn(
+            _principal(parent.chat_id, project.project_id),
+            prompt="do the thing",
+            provider="bogus",
+        )
+    assert not isinstance(excinfo.value, ControlPlaneError)
+    assert "Unknown provider 'bogus'" in str(excinfo.value)

--- a/tests/test_model_bucket.py
+++ b/tests/test_model_bucket.py
@@ -283,6 +283,39 @@ def test_explicit_openrouter_alias_requires_api_key(tmp_path):
         )
 
 
+def test_inherited_openrouter_alias_requires_api_key(tmp_path):
+    """An inherited routing bucket must resolve explicit tier aliases too."""
+    runtime = tmp_path / ".runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    config = CiaoConfig(
+        pwa_auth_token="t",
+        workspace_root=tmp_path,
+        state_path=runtime / "state.json",
+        media_root=runtime / "media",
+        openrouter=OpenRouterSettings(api_key=""),
+        workspaces={
+            "client": WorkspaceConfig(
+                name="client",
+                vault_root="vaults/client",
+                model_bucket="openrouter",
+                gws_profile="work",
+            )
+        },
+    )
+    pcm = ProjectChatManager(
+        config,
+        state_store=StateStore(config.state_path, tmp_path, config.media_root),
+        transcript_store=TranscriptStore(runtime, tmp_path / "transcripts"),
+        path=runtime / "web_projects.json",
+    )
+    project = pcm.create_project("client", workspace="client")
+
+    with pytest.raises(
+        ValueError, match="Unknown model 'anthropic/claude-opus-latest'"
+    ):
+        pcm.create_chat(project.project_id, model="opus")
+
+
 def test_failed_bucket_validation_preserves_empty_chats(tmp_path):
     """A rejected bucket must not clean up an existing empty draft."""
     runtime = tmp_path / ".runtime"

--- a/tests/test_model_bucket.py
+++ b/tests/test_model_bucket.py
@@ -215,6 +215,39 @@ def test_configured_workspace_provider_preselects_openrouter_bucket(tmp_path):
     assert env["ANTHROPIC_AUTH_TOKEN"] == "sk-or"
 
 
+def test_configured_openrouter_bucket_requires_api_key(tmp_path):
+    """A persisted OpenRouter bucket must not survive credential removal."""
+    runtime = tmp_path / ".runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    config = CiaoConfig(
+        pwa_auth_token="t",
+        workspace_root=tmp_path,
+        state_path=runtime / "state.json",
+        media_root=runtime / "media",
+        openrouter=OpenRouterSettings(api_key=""),
+        workspaces={
+            "client": WorkspaceConfig(
+                name="client",
+                vault_root="vaults/client",
+                model_bucket="openrouter",
+                gws_profile="work",
+            )
+        },
+    )
+    pcm = ProjectChatManager(
+        config,
+        state_store=StateStore(config.state_path, tmp_path, config.media_root),
+        transcript_store=TranscriptStore(runtime, tmp_path / "transcripts"),
+        path=runtime / "web_projects.json",
+    )
+    project = pcm.create_project("client", workspace="client")
+
+    with pytest.raises(
+        ValueError, match="Unknown model 'anthropic/claude-opus-latest'"
+    ):
+        pcm.create_chat(project.project_id)
+
+
 def test_openrouter_fable_alias_uses_fable_latest(tmp_path):
     runtime = tmp_path / ".runtime"
     runtime.mkdir(parents=True, exist_ok=True)

--- a/tests/test_model_bucket.py
+++ b/tests/test_model_bucket.py
@@ -316,6 +316,77 @@ def test_inherited_openrouter_alias_requires_api_key(tmp_path):
         pcm.create_chat(project.project_id, model="opus")
 
 
+def test_inherited_ollama_alias_requires_backend(tmp_path):
+    """An inherited Ollama bucket must resolve before validation."""
+    runtime = tmp_path / ".runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    config = CiaoConfig(
+        pwa_auth_token="t",
+        workspace_root=tmp_path,
+        state_path=runtime / "state.json",
+        media_root=runtime / "media",
+        ollama=OllamaSettings(api_key="", models=()),
+        workspaces={
+            "client": WorkspaceConfig(
+                name="client",
+                vault_root="vaults/client",
+                model_bucket="ollama",
+                gws_profile="work",
+            )
+        },
+    )
+    pcm = ProjectChatManager(
+        config,
+        state_store=StateStore(config.state_path, tmp_path, config.media_root),
+        transcript_store=TranscriptStore(runtime, tmp_path / "transcripts"),
+        path=runtime / "web_projects.json",
+    )
+    project = pcm.create_project("client", workspace="client")
+
+    with pytest.raises(
+        ValueError, match="Unknown model 'minimax-m3:cloud'"
+    ):
+        pcm.create_chat(project.project_id, model="opus")
+
+
+def test_update_chat_validates_bucket_resolved_model_before_mutating(tmp_path):
+    """A failed bucket-resolved update leaves the chat unchanged."""
+    runtime = tmp_path / ".runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    config = CiaoConfig(
+        pwa_auth_token="t",
+        workspace_root=tmp_path,
+        state_path=runtime / "state.json",
+        media_root=runtime / "media",
+        openrouter=OpenRouterSettings(api_key="sk-or"),
+        workspaces={
+            "client": WorkspaceConfig(
+                name="client",
+                vault_root="vaults/client",
+                model_bucket="openrouter",
+                gws_profile="work",
+            )
+        },
+    )
+    pcm = ProjectChatManager(
+        config,
+        state_store=StateStore(config.state_path, tmp_path, config.media_root),
+        transcript_store=TranscriptStore(runtime, tmp_path / "transcripts"),
+        path=runtime / "web_projects.json",
+    )
+    project = pcm.create_project("client", workspace="client")
+    chat = pcm.create_chat(project.project_id, model="opus", model_bucket="work")
+    before = (chat.model, chat.provider, chat.model_bucket)
+
+    config.openrouter = OpenRouterSettings(api_key="")
+    with pytest.raises(
+        ValueError, match="Unknown model 'anthropic/claude-opus-latest'"
+    ):
+        pcm.update_chat(chat.chat_id, model="opus", model_bucket="openrouter")
+
+    assert (chat.model, chat.provider, chat.model_bucket) == before
+
+
 def test_failed_bucket_validation_preserves_empty_chats(tmp_path):
     """A rejected bucket must not clean up an existing empty draft."""
     runtime = tmp_path / ".runtime"

--- a/tests/test_model_bucket.py
+++ b/tests/test_model_bucket.py
@@ -622,3 +622,113 @@ def test_configured_workspace_provider_preselects_ollama_bucket_and_tier(tmp_pat
     assert chat.model_bucket == "ollama"
     assert chat.model == "minimax-m3:cloud"
     assert pcm._runtime_model_for_chat(chat) == "minimax-m3:cloud"
+
+
+def test_onboarding_chat_keeps_openrouter_workspace_bucket(tmp_path: Path) -> None:
+    """Wizard-selected OpenRouter must not be forced onto Anthropic work."""
+    runtime = tmp_path / ".runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    config = CiaoConfig(
+        pwa_auth_token="t",
+        workspace_root=tmp_path,
+        state_path=runtime / "state.json",
+        media_root=runtime / "media",
+        openrouter=OpenRouterSettings(api_key="sk-or"),
+        workspaces={
+            "home": WorkspaceConfig(
+                name="home",
+                vault_root="vaults/home",
+                model_bucket="openrouter",
+                gws_profile="personal",
+            )
+        },
+    )
+    pcm = ProjectChatManager(
+        config,
+        state_store=StateStore(config.state_path, tmp_path, config.media_root),
+        transcript_store=TranscriptStore(runtime, tmp_path / "transcripts"),
+        path=runtime / "web_projects.json",
+    )
+    project = pcm.create_project("General", workspace="home")
+
+    pcm._create_onboarding_chat(project.project_id)
+
+    chat = next(iter(pcm._chats.values()))
+    assert chat.provider == "claude"
+    assert chat.model_bucket == "openrouter"
+    assert chat.model == "anthropic/claude-haiku-latest"
+    assert chat.handover_context_pending is True
+
+
+def test_onboarding_chat_keeps_ollama_workspace_bucket(tmp_path: Path) -> None:
+    """Wizard-selected Ollama must not be forced onto Anthropic work."""
+    runtime = tmp_path / ".runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    config = CiaoConfig(
+        pwa_auth_token="t",
+        workspace_root=tmp_path,
+        state_path=runtime / "state.json",
+        media_root=runtime / "media",
+        ollama=OLLAMA,
+        workspaces={
+            "home": WorkspaceConfig(
+                name="home",
+                vault_root="vaults/home",
+                model_bucket="ollama",
+                gws_profile="personal",
+            )
+        },
+    )
+    pcm = ProjectChatManager(
+        config,
+        state_store=StateStore(config.state_path, tmp_path, config.media_root),
+        transcript_store=TranscriptStore(runtime, tmp_path / "transcripts"),
+        path=runtime / "web_projects.json",
+    )
+    project = pcm.create_project("General", workspace="home")
+
+    pcm._create_onboarding_chat(project.project_id)
+
+    chat = next(iter(pcm._chats.values()))
+    assert chat.provider == "claude"
+    assert chat.model_bucket == "ollama"
+    assert chat.model == OLLAMA.haiku_model
+    assert chat.handover_context_pending is True
+
+
+def test_onboarding_chat_falls_back_to_work_when_bucket_invalid(
+    tmp_path: Path,
+) -> None:
+    """Stale OpenRouter credentials must not crash bootstrap chat creation."""
+    runtime = tmp_path / ".runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    config = CiaoConfig(
+        pwa_auth_token="t",
+        workspace_root=tmp_path,
+        state_path=runtime / "state.json",
+        media_root=runtime / "media",
+        openrouter=OpenRouterSettings(api_key=""),
+        workspaces={
+            "home": WorkspaceConfig(
+                name="home",
+                vault_root="vaults/home",
+                model_bucket="openrouter",
+                gws_profile="personal",
+            )
+        },
+    )
+    pcm = ProjectChatManager(
+        config,
+        state_store=StateStore(config.state_path, tmp_path, config.media_root),
+        transcript_store=TranscriptStore(runtime, tmp_path / "transcripts"),
+        path=runtime / "web_projects.json",
+    )
+    project = pcm.create_project("General", workspace="home")
+
+    pcm._create_onboarding_chat(project.project_id)
+
+    chat = next(iter(pcm._chats.values()))
+    assert chat.provider == "claude"
+    assert chat.model_bucket == "work"
+    assert chat.model == "haiku"
+    assert chat.handover_context_pending is True

--- a/tests/test_model_bucket.py
+++ b/tests/test_model_bucket.py
@@ -248,6 +248,78 @@ def test_configured_openrouter_bucket_requires_api_key(tmp_path):
         pcm.create_chat(project.project_id)
 
 
+def test_explicit_openrouter_alias_requires_api_key(tmp_path):
+    """An explicit tier alias must be resolved through its selected bucket."""
+    runtime = tmp_path / ".runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    config = CiaoConfig(
+        pwa_auth_token="t",
+        workspace_root=tmp_path,
+        state_path=runtime / "state.json",
+        media_root=runtime / "media",
+        openrouter=OpenRouterSettings(api_key=""),
+        workspaces={
+            "client": WorkspaceConfig(
+                name="client",
+                vault_root="vaults/client",
+                model_bucket="openrouter",
+                gws_profile="work",
+            )
+        },
+    )
+    pcm = ProjectChatManager(
+        config,
+        state_store=StateStore(config.state_path, tmp_path, config.media_root),
+        transcript_store=TranscriptStore(runtime, tmp_path / "transcripts"),
+        path=runtime / "web_projects.json",
+    )
+    project = pcm.create_project("client", workspace="client")
+
+    with pytest.raises(
+        ValueError, match="Unknown model 'anthropic/claude-opus-latest'"
+    ):
+        pcm.create_chat(
+            project.project_id, model="opus", model_bucket="openrouter"
+        )
+
+
+def test_failed_bucket_validation_preserves_empty_chats(tmp_path):
+    """A rejected bucket must not clean up an existing empty draft."""
+    runtime = tmp_path / ".runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    config = CiaoConfig(
+        pwa_auth_token="t",
+        workspace_root=tmp_path,
+        state_path=runtime / "state.json",
+        media_root=runtime / "media",
+        openrouter=OpenRouterSettings(api_key="sk-or"),
+        workspaces={
+            "client": WorkspaceConfig(
+                name="client",
+                vault_root="vaults/client",
+                model_bucket="openrouter",
+                gws_profile="work",
+            )
+        },
+    )
+    pcm = ProjectChatManager(
+        config,
+        state_store=StateStore(config.state_path, tmp_path, config.media_root),
+        transcript_store=TranscriptStore(runtime, tmp_path / "transcripts"),
+        path=runtime / "web_projects.json",
+    )
+    project = pcm.create_project("client", workspace="client")
+    empty = pcm.create_chat(project.project_id, model="opus", model_bucket="work")
+
+    config.openrouter = OpenRouterSettings(api_key="")
+    with pytest.raises(
+        ValueError, match="Unknown model 'anthropic/claude-opus-latest'"
+    ):
+        pcm.create_chat(project.project_id)
+
+    assert pcm.get_chat(empty.chat_id) is not None
+
+
 def test_openrouter_fable_alias_uses_fable_latest(tmp_path):
     runtime = tmp_path / ".runtime"
     runtime.mkdir(parents=True, exist_ok=True)

--- a/tests/test_providers_ollama.py
+++ b/tests/test_providers_ollama.py
@@ -345,6 +345,7 @@ def test_create_chat_uses_personal_workspace_default(
     monkeypatch.setenv("CLAUDE_DEFAULT_MODEL_PERSONAL", "kimi-k2.7-code:cloud")
     monkeypatch.setenv("CLAUDE_DEFAULT_MODEL_WORK", "opus")
     monkeypatch.setenv("CIAO_OLLAMA_MODELS", "kimi-k2.7-code:cloud")
+    monkeypatch.setenv("CIAO_OLLAMA_API_KEY", "test-cloud-key")
     runtime = tmp_path / ".runtime"
     runtime.mkdir(parents=True, exist_ok=True)
     config = CiaoConfig.from_env()


### PR DESCRIPTION
Fixes #259

The MCP `delegate_spawn` tool accepted a free-text `model` parameter and forwarded it straight to `pcm.create_chat()` with no validation against the configured set. A misspelled id like `deepseek-coder` (when the configured id is `deepseek-v4-flash:cloud`) opened a chat that silently failed on its first turn, leaving the calling agent with no signal at dispatch time and no path to recover.

## What changed

- New `_validate_configured_model` on `ProjectChatManager` resolves a model id against the same source of truth the picker reads from: `claude_models` plus tier aliases (`haiku`/`sonnet`/`opus`/`fable`), Ollama-routed ids via `is_ollama_model`, and `custom:<id>:<model>` via `provider_for_model`. Codex is intentionally skipped (its catalog is async and the CLI surfaces a clear error on its own).
- Wired into `create_chat` and `update_chat` so every entry point (`chat_create`, `chat_update`, `delegate_spawn`) is covered.
- `delegate_spawn` translates the resulting `ValueError` into a stable `ControlPlaneError("invalid_model")` at the MCP boundary, with a message that names valid alternatives.
- `mcp_server.py` docstring updated to document the new validation contract.
- Three new tests in `tests/test_delegates.py`: unknown id rejected with `invalid_model` and a message that names valid alternatives, configured model accepted, and `create_chat` (the underlying path) raises the same error.

## Test results

- `pytest tests/test_delegates.py` — 23/23 pass (3 new).
- Full suite (`pytest tests/`) — 1880 passed, 1 skipped, 2 pre-existing `test_cli.py` desktop-install flakes deselected (unrelated to this change; `test_setup_installs_the_desktop_app_when_none_is_present` and `test_setup_survives_a_failed_desktop_app_download` are environment-dependent tests against the running macOS app bundle).
- `mypy ciao/web/project_chats.py ciao/control_plane.py ciao/mcp_server.py` — clean.