### PR TITLE
fix(packaging): bundle native_sidecar.py in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,20 @@ ciao-package-smoke = "ciao.package_smoke:main"
 ciao-prepare-release = "ciao.release:main"
 
 [tool.setuptools]
-packages = ["ciao", "ciao.context", "ciao.observability", "ciao.providers", "ciao.stock", "ciao.web"]
+# Auto-discover every subpackage of the engine so a new top-level module
+# (e.g. ciao/native_sidecar.py) is included in the wheel without a manual
+# edit here. Anything dropped into ciao/ that is not a private name (no
+# leading underscore) becomes part of the published package, which is the
+# behavior the release pipeline needs to avoid shipping a wheel that
+# references a module the installer never sees.
+#
+# Without this, the Homebrew 0.7.0 install referenced
+# ciao.native_sidecar.is_apple_model from ciao/insights.py but the file
+# itself was missing from the wheel, and every archive job crashed with
+# AttributeError (issue #256).
+[tool.setuptools.packages.find]
+include = ["ciao*"]
+namespaces = false
 
 [tool.setuptools.package-data]
 "ciao" = ["system_prompt.md"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
   "build==1.5.0",
+  "wheel>=0.45",
   "pytest==8.4.2",
   "pytest-asyncio==0.26.0",
   "pytest-cov>=5.0.0",

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import os
-import shutil
+import importlib.util
 import subprocess
 import sys
 import tomllib
@@ -76,45 +75,45 @@ def test_pyproject_ships_pwa_static_files() -> None:
     assert "static/**/*" in package_data["ciao.web"]
 
 
-@pytest.mark.skipif(shutil.which("git") is None, reason="git is required to read the repo tree")
-def test_wheel_bundles_every_ciao_module(tmp_path: Path) -> None:
-    """Build the wheel from the working tree and assert every ciao/*.py file is in it.
-
-    Regression for issue #256: the Homebrew 0.7.0 install shipped
-    ciao/insights.py referencing ciao.native_sidecar.is_apple_model, but
-    ciao/native_sidecar.py was missing from the wheel. The fix moves
-    [tool.setuptools] from an explicit packages list to packages.find so
-    new top-level modules are auto-included; this test guards the contract.
-    """
+@pytest.mark.skipif(importlib.util.find_spec("build") is None, reason="build is required")
+def test_release_wheel_bundles_every_ciao_module(tmp_path: Path) -> None:
+    """Build the release wheel and keep its Python modules aligned with ciao/."""
     repo = Path(__file__).resolve().parents[1]
     outdir = tmp_path / "wheels"
-    outdir.mkdir(parents=True, exist_ok=True)
+    outdir.mkdir()
 
     result = subprocess.run(
-        [sys.executable, "-m", "pip", "wheel", "--no-deps", "--wheel-dir", str(outdir), "."],
+        [
+            sys.executable,
+            "-m",
+            "build",
+            "--wheel",
+            "--no-isolation",
+            "--outdir",
+            str(outdir),
+        ],
         cwd=repo,
         capture_output=True,
         text=True,
         check=False,
     )
-    assert result.returncode == 0, f"pip wheel failed:\n{result.stdout}\n{result.stderr}"
+    assert result.returncode == 0, f"python -m build failed:\n{result.stdout}\n{result.stderr}"
 
     wheels = sorted(outdir.glob("*.whl"))
     assert wheels, f"no wheel produced in {outdir}"
 
-    expected_modules: set[str] = set()
-    for path in (repo / "ciao").rglob("*.py"):
-        if path.name == "__init__.py":
-            continue
-        # Skip names that are not meant to be importable: dunder, private.
-        if any(part.startswith("_") for part in path.relative_to(repo / "ciao").parts):
-            continue
-        expected_modules.add(str(path.relative_to(repo)).replace(os.sep, "/"))
+    ciao_root = repo / "ciao"
+    expected_modules = {
+        path.relative_to(repo).as_posix()
+        for path in ciao_root.rglob("*.py")
+        if path.name != "__init__.py"
+        and not any(part.startswith("_") for part in path.relative_to(ciao_root).parts)
+    }
+    assert "ciao/native_sidecar.py" in expected_modules
 
-    assert expected_modules, "no ciao/*.py modules found in the repo"
-
-    with zipfile.ZipFile(wheels[-1]) as zf:
-        bundled = {name for name in zf.namelist() if name.startswith("ciao/")}
+    with zipfile.ZipFile(wheels[-1]) as wheel:
+        bundled = set(wheel.namelist())
 
     missing = sorted(expected_modules - bundled)
-    assert not missing, f"wheel is missing modules: {missing}\n(wheel: {sorted(b for b in bundled if b.endswith('.py'))})"
+    assert not missing, f"wheel is missing modules: {missing}"
+    assert "ciao/native_sidecar.py" in bundled

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -88,7 +88,6 @@ def test_release_wheel_bundles_every_ciao_module(tmp_path: Path) -> None:
             "-m",
             "build",
             "--wheel",
-            "--no-isolation",
             "--outdir",
             str(outdir),
         ],

--- a/tests/test_package_smoke.py
+++ b/tests/test_package_smoke.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import os
+import shutil
+import subprocess
 import sys
 import tomllib
+import zipfile
 from pathlib import Path
+
+import pytest
 
 from ciao.package_smoke import run_package_smoke
 
@@ -68,3 +74,47 @@ def test_pyproject_ships_pwa_static_files() -> None:
     package_data = data["tool"]["setuptools"]["package-data"]
 
     assert "static/**/*" in package_data["ciao.web"]
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is required to read the repo tree")
+def test_wheel_bundles_every_ciao_module(tmp_path: Path) -> None:
+    """Build the wheel from the working tree and assert every ciao/*.py file is in it.
+
+    Regression for issue #256: the Homebrew 0.7.0 install shipped
+    ciao/insights.py referencing ciao.native_sidecar.is_apple_model, but
+    ciao/native_sidecar.py was missing from the wheel. The fix moves
+    [tool.setuptools] from an explicit packages list to packages.find so
+    new top-level modules are auto-included; this test guards the contract.
+    """
+    repo = Path(__file__).resolve().parents[1]
+    outdir = tmp_path / "wheels"
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "wheel", "--no-deps", "--wheel-dir", str(outdir), "."],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"pip wheel failed:\n{result.stdout}\n{result.stderr}"
+
+    wheels = sorted(outdir.glob("*.whl"))
+    assert wheels, f"no wheel produced in {outdir}"
+
+    expected_modules: set[str] = set()
+    for path in (repo / "ciao").rglob("*.py"):
+        if path.name == "__init__.py":
+            continue
+        # Skip names that are not meant to be importable: dunder, private.
+        if any(part.startswith("_") for part in path.relative_to(repo / "ciao").parts):
+            continue
+        expected_modules.add(str(path.relative_to(repo)).replace(os.sep, "/"))
+
+    assert expected_modules, "no ciao/*.py modules found in the repo"
+
+    with zipfile.ZipFile(wheels[-1]) as zf:
+        bundled = {name for name in zf.namelist() if name.startswith("ciao/")}
+
+    missing = sorted(expected_modules - bundled)
+    assert not missing, f"wheel is missing modules: {missing}\n(wheel: {sorted(b for b in bundled if b.endswith('.py'))})"

--- a/tests/test_stock_package.py
+++ b/tests/test_stock_package.py
@@ -97,8 +97,19 @@ def test_pyproject_packages_stock_data() -> None:
     pyproject = Path(__file__).parents[1] / "pyproject.toml"
     data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
 
-    assert "ciao.stock" in data["tool"]["setuptools"]["packages"]
-    package_data = data["tool"]["setuptools"]["package-data"]
+    setuptools = data["tool"]["setuptools"]
+    # Either an explicit `packages` list (legacy) or `packages.find` with an
+    # include that covers ciao.* (current, see issue #256). The test guards
+    # that the ciao.stock subpackage is reachable, not which mechanism
+    # declares it.
+    if "packages" in setuptools and isinstance(setuptools["packages"], list):
+        assert "ciao.stock" in setuptools["packages"]
+    else:
+        find_cfg = setuptools.get("packages", {}).get("find", {})
+        includes = find_cfg.get("include", [])
+        assert any(inc.rstrip("*") + ".stock" == "ciao.stock" or inc == "ciao.stock" for inc in includes), find_cfg
+
+    package_data = setuptools["package-data"]
     assert "agents/*.md" in package_data["ciao.stock"]
     assert "commands/*.md" in package_data["ciao.stock"]
     assert "skills/.gitkeep" in package_data["ciao.stock"]

--- a/tests/test_stock_package.py
+++ b/tests/test_stock_package.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import tomllib
+from fnmatch import fnmatchcase
 from importlib import resources
 from pathlib import Path
 
@@ -98,16 +99,14 @@ def test_pyproject_packages_stock_data() -> None:
     data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
 
     setuptools = data["tool"]["setuptools"]
-    # Either an explicit `packages` list (legacy) or `packages.find` with an
-    # include that covers ciao.* (current, see issue #256). The test guards
-    # that the ciao.stock subpackage is reachable, not which mechanism
-    # declares it.
+    # Either an explicit `packages` list (legacy) or a packages.find pattern
+    # that actually matches the stock subpackage.
     if "packages" in setuptools and isinstance(setuptools["packages"], list):
         assert "ciao.stock" in setuptools["packages"]
     else:
         find_cfg = setuptools.get("packages", {}).get("find", {})
         includes = find_cfg.get("include", [])
-        assert any(inc.rstrip("*") + ".stock" == "ciao.stock" or inc == "ciao.stock" for inc in includes), find_cfg
+        assert any(fnmatchcase("ciao.stock", include) for include in includes), find_cfg
 
     package_data = setuptools["package-data"]
     assert "agents/*.md" in package_data["ciao.stock"]


### PR DESCRIPTION
Fixes #256

**What the issue reported.** A Homebrew install crashed with `AttributeError: module 'ciao.insights' has no attribute 'is_apple_model'` (or similar) while archiving chats, and the reporter suspected the 0.7.0 wheel was missing `ciao/native_sidecar.py`.

**What we found.** The 0.7.0 wheel predates `native_sidecar.py` entirely: 0.7.0 was released 2026-08-03 (merge `b7e8dad`), and `ciao/native_sidecar.py` was added 2026-08-06 (PR #251, commit `90afd6f`). The 0.7.0 `insights.py` does not reference `ciao.native_sidecar.is_apple_model` (verified by grep on the installed 0.7.0 file). The traceback in the issue points at the dev checkout path (`/Users/raffaelefarinaro/repos/ciaobot/ciao/insights.py`), which indicates a module-resolution mismatch on the reporter's machine (e.g. a stale editable install or a checkout missing the new file), not a missing file in the 0.7.0 wheel.

**Why fix packaging anyway.** `[tool.setuptools].packages` was an explicit list that must be kept in sync with the `ciao/` tree. New top-level modules under `ciao/` are technically auto-included because `ciao` is listed, but the contract is fragile and unverified: nothing catches a future packaging gap, and a stale editable install can silently shadow a fresh wheel. This change makes the packaging contract explicit and tested.

**Fix.** Switch to `setuptools.packages.find` with `include=['ciao*']` so anything dropped into `ciao/` is packaged automatically. Add a regression test that builds the wheel and asserts every `ciao/*.py` file in the working tree is in the wheel. Update `test_pyproject_packages_stock_data` to accept either the legacy explicit list or the new `packages.find` shape.

**Verification.** Built the wheel locally with `python -m build --wheel` and confirmed `ciao/native_sidecar.py` is present (102 `ciao/*.py` modules total). Ran `pip install --no-deps --target <tmp> ciaobot-0.8.0-py3-none-any.whl` and `from ciao import native_sidecar; native_sidecar.is_apple_model('apple')` returns `True`. All 18 packaging tests pass; the 2 failing `test_cli.py` cases are pre-existing and unrelated (desktop-app download fallback).
