### PR TITLE
fix(pwa): quieten the home lanes after live review

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -171,7 +171,7 @@ Shadows are reserved for content that genuinely floats above another interaction
 
 ## Shapes
 
-The shape language is compact and gently rounded. Standard controls and cards use a 10px radius, small nested elements use 6px, and modals use 14px. Fully rounded shapes are limited to badges, status dots, avatars, and true pill selectors.
+The shape language is compact and gently rounded. Standard controls and cards use a 10px radius, small nested elements use 6px, and modals use 14px. A tighter 4px radius (`--radius-xs`) is reserved for small squared tags that must not be mistaken for count badges: the needs-you state chip and the workspace key badges. Fully rounded shapes are limited to badges, status dots, avatars, and true pill selectors.
 
 Borders are structural, not decorative. Active navigation is marked by a slim pink edge plus a tonal background. Do not mix exaggerated rounding, glass effects, or unrelated shape styles into the same view.
 

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -277,6 +277,7 @@ watch(showStartup, (show) => {
   --warning: #ff9800;
   --error: #f44336;
   /* Geometry */
+  --radius-xs: 4px;     /* small squared tags: state chips, key badges */
   --radius: 10px;
   --radius-sm: 6px;
   --radius-lg: 14px;

--- a/web/src/components/BrandMark.vue
+++ b/web/src/components/BrandMark.vue
@@ -1,0 +1,116 @@
+<template>
+  <button
+    type="button"
+    class="brand wordmark wordmark--sm"
+    :class="{ 'brand--refreshing': refreshing }"
+    @click="onBrandClick"
+    :title="refreshing ? 'Reloading...' : 'Click to reload the latest app build'"
+    :aria-busy="refreshing"
+  ><span class="brand-label">{{ brandLabel }}</span></button>
+</template>
+
+<script setup lang="ts">
+// The wordmark, and the click-to-reload behind it. This used to live inline in
+// ProjectSidebar's header; it is a component so the pane header can carry the
+// mark without the reload logic being copied to a second place.
+import { onBeforeUnmount, ref } from 'vue'
+
+const refreshing = ref(false)
+const BRAND_TEXT = 'ciaobot'
+const PIXEL_CHARS = '█▓▒░▄▀▐▌▆▅▃▂▪▫◆●○·'
+const brandLabel = ref(BRAND_TEXT)
+
+let brandPixelTimer: ReturnType<typeof setInterval> | null = null
+
+function startBrandPixelAnimation() {
+  stopBrandPixelAnimation()
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+  brandPixelTimer = setInterval(() => {
+    brandLabel.value = BRAND_TEXT
+      .split('')
+      .map((char) => (Math.random() < 0.18 ? char : PIXEL_CHARS[Math.floor(Math.random() * PIXEL_CHARS.length)]))
+      .join('')
+  }, 80)
+}
+
+function stopBrandPixelAnimation() {
+  if (brandPixelTimer !== null) {
+    clearInterval(brandPixelTimer)
+    brandPixelTimer = null
+  }
+  brandLabel.value = BRAND_TEXT
+}
+
+onBeforeUnmount(stopBrandPixelAnimation)
+
+async function onBrandClick() {
+  if (refreshing.value) return
+  refreshing.value = true
+  startBrandPixelAnimation()
+  try {
+    // Force the service worker to update without unregistering it,
+    // so push subscriptions survive across builds.
+    if ('serviceWorker' in navigator) {
+      const regs = await navigator.serviceWorker.getRegistrations()
+      await Promise.all(regs.map(r => r.update()))
+    }
+    if (typeof caches !== 'undefined') {
+      const keys = await caches.keys()
+      await Promise.all(keys.map(k => caches.delete(k)))
+    }
+  } catch (e) {
+    console.warn('Hard refresh cleanup failed', e)
+  }
+  // Bust HTTP cache too via a query string; replace so no back-button stale entry.
+  const url = new URL(window.location.href)
+  url.searchParams.set('_r', String(Date.now()))
+  window.location.replace(url.toString())
+}
+</script>
+
+<style scoped>
+.brand {
+  /* Inherits .wordmark base from App.vue; override size and add interaction.
+     --text-lg is the same 16px * font-scale the pane title uses, so the mark
+     and the title beside it move together when the font scale changes. */
+  font-size: var(--text-lg);
+  cursor: pointer;
+  transition: opacity 120ms var(--ease);
+  min-height: var(--touch);
+  align-items: center;
+  padding: 0 var(--space-1);
+  border: 0;
+  background: transparent;
+}
+.brand::before {
+  content: none;
+}
+.brand:hover { opacity: 0.85; }
+.brand:active { opacity: 0.7; }
+.brand-label {
+  display: inline-block;
+  /* Fixed character width so the pixel-jitter animation cannot change the
+     mark's width - in the pane header that would shift the centred column. */
+  min-width: 7ch;
+  text-align: left;
+}
+.brand--refreshing {
+  opacity: 1;
+  color: var(--accent);
+  pointer-events: none;
+}
+.brand--refreshing .brand-label {
+  animation: brand-pixel-jitter 0.12s steps(2, end) infinite;
+  text-shadow:
+    1px 0 color-mix(in srgb, var(--accent) 75%, transparent),
+    -1px 0 color-mix(in srgb, var(--accent2) 55%, transparent),
+    0 1px color-mix(in srgb, var(--fg) 35%, transparent);
+}
+@keyframes brand-pixel-jitter {
+  0%, 100% { transform: translate(0, 0); }
+  50% { transform: translate(1px, -1px); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .brand--refreshing .brand-label { animation: none; }
+}
+</style>

--- a/web/src/components/ChatLayout.vue
+++ b/web/src/components/ChatLayout.vue
@@ -674,12 +674,33 @@ function onUnreservedKeydown(e: KeyboardEvent) {
   if (e.key === 'Escape') {
     // The confirm dialog and the file viewer own Esc while they are up.
     if (pendingConfirm.value || fileViewer.isOpen) return
+    // A nested control that handled the key already, without claiming it. Popups
+    // like ModelSelector close on Esc but do not stopPropagation, and treating
+    // that press as "go home" both discarded their dismissal and navigated away
+    // from half-finished settings edits.
+    if (e.defaultPrevented) return
+
+    // Settings and Automations come first, ahead of any chat handling.
+    // activeChatId deliberately stays populated when either is opened from a
+    // chat, so checking the chat first meant Esc ran closeChat() on a chat that
+    // was not even on screen - disconnecting it, and deleting it outright when it
+    // was an unused draft with an unsent composer message. Leaving the view is
+    // what the key means there.
+    //
+    // Project routes stay chat-first on purpose: Esc closing the chat you opened
+    // through a project is long-standing, tested behaviour, and a project page is
+    // one press further from home either way.
+    if (viewMode.value === 'settings' || viewMode.value === 'schedules') {
+      e.preventDefault()
+      void router.push('/')
+      return
+    }
     if (store.activeChat) {
       e.preventDefault()
       closeChat()
       return
     }
-    if (viewMode.value !== 'chat' || projectIdParam.value) {
+    if (projectIdParam.value) {
       e.preventDefault()
       void router.push('/')
       return

--- a/web/src/components/ChatLayout.vue
+++ b/web/src/components/ChatLayout.vue
@@ -48,31 +48,32 @@
             <PaneHeader title="ciaobot" @open-sidebar="sidebarCollapsed = false" />
             <div class="empty-state" :class="{ 'empty-state--active': store.activeChatsAll.length > 0 }">
               <div class="empty-home-header">
-                <div class="empty-mark" :class="{ 'empty-mark--compact': store.activeChatsAll.length > 0 }">
-                <button
-                  type="button"
-                  class="empty-face-btn"
-                  :class="{ 'empty-face-btn--compact': store.activeChatsAll.length > 0 }"
-                  aria-label="Say hello"
-                  @click="onFaceClick"
-                  @mouseenter="onFaceEnter"
-                  @mouseleave="onFaceLeave"
-                >
-                  <Transition name="face-bubble">
-                    <div v-if="speechGreeting" :key="speechGreeting" class="face-speech-bubble">
-                      {{ speechGreeting }}
-                    </div>
-                  </Transition>
-                  <img
-                    class="empty-face"
-                    :class="{ 'empty-face--compact': store.activeChatsAll.length > 0 }"
-                    :src="faceSrc"
-                    alt=""
-                    draggable="false"
-                  />
-                </button>
+                <!-- With chats on screen the mark is decoration beside a status line, so it
+                     is a plain image: no button, no hover handlers, no greeting bubble. The
+                     bubble belongs to the big first-run face below, where it is the only
+                     thing on the screen and has room to be a greeting. Next to a sentence
+                     that already reads "nothing needs you" it just collided with it. -->
+                <template v-if="store.activeChatsAll.length">
+                  <img class="empty-face empty-face--compact" :src="faceSrc" alt="" draggable="false" />
+                  <span class="empty-status-text">{{ homeStatus }}</span>
+                </template>
+                <div v-else class="empty-mark">
+                  <button
+                    type="button"
+                    class="empty-face-btn"
+                    aria-label="Say hello"
+                    @click="onFaceClick"
+                    @mouseenter="onFaceEnter"
+                    @mouseleave="onFaceLeave"
+                  >
+                    <Transition name="face-bubble">
+                      <div v-if="speechGreeting" :key="speechGreeting" class="face-speech-bubble">
+                        {{ speechGreeting }}
+                      </div>
+                    </Transition>
+                    <img class="empty-face" :src="faceSrc" alt="" draggable="false" />
+                  </button>
                 </div>
-                <span v-if="store.activeChatsAll.length" class="empty-status-text">{{ homeStatus }}</span>
               </div>
               <HomeRecentChats ref="homeRecentRef" @new-workspace-chat="createWorkspaceChat" />
               <div v-if="showGlobalNewChatActions" class="empty-actions">
@@ -133,31 +134,32 @@
           <PaneHeader title="ciaobot" @open-sidebar="sidebarCollapsed = false" />
           <div class="empty-state" :class="{ 'empty-state--active': store.activeChatsAll.length > 0 }">
             <div class="empty-home-header">
-              <div class="empty-mark" :class="{ 'empty-mark--compact': store.activeChatsAll.length > 0 }">
-              <button
-                type="button"
-                class="empty-face-btn"
-                :class="{ 'empty-face-btn--compact': store.activeChatsAll.length > 0 }"
-                aria-label="Say hello"
-                @click="onFaceClick"
-                @mouseenter="onFaceEnter"
-                @mouseleave="onFaceLeave"
-              >
-                <Transition name="face-bubble">
-                  <div v-if="speechGreeting" :key="speechGreeting" class="face-speech-bubble">
-                    {{ speechGreeting }}
-                  </div>
-                </Transition>
-                <img
-                  class="empty-face"
-                  :class="{ 'empty-face--compact': store.activeChatsAll.length > 0 }"
-                  :src="faceSrc"
-                  alt=""
-                  draggable="false"
-                />
-              </button>
+              <!-- With chats on screen the mark is decoration beside a status line, so it
+                   is a plain image: no button, no hover handlers, no greeting bubble. The
+                   bubble belongs to the big first-run face below, where it is the only
+                   thing on the screen and has room to be a greeting. Next to a sentence
+                   that already reads "nothing needs you" it just collided with it. -->
+              <template v-if="store.activeChatsAll.length">
+                <img class="empty-face empty-face--compact" :src="faceSrc" alt="" draggable="false" />
+                <span class="empty-status-text">{{ homeStatus }}</span>
+              </template>
+              <div v-else class="empty-mark">
+                <button
+                  type="button"
+                  class="empty-face-btn"
+                  aria-label="Say hello"
+                  @click="onFaceClick"
+                  @mouseenter="onFaceEnter"
+                  @mouseleave="onFaceLeave"
+                >
+                  <Transition name="face-bubble">
+                    <div v-if="speechGreeting" :key="speechGreeting" class="face-speech-bubble">
+                      {{ speechGreeting }}
+                    </div>
+                  </Transition>
+                  <img class="empty-face" :src="faceSrc" alt="" draggable="false" />
+                </button>
               </div>
-              <span v-if="store.activeChatsAll.length" class="empty-status-text">{{ homeStatus }}</span>
             </div>
             <HomeRecentChats ref="homeRecentRef" @new-workspace-chat="createWorkspaceChat" />
             <div v-if="showGlobalNewChatActions" class="empty-actions">
@@ -956,12 +958,6 @@ onBeforeUnmount(() => {
   height: 30px;
 }
 
-.empty-face-btn--compact {
-  min-width: var(--touch);
-  min-height: var(--touch);
-  align-items: center;
-  justify-content: center;
-}
 .face-speech-bubble {
   position: absolute;
   bottom: calc(100% + 10px);

--- a/web/src/components/ChatLayout.vue
+++ b/web/src/components/ChatLayout.vue
@@ -39,13 +39,13 @@
           />
           <ChatPanel v-else-if="store.activeChat" ref="chatPanelRef" :key="store.activeChat.chat_id" @close="closeChat" @open-sidebar="sidebarCollapsed = false" />
           <div v-else-if="!store.bootstrapped" class="empty-shell home-boot" aria-busy="true">
-            <PaneHeader title="ciaobot" @open-sidebar="sidebarCollapsed = false" />
+            <PaneHeader page-tag="home" @open-sidebar="sidebarCollapsed = false" />
           </div>
           <!-- On mobile, the sidebar already lists every active chat. Showing the
                homepage behind it after closing a chat would just duplicate the
                same list. Hide the empty-state whenever the mobile sidebar is open. -->
           <div v-else-if="!(isMobile && !sidebarCollapsed)" class="empty-shell">
-            <PaneHeader title="ciaobot" @open-sidebar="sidebarCollapsed = false" />
+            <PaneHeader page-tag="home" @open-sidebar="sidebarCollapsed = false" />
             <div class="empty-state" :class="{ 'empty-state--active': store.activeChatsAll.length > 0 }">
               <div class="empty-home-header">
                 <!-- With chats on screen the mark is decoration beside a status line, so it
@@ -125,13 +125,13 @@
         />
         <ChatPanel v-else-if="store.activeChat" ref="chatPanelRef" :key="store.activeChat.chat_id" @close="closeChat" @open-sidebar="sidebarCollapsed = false" />
         <div v-else-if="!store.bootstrapped" class="empty-shell home-boot" aria-busy="true">
-          <PaneHeader title="ciaobot" @open-sidebar="sidebarCollapsed = false" />
+          <PaneHeader page-tag="home" @open-sidebar="sidebarCollapsed = false" />
         </div>
         <!-- On mobile, the sidebar already lists every active chat. Showing the
              homepage behind it after closing a chat would just duplicate the
              same list. Hide the empty-state whenever the mobile sidebar is open. -->
         <div v-else-if="!(isMobile && !sidebarCollapsed)" class="empty-shell">
-          <PaneHeader title="ciaobot" @open-sidebar="sidebarCollapsed = false" />
+          <PaneHeader page-tag="home" @open-sidebar="sidebarCollapsed = false" />
           <div class="empty-state" :class="{ 'empty-state--active': store.activeChatsAll.length > 0 }">
             <div class="empty-home-header">
               <!-- With chats on screen the mark is decoration beside a status line, so it

--- a/web/src/components/ChatLayout.vue
+++ b/web/src/components/ChatLayout.vue
@@ -662,6 +662,31 @@ function onUnreservedKeydown(e: KeyboardEvent) {
     }
   }
 
+  // Esc runs before the chat-only gate: it is the universal way back, and
+  // previously it did nothing at all on settings or automations because those
+  // views are excluded from shortcutsActive.
+  //
+  // It closes the open chat even while typing in the composer: escaping a chat
+  // is the more useful meaning of the key, and requiring a click-out first was
+  // the common complaint. Widgets that genuinely own Esc claim it with
+  // stopPropagation (the slash-command picker in ChatPanel, the notification
+  // bell), so this never steals the key from them.
+  if (e.key === 'Escape') {
+    // The confirm dialog and the file viewer own Esc while they are up.
+    if (pendingConfirm.value || fileViewer.isOpen) return
+    if (store.activeChat) {
+      e.preventDefault()
+      closeChat()
+      return
+    }
+    if (viewMode.value !== 'chat' || projectIdParam.value) {
+      e.preventDefault()
+      void router.push('/')
+      return
+    }
+    return
+  }
+
   if (!shortcutsActive.value) return
 
   if (e.key.startsWith('Arrow')) {
@@ -671,16 +696,6 @@ function onUnreservedKeydown(e: KeyboardEvent) {
     return
   }
 
-  // Esc closes the open chat even while typing in the composer: escaping a
-  // chat is the more useful meaning of the key, and requiring a click-out
-  // first was the common complaint. Widgets that genuinely own Esc claim it
-  // with stopPropagation (see the slash-command picker in ChatPanel), so this
-  // never steals the key from them.
-  if (e.key === 'Escape') {
-    if (!store.activeChat) return
-    e.preventDefault()
-    closeChat()
-  }
 }
 
 function onShortcutKeydown(e: KeyboardEvent) {

--- a/web/src/components/ChatLayout.vue
+++ b/web/src/components/ChatLayout.vue
@@ -443,14 +443,12 @@ const currentProjectId = computed(() => {
   if (chat?.project_id) return chat.project_id
   return ''
 })
-// The per-lane "+ new" button replaces these on a wide screen, but a lane
-// header is hidden for every collapsed lane below 820px — so on a phone with at
-// least one chat there would otherwise be no way to start a chat in a
-// non-active workspace. Keep the global buttons wherever the lane ones are not
-// all reachable.
-const showGlobalNewChatActions = computed(() =>
-  !store.activeChatsAll.length || isMobile.value,
-)
+// Only for the true empty state. Every lane carries its own "+ new" and lanes
+// no longer collapse at narrow widths, so on a phone with chats these were a
+// second, louder copy of an action already on screen — and a saturated fill
+// spent on something non-blocking, which the design system reserves for
+// "needs the user".
+const showGlobalNewChatActions = computed(() => !store.activeChatsAll.length)
 
 const generalWorkspaceActions = computed(() => {
   return store.workspaceOptions

--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -7,7 +7,16 @@
          what the breadcrumb and the transcript underneath it both already say.
          This is also the most crowded header in the app, so the room goes to the
          breadcrumb and the action icons instead. -->
-    <PaneHeader :active-bg-agents="store.activeBackgroundAgents" @open-sidebar="$emit('open-sidebar')">
+    <!-- No brand mark here. This is the densest header in the app - breadcrumb,
+         model picker, agent pill, archive - and the centred wordmark was
+         squeezing the chat title down to a few characters. The breadcrumb
+         already says where you are, and the mark is a click-to-reload
+         shortcut available on every other view. -->
+    <PaneHeader
+      :brand="false"
+      :active-bg-agents="store.activeBackgroundAgents"
+      @open-sidebar="$emit('open-sidebar')"
+    >
       <template #title>
         <div class="header-left">
           <button class="close-btn" @click="$emit('close')" title="Close chat">&times;</button>

--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -2,7 +2,11 @@
   <div class="chat-panel" @dragover.prevent="dragOver = true" @dragleave="dragOver = false" @drop.prevent="handleDrop" @click="handleFileLinkClick">
     <div v-if="dragOver" class="drop-overlay">Drop images to attach, or files to add their accessible path</div>
 
-    <!-- Header -->
+    <!-- Header. No page tag: the breadcrumb below already reads
+         `workspace / project / title`, so a "chat" marker beside it would name
+         what the breadcrumb and the transcript underneath it both already say.
+         This is also the most crowded header in the app, so the room goes to the
+         breadcrumb and the action icons instead. -->
     <PaneHeader :active-bg-agents="store.activeBackgroundAgents" @open-sidebar="$emit('open-sidebar')">
       <template #title>
         <div class="header-left">

--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -5386,6 +5386,9 @@ details[open] > .activity-summary::before {
   box-shadow: 0 0 4px var(--accent);
   animation: activity-pulse 1.1s ease-in-out infinite;
   flex-shrink: 0;
+  /* The halo and the expanding ring paint ~3px beyond this element's box, so the
+     row's 8px gap looked like ~5px and the dot read as touching the label. */
+  margin-right: var(--space-1);
 }
 
 .activity-spinner::before {

--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -18,7 +18,6 @@
               :data-workspace-color="workspaceCrumb.color"
               :title="`Workspace ${workspaceCrumb.name} (press ${workspaceCrumb.key})`"
             >
-              <span v-if="workspaceCrumb.key" class="breadcrumb-key" aria-hidden="true">{{ workspaceCrumb.key }}</span>
               {{ workspaceCrumb.name }}
             </span>
             <span v-if="workspaceCrumb" class="breadcrumb-separator">/</span>
@@ -4445,22 +4444,10 @@ defineExpose({ toggleDictation, toggleModelPicker, archiveActiveChat })
 .breadcrumb-workspace {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-1);
-  font-size: var(--text-sm);
+  font-size: var(--text-lg);
   color: var(--accent);
   white-space: nowrap;
   flex-shrink: 0;
-}
-
-.breadcrumb-key {
-  min-width: 15px;
-  padding: 0 3px;
-  border: 1px solid var(--accent);
-  border-radius: var(--radius-sm);
-  font-size: var(--text-xs);
-  font-weight: 700;
-  line-height: 1.3;
-  text-align: center;
 }
 
 @media (max-width: 600px) {
@@ -4486,7 +4473,10 @@ defineExpose({ toggleDictation, toggleModelPicker, archiveActiveChat })
 
 .breadcrumb-separator {
   color: var(--fg3);
-  font-size: 16px;
+  /* Same step as the crumb either side of it. The hardcoded 16px here sat
+     visibly smaller than --text-lg once the font scale was applied, and did not
+     move with the Appearance setting at all. */
+  font-size: var(--text-lg);
   user-select: none;
   flex-shrink: 0;
 }

--- a/web/src/components/ChatSignals.vue
+++ b/web/src/components/ChatSignals.vue
@@ -17,18 +17,15 @@
       class="chat-signal chat-signal--working"
       title="Working"
       aria-label="Working"
-    >
-      <span class="chat-signal-core chat-signal-core--pulse" aria-hidden="true" />
-      <span v-if="density === 'card'" class="chat-signal-label">working</span>
-    </span>
+    ><span class="activity-spinner" aria-hidden="true" /></span>
     <span
       v-else-if="primarySignal === 'agents'"
       class="chat-signal chat-signal--agents"
       :title="`${backgroundCount} background agents running`"
       :aria-label="`${backgroundCount} background agents running`"
     >
-      <span class="chat-signal-core chat-signal-core--pulse" aria-hidden="true" />
-      <span v-if="density === 'card'" class="chat-signal-label">{{ backgroundCount }} agents</span>
+      <span class="activity-spinner" aria-hidden="true" />
+      <span v-if="density === 'card' && backgroundCount > 1" class="chat-signal-count">{{ backgroundCount }}</span>
     </span>
     <span
       v-else-if="primarySignal === 'retry'"
@@ -114,11 +111,14 @@ const loopTitle = computed(() => {
   background: var(--accent);
 }
 
+/* A small squared tag, not a pill. The design this came from used a 4px radius
+   deliberately: the pill shape reads as a count badge, and counts mean something
+   else in this vocabulary. */
 .chat-signals--card .chat-signal--needs {
   width: auto;
   min-height: 20px;
-  padding: 0 7px;
-  border-radius: 10px;
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-xs);
   color: var(--bg);
 }
 
@@ -133,32 +133,45 @@ const loopTitle = computed(() => {
   white-space: nowrap;
 }
 
+/* Working reuses the chat transcript's own activity pulse rather than a
+   bordered pill: a solid accent dot with a halo and an expanding ring. The
+   outlined ring it replaced was nearly invisible at sidebar size, and the
+   card variant carried a redundant "working" label under a tier heading that
+   already said working. Kept in sync with .activity-spinner in ChatPanel.vue —
+   if that changes, change this. */
 .chat-signal--working,
 .chat-signal--agents {
-  width: 10px;
-  height: 10px;
-  border: 1.5px solid var(--accent);
-  border-radius: 50%;
+  gap: var(--space-1);
 }
 
-.chat-signals--card .chat-signal--working,
-.chat-signals--card .chat-signal--agents {
-  width: auto;
-  height: 20px;
-  gap: 5px;
-  padding: 0 7px 0 4px;
-  border-radius: 10px;
-}
-
-.chat-signal-core {
-  width: 3px;
-  height: 3px;
+.activity-spinner {
+  position: relative;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   background: var(--accent);
+  box-shadow: 0 0 4px var(--accent);
+  animation: chat-signal-pulse 1.1s ease-in-out infinite;
+  flex-shrink: 0;
 }
 
-.chat-signal-core--pulse {
-  animation: chat-signal-pulse 1.1s ease-in-out infinite;
+.activity-spinner::before {
+  content: "";
+  position: absolute;
+  inset: -3px;
+  border-radius: 50%;
+  background: var(--accent);
+  opacity: 0.45;
+  animation: chat-signal-ring 1.1s ease-out infinite;
+  pointer-events: none;
+}
+
+/* Only shown for more than one agent, where the number is the whole point. */
+.chat-signal-count {
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 700;
 }
 
 .chat-signal--retry {
@@ -178,14 +191,22 @@ const loopTitle = computed(() => {
 }
 
 @keyframes chat-signal-pulse {
-  0%, 100% { opacity: 0.65; transform: scale(0.75); }
-  50% { opacity: 1; transform: scale(1); }
+  0%, 100% { transform: scale(0.55); opacity: 0.35; }
+  50% { transform: scale(1); opacity: 1; }
+}
+
+@keyframes chat-signal-ring {
+  0% { transform: scale(0.6); opacity: 0.45; }
+  100% { transform: scale(1.6); opacity: 0; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .chat-signal-core--pulse {
+  .activity-spinner,
+  .activity-spinner::before {
     animation: none;
-    opacity: 0.65;
   }
+
+  .activity-spinner { opacity: 1; }
+  .activity-spinner::before { opacity: 0.3; }
 }
 </style>

--- a/web/src/components/HomeRecentChats.vue
+++ b/web/src/components/HomeRecentChats.vue
@@ -344,6 +344,11 @@ watch(() => store.activeWorkspace, async () => {
   max-width: 1320px;
   margin: 0 auto;
   text-align: left;
+  /* Stacking is decided by the width the lanes actually get, not the window's.
+     The sidebar is resizable and takes a large share, so a viewport media query
+     stacked far too late: at a 1750px window the lanes still had only ~450px
+     each and ellipsed almost every title. */
+  container-type: inline-size;
 }
 
 .home-recent-label {
@@ -691,7 +696,7 @@ watch(() => store.activeWorkspace, async () => {
   100% { background-position: -200% 0; }
 }
 
-@media (max-width: 819px) {
+@container (max-width: 760px) {
   /* Stack the lanes and keep every one of them open. Collapsing the inactive
      lane to a summary row read as a stray element rather than a control, and it
      hid that workspace's "+ new" button — leaving no way to start a chat there

--- a/web/src/components/HomeRecentChats.vue
+++ b/web/src/components/HomeRecentChats.vue
@@ -180,6 +180,7 @@ function makeLane(
       chats,
       chatId => store.chatNeedsInput(chatId),
       chatId => store.isChatStreaming(chatId) || store.chatHasBackgroundAgents(chatId),
+      chatId => store.chatUnread(chatId) > 0,
     ),
   }
 }
@@ -212,6 +213,10 @@ function laneWorkingCount(lane: HomeLane): number {
   return lane.tiers.working.length
 }
 
+function laneUnreadCount(lane: HomeLane): number {
+  return lane.tiers.unread.length
+}
+
 function laneQuietCount(lane: HomeLane): number {
   return lane.tiers.quiet.length + lane.tiers.older.length
 }
@@ -222,6 +227,7 @@ function laneQuietCount(lane: HomeLane): number {
 function laneSummaryRest(lane: HomeLane): string {
   const parts: string[] = []
   if (laneWorkingCount(lane)) parts.push(`${laneWorkingCount(lane)} working`)
+  if (laneUnreadCount(lane)) parts.push(`${laneUnreadCount(lane)} unread`)
   if (laneQuietCount(lane)) parts.push(`${laneQuietCount(lane)} quiet`)
   if (!parts.length && !laneNeedsCount(lane)) return 'all quiet'
   return parts.join(' · ')
@@ -248,6 +254,11 @@ function tierEntries(lane: HomeLane): Array<{ key: HomeTierKey; label: string; c
   return [
     { key: 'needsYou', label: 'needs you', chats: lane.tiers.needsYou },
     { key: 'working', label: 'working', chats: lane.tiers.working },
+    // A chat that finished while you were away is worth reading but is not
+    // blocking, so it sits between working and quiet rather than being called
+    // quiet - which contradicted the unread badge the sidebar showed for the
+    // very same chat.
+    { key: 'unread', label: 'unread', chats: lane.tiers.unread },
     // Older chats are listed inline with quiet rather than split behind a
     // disclosure. The age opacity ramp still dims them, so "old" stays legible
     // without a separate section and a count the user has to expand to read.
@@ -563,6 +574,7 @@ watch(() => store.activeWorkspace, async () => {
   font-weight: 400;
 }
 
+.home-chat-item--unread,
 .home-chat-item--quiet,
 .home-chat-item--older {
   flex-direction: row;
@@ -577,6 +589,7 @@ watch(() => store.activeWorkspace, async () => {
   background: transparent;
 }
 
+.home-chat-item--unread:hover,
 .home-chat-item--quiet:hover,
 .home-chat-item--older:hover {
   background: color-mix(in srgb, var(--accent) 7%, transparent);
@@ -592,6 +605,7 @@ watch(() => store.activeWorkspace, async () => {
   min-width: 0;
 }
 
+.home-chat-item--unread .home-chat-heading,
 .home-chat-item--quiet .home-chat-heading,
 .home-chat-item--older .home-chat-heading {
   flex: 1;
@@ -615,6 +629,7 @@ watch(() => store.activeWorkspace, async () => {
   font-weight: 600;
 }
 
+.home-chat-item--unread .home-chat-title,
 .home-chat-item--quiet .home-chat-title,
 .home-chat-item--older .home-chat-title {
   display: block;

--- a/web/src/components/HomeRecentChats.vue
+++ b/web/src/components/HomeRecentChats.vue
@@ -379,19 +379,22 @@ watch(() => store.activeWorkspace, async () => {
 
 .home-lane {
   min-width: 0;
-  padding-left: var(--space-3);
-  /* Reserved so switching workspaces does not shift the lanes sideways. */
-  border-left: 2px solid transparent;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  background: transparent;
 }
 
-/* The selected workspace: a rail down its edge, plus the emphatic header
-   rule, the brighter name and the accent key badge. Deliberately not a
-   tinted rounded panel - that wrapped a box around a column that already
-   holds cards, rows and a dashed button, so the screen became rounded
-   corners inside rounded corners. A flush rail reads at once and adds no
-   box. */
+/* The selected workspace reads as a raised surface, not another accent line.
+   Every card and row in the lane already carries a hue rail, so a rail on the
+   lane itself competed with them for the same meaning. A neutral lift says
+   "this column" without adding a fourth coloured edge, and the accent stays
+   where it identifies the workspace: the header rule, the name and the key
+   badge. No border, so this is a surface rather than another outlined box. */
 .home-lane--active {
-  border-left-color: var(--accent);
+  /* Between --bg and --bg2 on purpose: the cards inside are --bg2, so a full
+     --bg2 lane would swallow them. This lifts the column while leaving the
+     cards clearly above it. */
+  background: color-mix(in srgb, var(--bg2) 55%, var(--bg));
 }
 
 .home-lane-header {

--- a/web/src/components/HomeRecentChats.vue
+++ b/web/src/components/HomeRecentChats.vue
@@ -15,7 +15,7 @@
       >
         <header class="home-lane-header" :data-workspace-color="lane.color">
           <div class="home-lane-heading">
-            <span class="home-lane-shortcut">[{{ lane.shortcut }}]</span>
+            <span class="home-lane-shortcut">{{ lane.shortcut }}</span>
             <span class="home-lane-name">{{ lane.label || 'unassigned' }}</span>
             <span class="home-lane-summary" aria-live="polite">
               <template v-if="laneNeedsCount(lane)"><b>{{ laneNeedsCount(lane) }}</b> need{{ laneNeedsCount(lane) === 1 ? '' : 's' }} you</template>
@@ -363,11 +363,20 @@ watch(() => store.activeWorkspace, async () => {
 
 .home-lane {
   min-width: 0;
+  padding: 0 var(--space-3) var(--space-2);
   border-radius: var(--radius, 10px);
+  /* Reserved so switching workspaces does not shift the lanes sideways. */
+  border-left: 2px solid transparent;
 }
 
+/* The selected workspace. Several weak cues rather than one strong one, because
+   a saturated fill is reserved for "needs the user" (design system rule S1):
+   a hue rail down the side, a hue-tinted panel, and a full-strength underline
+   in the header — against inactive lanes that get none of the three. The
+   previous 28%-alpha tint on its own was invisible on this ground. */
 .home-lane--active {
-  background: color-mix(in srgb, var(--bg2) 28%, transparent);
+  border-left-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 7%, transparent);
 }
 
 .home-lane-header {
@@ -378,7 +387,15 @@ watch(() => store.activeWorkspace, async () => {
   min-width: 0;
   min-height: 44px;
   padding: 6px 0 8px;
-  border-bottom: 2px solid var(--accent);
+  /* Inactive lanes keep the hue so the workspace is still identifiable, but at
+     a fraction of the weight, so the active lane's rule reads as the emphatic
+     one instead of every lane looking equally selected. */
+  border-bottom: 1px solid color-mix(in srgb, var(--accent) 30%, var(--border));
+}
+
+.home-lane--active .home-lane-header {
+  border-bottom-width: 2px;
+  border-bottom-color: var(--accent);
 }
 
 .home-lane-heading {
@@ -389,19 +406,34 @@ watch(() => store.activeWorkspace, async () => {
   overflow: hidden;
 }
 
+.home-lane--active .home-lane-name {
+  color: var(--fg);
+}
+
+/* A bordered badge rather than bracketed text: it is a key you can press, and
+   the box is what makes that legible. Squared corners, per the design. */
 .home-lane-shortcut {
   flex: 0 0 auto;
-  color: var(--accent);
+  min-width: 18px;
+  padding: 0 var(--space-1);
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border-strong));
+  border-radius: var(--radius-xs);
+  color: color-mix(in srgb, var(--accent) 65%, var(--fg3));
   font-family: var(--font-mono);
-  font-size: var(--text-sm);
+  font-size: var(--text-xs);
   font-weight: 700;
+  text-align: center;
+}
+
+.home-lane--active .home-lane-shortcut {
+  border-color: var(--accent);
 }
 
 .home-lane-name {
   flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
-  color: var(--fg);
+  color: var(--fg2);
   font-family: var(--font-mono);
   font-size: var(--text-sm);
   font-weight: 700;
@@ -494,7 +526,7 @@ watch(() => store.activeWorkspace, async () => {
   padding: 10px 12px;
   border: 1px solid var(--border);
   border-left: 2px solid var(--accent);
-  border-radius: var(--radius, 10px);
+  border-radius: var(--radius-sm);
   background: var(--bg2);
   color: var(--fg);
   cursor: pointer;
@@ -535,7 +567,8 @@ watch(() => store.activeWorkspace, async () => {
   padding: 7px 10px;
   border: 0;
   border-left: 2px solid color-mix(in srgb, var(--accent) 45%, transparent);
-  border-radius: 0;
+  /* Square against its hue rail, rounded away from it. */
+  border-radius: 0 var(--radius-xs) var(--radius-xs) 0;
   background: transparent;
 }
 

--- a/web/src/components/HomeRecentChats.vue
+++ b/web/src/components/HomeRecentChats.vue
@@ -9,7 +9,6 @@
         class="home-lane"
         :class="{
           'home-lane--active': isLaneActive(lane),
-          'home-lane--expanded': isLaneExpanded(lane),
           'home-lane--unknown': !lane.workspace,
         }"
         :data-lane-key="lane.key"
@@ -34,31 +33,16 @@
           >{{ laneNewAction(lane)!.isCreating ? '...' : '+ new' }}</button>
         </header>
 
-        <button
-          v-if="!isLaneExpanded(lane)"
-          type="button"
-          class="home-lane-peek"
-          :data-workspace-color="lane.color"
-          :aria-label="`Show ${lane.label || 'unassigned'} workspace`"
-          @click="activateLane(lane)"
-        >
-          <span>[{{ lane.shortcut }}] {{ lane.label || 'unassigned' }}</span>
-          <span class="home-lane-peek-summary">· {{ laneSummary(lane) }}</span>
-        </button>
-
         <div class="home-lane-body">
           <div v-if="!laneHasChats(lane)" class="home-lane-empty">// no active chats</div>
 
           <template v-for="entry in tierEntries(lane)" :key="entry.key">
             <div
-              v-if="entry.key !== 'older' && (entry.chats.length || entry.key === 'needsYou')"
+              v-if="entry.chats.length"
               class="home-tier"
               :class="`home-tier--${entry.key}`"
             >
-              <div class="home-tier-label">
-                <span>{{ entry.label }}</span>
-                <span v-if="entry.key === 'needsYou' && !entry.chats.length">// nothing needs you here</span>
-              </div>
+              <div class="home-tier-label"><span>{{ entry.label }}</span></div>
               <button
                 v-for="chat in entry.chats"
                 :key="chat.chat_id"
@@ -100,37 +84,6 @@
               </button>
             </div>
 
-            <div v-else-if="entry.chats.length" class="home-tier home-tier--older">
-              <div class="home-tier-label"><span>older</span></div>
-              <button
-                type="button"
-                class="home-lane-older-toggle"
-                :aria-expanded="Boolean(olderExpanded[lane.key])"
-                @click="olderExpanded[lane.key] = !olderExpanded[lane.key]"
-              >
-                {{ olderExpanded[lane.key] ? 'Hide older chats' : `${entry.chats.length} more, older than a week` }}
-              </button>
-              <template v-if="olderExpanded[lane.key]">
-                <button
-                  v-for="chat in entry.chats"
-                  :key="chat.chat_id"
-                  type="button"
-                  class="home-chat-item home-chat-item--quiet home-chat-item--older"
-                  :class="chatItemClasses('older', chat)"
-                  :data-workspace-color="colorOf(chat)"
-                  :disabled="chat.local === false"
-                  :title="chat.local === false ? 'This chat lives on another instance' : chat.title"
-                  @click="chat.local !== false && store.switchChat(chat.chat_id)"
-                >
-                  <span
-                    class="home-chat-title"
-                    :class="{ 'home-chat-title--unread': store.chatUnread(chat.chat_id) > 0 }"
-                  >{{ chat.title }}</span>
-                  <ChatSignals :chat-id="chat.chat_id" density="row" :hue="colorOf(chat)" />
-                  <span class="home-chat-time">{{ relativeActivity(chat) }}</span>
-                </button>
-              </template>
-            </div>
           </template>
         </div>
       </section>
@@ -139,7 +92,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 import { useProjectStore } from '../stores/projects'
 import type { ChatInfo } from '../lib/types'
 import { ageBucket, chatActivityTimestamp, groupHomeTiers, type HomeTierKey, type HomeTiers } from '../lib/homeLanes'
@@ -156,8 +109,6 @@ const emit = defineEmits<{
 const store = useProjectStore()
 const lanesEl = ref<HTMLElement | null>(null)
 const laneElements = ref<Record<string, HTMLElement>>({})
-const olderExpanded = ref<Record<string, boolean>>({})
-const isNarrow = ref(typeof window !== 'undefined' && window.innerWidth < 820)
 
 interface HomeLane {
   key: string
@@ -265,17 +216,6 @@ function laneQuietCount(lane: HomeLane): number {
   return lane.tiers.quiet.length + lane.tiers.older.length
 }
 
-function laneSummary(lane: HomeLane): string {
-  const needs = laneNeedsCount(lane)
-  const working = laneWorkingCount(lane)
-  const quiet = laneQuietCount(lane)
-  const parts: string[] = []
-  if (needs) parts.push(`${needs} need you`)
-  if (working) parts.push(`${working} working`)
-  if (quiet) parts.push(`${quiet} quiet`)
-  return parts.join(' · ') || 'all quiet'
-}
-
 // The header renders the needs count itself so it can carry the hue emphasis;
 // this is everything after it. Returning 'all quiet' only when the lane is
 // wholly empty keeps the header from printing "3 quiet all quiet".
@@ -285,13 +225,6 @@ function laneSummaryRest(lane: HomeLane): string {
   if (laneQuietCount(lane)) parts.push(`${laneQuietCount(lane)} quiet`)
   if (!parts.length && !laneNeedsCount(lane)) return 'all quiet'
   return parts.join(' · ')
-}
-
-// Lanes without a real workspace cannot be activated via switchWorkspace, so
-// they must never be the collapsed one at narrow widths or they become
-// unreachable: the peek button's click handler has nothing to switch to.
-function isLaneExpanded(lane: HomeLane): boolean {
-  return !lane.workspace || isLaneActive(lane)
 }
 
 function laneNewAction(lane: HomeLane): NewWorkspaceChatAction | null {
@@ -311,16 +244,14 @@ function isLaneActive(lane: HomeLane): boolean {
   return lane.workspace === store.activeWorkspace
 }
 
-function activateLane(lane: HomeLane) {
-  if (lane.workspace) void store.switchWorkspace(lane.workspace)
-}
-
 function tierEntries(lane: HomeLane): Array<{ key: HomeTierKey; label: string; chats: ChatInfo[] }> {
   return [
     { key: 'needsYou', label: 'needs you', chats: lane.tiers.needsYou },
     { key: 'working', label: 'working', chats: lane.tiers.working },
-    { key: 'quiet', label: 'quiet', chats: lane.tiers.quiet },
-    { key: 'older', label: 'older', chats: lane.tiers.older },
+    // Older chats are listed inline with quiet rather than split behind a
+    // disclosure. The age opacity ramp still dims them, so "old" stays legible
+    // without a separate section and a count the user has to expand to read.
+    { key: 'quiet', label: 'quiet', chats: [...lane.tiers.quiet, ...lane.tiers.older] },
   ]
 }
 
@@ -345,16 +276,10 @@ function setLaneRef(key: string, element: HTMLElement | null) {
 function focusableLanes(): HTMLElement[][] {
   const container = lanesEl.value
   if (!container) return []
-  return Array.from(container.querySelectorAll<HTMLElement>('.home-lane')).map(lane => {
-    // Read the rendered class rather than recomputing from activeWorkspace, so
-    // arrow navigation always matches what is actually on screen — including
-    // workspace-less lanes, which stay expanded at every width.
-    const collapsed = isNarrow.value && !lane.classList.contains('home-lane--expanded')
-    const selector = collapsed
-      ? '.home-lane-peek:not([disabled])'
-      : '.home-chat-item:not([disabled]), .home-lane-older-toggle:not([disabled])'
-    return Array.from(lane.querySelectorAll<HTMLElement>(selector))
-  })
+  // Every lane renders in full at every width now, so there is one selector.
+  return Array.from(container.querySelectorAll<HTMLElement>('.home-lane')).map(lane =>
+    Array.from(lane.querySelectorAll<HTMLElement>('.home-chat-item:not([disabled])')),
+  )
 }
 
 function focusElement(element: HTMLElement) {
@@ -385,7 +310,6 @@ function onArrow(key: string): boolean {
   }
 
   if (key !== 'ArrowLeft' && key !== 'ArrowRight') return false
-  if (isNarrow.value) return false
 
   const delta = key === 'ArrowRight' ? 1 : -1
   if (itemIndex < 0) {
@@ -406,18 +330,12 @@ function clamp(value: number, lower: number, upper: number): number {
 
 defineExpose({ onArrow })
 
-function onResize() {
-  isNarrow.value = window.innerWidth < 820
-}
-
 watch(() => store.activeWorkspace, async () => {
   await nextTick()
   const lane = laneElements.value[store.activeWorkspace]
   lane?.scrollIntoView({ block: 'nearest' })
 })
 
-onMounted(() => window.addEventListener('resize', onResize))
-onBeforeUnmount(() => window.removeEventListener('resize', onResize))
 </script>
 
 <style scoped>
@@ -552,22 +470,18 @@ onBeforeUnmount(() => window.removeEventListener('resize', onResize))
   min-width: 0;
 }
 
+/* Lowercase deliberately: these are quiet structural markers, not headings.
+   They used to inherit `text-transform: uppercase` with a `span:last-child`
+   override cancelling it — which only fired when a tier had a second span, so
+   "needs you" shouted in caps while "working" and "quiet" did not. */
 .home-tier-label {
   display: flex;
-  justify-content: space-between;
-  gap: 8px;
-  padding-bottom: 4px;
+  gap: var(--space-2);
+  padding-bottom: var(--space-1);
   border-bottom: 1px solid var(--border);
   color: var(--fg3);
   font-family: var(--font-mono);
   font-size: var(--text-xs);
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-}
-
-.home-tier-label span:last-child {
-  letter-spacing: 0;
-  text-transform: none;
 }
 
 .home-chat-item {
@@ -598,9 +512,7 @@ onBeforeUnmount(() => window.removeEventListener('resize', onResize))
   transform: translateY(1px);
 }
 
-.home-chat-item:focus-visible,
-.home-lane-peek:focus-visible,
-.home-lane-older-toggle:focus-visible {
+.home-chat-item:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px var(--accent);
 }
@@ -720,46 +632,6 @@ onBeforeUnmount(() => window.removeEventListener('resize', onResize))
   white-space: nowrap;
 }
 
-.home-lane-older-toggle {
-  align-self: flex-start;
-  min-height: var(--touch, 44px);
-  padding: 5px 2px;
-  border: 0;
-  background: none;
-  color: var(--fg2);
-  cursor: pointer;
-  font: inherit;
-  font-size: var(--text-xs);
-  text-align: left;
-}
-
-.home-lane-older-toggle:hover { color: var(--fg); }
-
-.home-lane-peek {
-  display: none;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  min-height: var(--touch, 44px);
-  padding: 7px 10px;
-  border: 1px solid color-mix(in srgb, var(--accent) 55%, var(--border));
-  border-radius: var(--radius, 10px);
-  background: color-mix(in srgb, var(--accent) 5%, var(--bg2));
-  color: var(--fg);
-  cursor: pointer;
-  font: inherit;
-  font-size: var(--text-sm);
-  text-align: left;
-}
-
-.home-lane-peek-summary {
-  min-width: 0;
-  overflow: hidden;
-  color: var(--fg2);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .remote-chip {
   flex: 0 0 auto;
   padding: 1px 4px;
@@ -787,18 +659,13 @@ onBeforeUnmount(() => window.removeEventListener('resize', onResize))
 }
 
 @media (max-width: 819px) {
+  /* Stack the lanes and keep every one of them open. Collapsing the inactive
+     lane to a summary row read as a stray element rather than a control, and it
+     hid that workspace's "+ new" button — leaving no way to start a chat there
+     on a phone. Scrolling past a short lane is cheaper than that. */
   .home-lanes {
     grid-template-columns: minmax(0, 1fr);
-    gap: 8px;
-  }
-
-  .home-lane:not(.home-lane--expanded) .home-lane-header,
-  .home-lane:not(.home-lane--expanded) .home-lane-body {
-    display: none;
-  }
-
-  .home-lane:not(.home-lane--expanded) .home-lane-peek {
-    display: flex;
+    gap: var(--space-5);
   }
 }
 

--- a/web/src/components/HomeRecentChats.vue
+++ b/web/src/components/HomeRecentChats.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="store.activeChatsAll.length" class="home-recent">
-    <div class="home-recent-label">jump back in</div>
+    <h2 class="home-recent-label">jump back in</h2>
     <div ref="lanesEl" class="home-lanes">
       <section
         v-for="lane in lanes"
@@ -362,12 +362,20 @@ watch(() => store.activeWorkspace, async () => {
   container-type: inline-size;
 }
 
+/* Off the screen, still in the document. The lane headings and tier headings
+   below already say what this list is, so the label was a caption for something
+   self-evident - but it is the only heading naming this region, so assistive
+   tech keeps it. Same rule as .sr-only in App.vue. */
 .home-recent-label {
-  margin: 0 0 8px 2px;
-  color: var(--fg2);
-  font-size: var(--text-xs, 0.72rem);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .home-lanes {

--- a/web/src/components/HomeRecentChats.vue
+++ b/web/src/components/HomeRecentChats.vue
@@ -341,7 +341,7 @@ watch(() => store.activeWorkspace, async () => {
 <style scoped>
 .home-recent {
   width: 100%;
-  max-width: 1040px;
+  max-width: 1320px;
   margin: 0 auto;
   text-align: left;
 }
@@ -363,20 +363,19 @@ watch(() => store.activeWorkspace, async () => {
 
 .home-lane {
   min-width: 0;
-  padding: 0 var(--space-3) var(--space-2);
-  border-radius: var(--radius, 10px);
+  padding-left: var(--space-3);
   /* Reserved so switching workspaces does not shift the lanes sideways. */
   border-left: 2px solid transparent;
 }
 
-/* The selected workspace. Several weak cues rather than one strong one, because
-   a saturated fill is reserved for "needs the user" (design system rule S1):
-   a hue rail down the side, a hue-tinted panel, and a full-strength underline
-   in the header — against inactive lanes that get none of the three. The
-   previous 28%-alpha tint on its own was invisible on this ground. */
+/* The selected workspace: a rail down its edge, plus the emphatic header
+   rule, the brighter name and the accent key badge. Deliberately not a
+   tinted rounded panel - that wrapped a box around a column that already
+   holds cards, rows and a dashed button, so the screen became rounded
+   corners inside rounded corners. A flush rail reads at once and adds no
+   box. */
 .home-lane--active {
   border-left-color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 7%, transparent);
 }
 
 .home-lane-header {
@@ -545,8 +544,9 @@ watch(() => store.activeWorkspace, async () => {
 }
 
 .home-chat-item:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--bg), 0 0 0 4px var(--accent);
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+  box-shadow: none;
 }
 
 .home-chat-item--needsYou {

--- a/web/src/components/HomeRecentChats.vue
+++ b/web/src/components/HomeRecentChats.vue
@@ -271,10 +271,17 @@ function relativeActivity(chat: ChatInfo): string {
 }
 
 function chatItemClasses(tier: HomeTierKey, chat: ChatInfo): string[] {
+  // Age only dims the tiers where age is the whole story. An unread chat is
+  // surfaced precisely because it wants reading, and one that has been waiting a
+  // week is the most likely to be missed - fading it to 55% made the row look
+  // disabled and undid the reason it was pulled out of quiet. Same for anything
+  // needing you or working, which are about now rather than when.
+  const dimByAge = tier === 'quiet' || tier === 'older'
+  const age = dimByAge ? ageBucket(chatActivityTimestamp(chat)) : 'fresh'
   return [
     `home-chat-item--${tier}`,
-    ageBucket(chatActivityTimestamp(chat)) === 'week' ? 'home-chat-item--week-old' : '',
-    ageBucket(chatActivityTimestamp(chat)) === 'older' ? 'home-chat-item--old' : '',
+    age === 'week' ? 'home-chat-item--week-old' : '',
+    age === 'older' ? 'home-chat-item--old' : '',
     chat.local === false ? 'remote' : '',
   ].filter(Boolean)
 }
@@ -570,10 +577,15 @@ watch(() => store.activeWorkspace, async () => {
   transform: translateY(1px);
 }
 
+/* Positive offset, so the ring sits clear of the card edge. At -1px it was drawn
+   inside the border and merged with the accent rail on the left, which is the
+   one place a keyboard user most needs to see where focus is. Kept to a single
+   ring - the old two-ring treatment was what made the rows read as boxes inside
+   boxes - with a --bg gap so it separates on any surface. */
 .home-chat-item:focus-visible {
   outline: 2px solid var(--accent);
-  outline-offset: -1px;
-  box-shadow: none;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px var(--bg);
 }
 
 .home-chat-item--needsYou {

--- a/web/src/components/ModelSelector.vue
+++ b/web/src/components/ModelSelector.vue
@@ -207,6 +207,12 @@ function scrollActiveIntoView() {
 
 function onKeydown(event: KeyboardEvent) {
   if (event.key === 'Escape') {
+    // Claim the key. Dismissing this popover is the whole meaning of the press,
+    // and the global handler in ChatLayout treats an unclaimed Escape as "go
+    // home" - so without this, closing the picker also navigated away, out of
+    // half-finished Settings edits.
+    event.preventDefault()
+    event.stopPropagation()
     close()
     triggerRef.value?.focus()
     return

--- a/web/src/components/NotificationBell.vue
+++ b/web/src/components/NotificationBell.vue
@@ -68,12 +68,28 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, ref } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useProjectStore } from '../stores/projects'
 import type { ChatInfo } from '../lib/types'
 
 const store = useProjectStore()
 const open = ref(false)
+
+// Esc closes the panel from anywhere, not only when focus happens to be inside
+// it. Opening the bell by click leaves focus on the button, and clicking a row
+// can move it out entirely, so the root-level `@keydown.esc` missed most cases.
+// Captured and stopped so the same press does not also navigate home: the panel
+// is the innermost dismissable thing on screen, so it wins.
+function onWindowKeydown(e: KeyboardEvent) {
+  if (e.key !== 'Escape' || !open.value) return
+  e.preventDefault()
+  e.stopPropagation()
+  open.value = false
+  btnRef.value?.focus()
+}
+
+onMounted(() => window.addEventListener('keydown', onWindowKeydown, true))
+onBeforeUnmount(() => window.removeEventListener('keydown', onWindowKeydown, true))
 const btnRef = ref<HTMLElement | null>(null)
 const panelStyle = ref<Record<string, string>>({})
 

--- a/web/src/components/PaneHeader.vue
+++ b/web/src/components/PaneHeader.vue
@@ -62,7 +62,9 @@ defineEmits<{ 'open-sidebar': [] }>()
 }
 :deep(.pane-title) {
   font-weight: 600;
-  font-size: 16px;
+  /* Token, not 16px: the breadcrumb beside this uses --text-lg, so a fixed
+     pixel value drifted apart from it as soon as the font scale moved. */
+  font-size: var(--text-lg);
   display: block;
   min-width: 0;
   max-width: 100%;

--- a/web/src/components/PaneHeader.vue
+++ b/web/src/components/PaneHeader.vue
@@ -7,58 +7,126 @@
         <line x1="4" y1="17" x2="20" y2="17"/>
       </svg>
     </button>
-    <div class="header-title">
-      <slot name="title">
-        <h2>{{ title }}</h2>
-      </slot>
+    <div v-if="hasTitle" class="header-title">
+      <slot name="title" />
     </div>
-    <div v-if="$slots.actions" class="header-actions" :key="activeBgAgents">
-      <slot name="actions" />
+    <div class="header-center">
+      <BrandMark v-if="brand" />
+      <!-- Which view this is. Styled as a quiet marker, never as a heading: it
+           answers "where am I", it is not the subject of the page, so it stays at
+           --fg3 in an outlined chip. A fill would read as "needs you" (Rule S1).
+           It is an <h2> on views that have no title of their own (home, settings,
+           the automations list) so those pages keep the one heading their pane
+           header used to give them, and a plain <span> where a title already
+           names the page. -->
+      <component :is="hasTitle ? 'span' : 'h2'" v-if="pageTag" class="page-tag">{{ pageTag }}</component>
     </div>
-    <NotificationBell class="header-bell" />
+    <div class="header-trail">
+      <div v-if="$slots.actions" class="header-actions" :key="activeBgAgents">
+        <slot name="actions" />
+      </div>
+      <NotificationBell class="header-bell" />
+    </div>
   </header>
 </template>
 
 <script setup lang="ts">
+import { computed, useSlots } from 'vue'
 import NotificationBell from './NotificationBell.vue'
+import BrandMark from './BrandMark.vue'
 
-defineProps<{ title?: string; activeBgAgents?: number }>()
+withDefaults(defineProps<{
+  activeBgAgents?: number
+  /** Short marker for the current view: 'home', 'settings', 'automations', … */
+  pageTag?: string
+  /** Off only where a second mark would duplicate the main pane's (split view). */
+  brand?: boolean
+}>(), { brand: true })
 defineEmits<{ 'open-sidebar': [] }>()
+
+const slots = useSlots()
+// An empty `.header-title` would still claim the left grid track and, on mobile,
+// a second row. Views with no title of their own (home, settings, the automations
+// list) drop the element and let the page tag name them instead.
+const hasTitle = computed(() => !!slots.title)
 </script>
 
 <style scoped>
 .pane-header {
-  display: flex;
+  /* Three columns, so the brand in the middle one is genuinely centred on the
+     header rather than centred-by-eye with an absolute offset.
+       col 1  minmax(0, 1fr)  the title: may shrink to nothing, so it ellipses
+                              instead of pushing the middle column off centre
+       col 2  auto            the brand + page tag, sized by content
+       col 3  1fr             the actions: `1fr` is minmax(auto, 1fr), so its
+                              min is the icons' own width and they never crush
+     Both side tracks are `1fr`, so while there is free space they are equal and
+     the middle one lands dead centre. Once the actions need more than their
+     share they take it from col 1, which is the correct order of sacrifice: a
+     long chat title ellipses, no icon is clipped, and the mark drifts off centre
+     only in the layout where nothing could have stayed centred anyway. */
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto 1fr;
   align-items: center;
   /* Match the sidebar header: 44px controls + 8px vertical padding + border. */
   height: calc(61px + var(--safe-top));
-  padding: calc(8px + var(--safe-top)) 8px 8px;
+  padding: calc(var(--space-2) + var(--safe-top)) var(--space-2) var(--space-2);
   border-bottom: 1px solid var(--border);
   background: var(--bg);
-  gap: 8px;
+  column-gap: var(--space-2);
   flex-shrink: 0;
   box-sizing: border-box;
 }
 .header-title {
-  flex: 1;
+  grid-column: 1;
   min-width: 0;
-  text-align: center;
+  text-align: left;
+}
+.header-center {
+  grid-column: 2;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+.header-trail {
+  grid-column: 3;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+/* In the split view the chat pane can be dragged down to its 240px floor, where
+   the header cannot hold a centred mark on top of a title and the action icons.
+   The middle column is the first thing to go: the mark is decoration plus a
+   reload shortcut that is one drag of the splitter away, whereas a clipped icon
+   is a lost action. `chat-split` is declared on `.chat-split-main` in
+   ChatLayout, so this only applies inside the split view. */
+@container chat-split (max-width: 420px) {
+  .header-center { display: none; }
+}
+.page-tag {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 400;
+  line-height: 1;
+  color: var(--fg3);
+  letter-spacing: 0.06em;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xs);
+  background: transparent;
+  white-space: nowrap;
+  user-select: none;
 }
 :deep(.header-left) {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   min-width: 0;
   flex: 1;
   text-align: left;
-}
-.header-title h2 {
-  margin: 0;
-  font-size: 16px;
-  font-weight: 600;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 :deep(.pane-title) {
   font-weight: 600;
@@ -76,7 +144,7 @@ defineEmits<{ 'open-sidebar': [] }>()
 .header-actions {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--space-1);
   flex-shrink: 0;
 }
 .header-hamburger {
@@ -89,7 +157,7 @@ defineEmits<{ 'open-sidebar': [] }>()
   border: none;
   color: var(--fg);
   cursor: pointer;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   flex-shrink: 0;
 }
 .header-hamburger:active { transform: scale(0.96); }
@@ -109,7 +177,7 @@ defineEmits<{ 'open-sidebar': [] }>()
   min-height: 30px;
   padding: calc((var(--touch) - 30px) / 2);
   margin: calc((30px - var(--touch)) / 2);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   position: relative;
   isolation: isolate;
 }
@@ -121,7 +189,7 @@ defineEmits<{ 'open-sidebar': [] }>()
   position: absolute;
   inset: calc((var(--touch) - 30px) / 2);
   z-index: -1;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: transparent;
   pointer-events: none;
   transition: background 120ms var(--ease);
@@ -160,7 +228,7 @@ defineEmits<{ 'open-sidebar': [] }>()
   justify-content: center;
   width: 30px;
   height: 30px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: transparent;
   border: none;
   color: var(--fg2);
@@ -179,25 +247,58 @@ defineEmits<{ 'open-sidebar': [] }>()
   background: transparent;
 }
 @media (max-width: 768px) {
+  /* Narrow: the hamburger joins the row, so a single row would have to fit
+     hamburger + title + brand + actions + bell across ~360px and the title is
+     what would lose. Instead the chrome keeps row 1 - hamburger, brand, actions -
+     and the title gets row 2 to itself, full width, where its two-line clamp has
+     somewhere to go. Row 2 only exists when there is a title, because
+     `.header-title` is not rendered otherwise.
+     The columns are content-sized here rather than equal `1fr` tracks: with the
+     actions unable to shrink, equal tracks would let them overrun the middle
+     column and sit on top of the mark. The mark centres in the space left
+     between the hamburger and the actions. */
   .pane-header {
     height: auto;
-    padding-left: calc(12px + var(--safe-left));
-    padding-right: calc(12px + var(--safe-right));
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    padding-left: calc(var(--space-3) + var(--safe-left));
+    padding-right: calc(var(--space-3) + var(--safe-right));
+    row-gap: var(--space-1);
   }
-  .header-hamburger,
+  .header-hamburger {
+    display: flex;
+    grid-column: 1;
+    grid-row: 1;
+    justify-self: start;
+  }
+  .header-center {
+    grid-column: 2;
+    grid-row: 1;
+    justify-content: center;
+  }
+  .header-trail {
+    grid-column: 3;
+    grid-row: 1;
+  }
+  .header-title {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    text-align: left;
+    min-width: 0;
+  }
   .header-bell { display: flex; }
-  .header-title { text-align: left; min-width: 0; }
   :deep(.header-left) { min-width: 0; }
   :deep(.header-actions) {
     flex-shrink: 0;
-    gap: 6px;
+    gap: var(--space-1);
   }
   :deep(.pane-title) {
     flex: 1 1 100%;
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
-    font-size: 12px;
+    /* Token, not 12px: a literal here does not answer the Appearance font-scale
+       setting, so raising the scale grew every other string but this one. */
+    font-size: var(--text-sm);
     line-height: 1.2;
     white-space: normal;
   }

--- a/web/src/components/PaneHeader.vue
+++ b/web/src/components/PaneHeader.vue
@@ -105,6 +105,13 @@ const hasTitle = computed(() => !!slots.title)
 @container chat-split (max-width: 420px) {
   .header-center { display: none; }
 }
+
+/* Very narrow viewports: drop the mark outright rather than clip it. The trail's
+   controls cannot shrink, so something has to go, and the mark is the only thing
+   here that is not an action. */
+@media (max-width: 460px) {
+  .header-center { display: none; }
+}
 /* Kept in the document, not on the screen. The page now names itself next to
    its own nav icon in the sidebar, which is where it was asked for, so a second
    copy here beside the wordmark was the same fact twice. It stays rendered
@@ -276,6 +283,14 @@ const hasTitle = computed(() => !!slots.title)
     grid-column: 2;
     grid-row: 1;
     justify-content: center;
+    /* The track shrinks but the wordmark does not, so on the tightest headers -
+       an automation detail at 375px, where the trail already holds Run now,
+       overflow and the bell, and worse again at a raised font scale - it
+       overran the hamburger and the actions. Let it disappear instead: it is
+       decoration plus a reload shortcut, and a clipped control is a lost
+       action. Same trade the split-view rule above makes. */
+    min-width: 0;
+    overflow: hidden;
   }
   .header-trail {
     grid-column: 3;

--- a/web/src/components/PaneHeader.vue
+++ b/web/src/components/PaneHeader.vue
@@ -105,20 +105,22 @@ const hasTitle = computed(() => !!slots.title)
 @container chat-split (max-width: 420px) {
   .header-center { display: none; }
 }
+/* Kept in the document, not on the screen. The page now names itself next to
+   its own nav icon in the sidebar, which is where it was asked for, so a second
+   copy here beside the wordmark was the same fact twice. It stays rendered
+   because on home, settings and the automations list it is the pane's only
+   heading, and dropping the element would cost those views their document
+   outline. Same rule as .sr-only in App.vue. */
 .page-tag {
-  margin: 0;
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  font-weight: 400;
-  line-height: 1;
-  color: var(--fg3);
-  letter-spacing: 0.06em;
-  padding: var(--space-1) var(--space-2);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-xs);
-  background: transparent;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
   white-space: nowrap;
-  user-select: none;
+  border: 0;
 }
 :deep(.header-left) {
   display: flex;

--- a/web/src/components/PinnedFilePanel.vue
+++ b/web/src/components/PinnedFilePanel.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="pinned-file-panel" ref="rootEl">
-    <PaneHeader @open-sidebar="$emit('close')">
+    <!-- No brand and no page tag: this header sits beside the main pane's in the
+         split view, and a second wordmark two inches away is the duplication the
+         mark was moved out of the sidebar to end. The filename is the title. -->
+    <PaneHeader :brand="false" @open-sidebar="$emit('close')">
       <template #title>
         <div class="header-left">
           <button class="close-btn desktop-only" @click="$emit('close')" title="Unpin file">&times;</button>

--- a/web/src/components/ProjectSidebar.vue
+++ b/web/src/components/ProjectSidebar.vue
@@ -19,14 +19,9 @@
         </svg>
       </button>
       <template v-if="!collapsed">
-        <button
-          type="button"
-          class="brand wordmark wordmark--sm"
-          :class="{ 'brand--refreshing': refreshing }"
-          @click="onBrandClick"
-          :title="refreshing ? 'Reloading...' : 'Click to reload the latest app build'"
-          :aria-busy="refreshing"
-        ><span class="brand-label">{{ brandLabel }}</span></button>
+        <!-- The wordmark used to sit here, between the toggle and these icons.
+             It is `BrandMark` in the pane header now, where it is centred and
+             does not have to share the sidebar's width. -->
         <div class="nav-links">
           <router-link
             to="/"
@@ -642,7 +637,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, computed, watch, onBeforeUnmount } from 'vue'
+import { ref, reactive, computed, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useProjectStore } from '../stores/projects'
 import { errorMessage } from '../lib/errorMessage'
@@ -733,11 +728,6 @@ const moveSubmenu = ref(false)
 const editingProject = ref<string | null>(null)
 const renamingChat = ref<string | null>(null)
 const renameValue = ref('')
-const refreshing = ref(false)
-const BRAND_TEXT = 'ciaobot'
-const PIXEL_CHARS = '█▓▒░▄▀▐▌▆▅▃▂▪▫◆●○·'
-const brandLabel = ref(BRAND_TEXT)
-
 const isAnyChatWorking = computed(() => {
   return Object.values(store.streaming).some(Boolean) ||
          Object.values(store.projectStreaming).some(Boolean) ||
@@ -748,29 +738,6 @@ const hasAutomationWarning = computed(() => {
   return taskStore.schedules.some(s => s.enabled && s.missed) ||
          taskStore.loops.some(l => l.running && (l.last_status === 'error' || l.last_status === 'missing-chat'))
 })
-let brandPixelTimer: ReturnType<typeof setInterval> | null = null
-
-function startBrandPixelAnimation() {
-  stopBrandPixelAnimation()
-  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
-  brandPixelTimer = setInterval(() => {
-    brandLabel.value = BRAND_TEXT
-      .split('')
-      .map((char) => (Math.random() < 0.18 ? char : PIXEL_CHARS[Math.floor(Math.random() * PIXEL_CHARS.length)]))
-      .join('')
-  }, 80)
-}
-
-function stopBrandPixelAnimation() {
-  if (brandPixelTimer !== null) {
-    clearInterval(brandPixelTimer)
-    brandPixelTimer = null
-  }
-  brandLabel.value = BRAND_TEXT
-}
-
-onBeforeUnmount(stopBrandPixelAnimation)
-
 // Destination projects for "Move to..." — same workspace as the chat,
 // excluding the chat's current project. Backend rejects cross-workspace moves.
 const chatMenuChat = computed<ChatInfo | null>(() => {
@@ -876,30 +843,6 @@ async function moveChatToProject(chatId: string, targetProjectId: string) {
   } catch (e) {
     store.pushErrorToast('Could not move chat', `${errorMessage(e)}`)
   }
-}
-
-async function onBrandClick() {
-  if (refreshing.value) return
-  refreshing.value = true
-  startBrandPixelAnimation()
-  try {
-    // Force the service worker to update without unregistering it,
-    // so push subscriptions survive across builds.
-    if ('serviceWorker' in navigator) {
-      const regs = await navigator.serviceWorker.getRegistrations()
-      await Promise.all(regs.map(r => r.update()))
-    }
-    if (typeof caches !== 'undefined') {
-      const keys = await caches.keys()
-      await Promise.all(keys.map(k => caches.delete(k)))
-    }
-  } catch (e) {
-    console.warn('Hard refresh cleanup failed', e)
-  }
-  // Bust HTTP cache too via a query string; replace so no back-button stale entry.
-  const url = new URL(window.location.href)
-  url.searchParams.set('_r', String(Date.now()))
-  window.location.replace(url.toString())
 }
 
 // Auto-expand all projects when they load (and keep new ones expanded)
@@ -1239,47 +1182,6 @@ async function confirmDeleteChat(chatId: string) {
 .toggle-btn:active { transform: scale(0.94); }
 .toggle-btn--collapsed svg { transform: scaleX(-1); }
 
-.brand {
-  /* Inherits .wordmark base from App.vue; override size and add interaction. */
-  font-size: calc(16px * var(--font-scale));
-  cursor: pointer;
-  transition: opacity 120ms var(--ease);
-  min-height: var(--touch);
-  align-items: center;
-  padding: 0 4px;
-  border: 0;
-  background: transparent;
-}
-.brand::before {
-  content: none;
-}
-.brand:hover { opacity: 0.85; }
-.brand:active { opacity: 0.7; }
-.brand-label {
-  display: inline-block;
-  min-width: 7ch;
-  text-align: left;
-}
-.brand--refreshing {
-  opacity: 1;
-  color: var(--accent);
-  pointer-events: none;
-}
-.brand--refreshing .brand-label {
-  animation: brand-pixel-jitter 0.12s steps(2, end) infinite;
-  text-shadow:
-    1px 0 color-mix(in srgb, var(--accent) 75%, transparent),
-    -1px 0 color-mix(in srgb, var(--accent2) 55%, transparent),
-    0 1px color-mix(in srgb, var(--fg) 35%, transparent);
-}
-@keyframes brand-pixel-jitter {
-  0%, 100% { transform: translate(0, 0); }
-  50% { transform: translate(1px, -1px); }
-}
-@media (prefers-reduced-motion: reduce) {
-  .brand--refreshing .brand-label { animation: none; }
-}
-
 /* Pulsing dot used inline next to project / chat names to signal activity.
    A breathing scale+opacity pulse reads as "alive" at a glance, unlike a
    thin two-tone ring spin which is too subtle at this size to notice. */
@@ -1471,7 +1373,20 @@ async function confirmDeleteChat(chatId: string) {
 .nav-links {
   display: flex;
   align-items: center;
-  gap: 4px;
+  /* The wordmark used to take the middle of this row, leaving these four icons
+     huddled at a 4px gap against the right edge. It is in the pane header now, and
+     the ~90px it gives back is spent here: the icons spread across a 200px strip,
+     so each 30px glyph gets ~27px of air and its 44px touch target no longer
+     overlaps its neighbour's. The glyphs stay 30px, because the pane header sizes
+     its own icons to match the sidebar - see the note there.
+     `space-between` over a capped basis rather than a fixed gap, because that
+     degrades in both directions: a sidebar dragged out to 500px does not fling the
+     icons to the far edge (the strip stops at 200px), and one dragged down to its
+     180px minimum packs them back to the --space-1 floor instead of overflowing
+     the rail. The strip is narrower on mobile, where the bell hides - see below. */
+  flex: 0 1 200px;
+  justify-content: space-between;
+  gap: var(--space-1);
   margin-left: auto;
 }
 
@@ -2141,6 +2056,10 @@ async function confirmDeleteChat(chatId: string) {
   }
   .add-chat-btn { opacity: 1; }
   .sidebar-bell { display: none; }
+  /* Three icons here instead of four (the pane header carries the bell on mobile),
+     so the strip narrows to match. Left at 200px it would space three glyphs
+     40px apart and read as scattered rather than spread. */
+  .nav-links { flex-basis: 150px; }
 }
 
 /* Schedules list in sidebar (schedules mode) */

--- a/web/src/components/ProjectSidebar.vue
+++ b/web/src/components/ProjectSidebar.vue
@@ -1313,25 +1313,44 @@ async function confirmDeleteChat(chatId: string) {
   background: var(--accent);
 }
 
-.workspace-status-ring,
-.rollup-ring {
+/* Working, at rollup level. Same treatment as the chat transcript's own
+   activity pulse and ChatSignals: a solid accent dot with a halo plus an
+   expanding ring. The outlined ring this replaced was nearly invisible at this
+   size against the sidebar ground. */
+.rollup-ring,
+.workspace-status-ring {
+  position: relative;
   display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 10px;
-  height: 10px;
+  width: 8px;
+  height: 8px;
   flex: 0 0 auto;
-  border: 1.5px solid var(--accent);
-  border-radius: 50%;
-}
-
-.workspace-status-core,
-.rollup-ring-core {
-  width: 3px;
-  height: 3px;
   border-radius: 50%;
   background: var(--accent);
+  box-shadow: 0 0 4px var(--accent);
   animation: ciao-pulse 1.1s ease-in-out infinite;
+}
+
+.rollup-ring::before,
+.workspace-status-ring::before {
+  content: "";
+  position: absolute;
+  inset: -3px;
+  border-radius: 50%;
+  background: var(--accent);
+  opacity: 0.45;
+  animation: ciao-ring 1.1s ease-out infinite;
+  pointer-events: none;
+}
+
+/* The inner core is now the dot itself, so the nested span is decorative. */
+.workspace-status-core,
+.rollup-ring-core {
+  display: none;
+}
+
+@keyframes ciao-ring {
+  0% { transform: scale(0.6); opacity: 0.45; }
+  100% { transform: scale(1.6); opacity: 0; }
 }
 
 /* Scrollable area for chats and projects */

--- a/web/src/components/ProjectSidebar.vue
+++ b/web/src/components/ProjectSidebar.vue
@@ -41,6 +41,7 @@
               <line x1="6" y1="13" x2="18" y2="13" />
               <polyline points="8 18 8 21 11 18" />
             </svg>
+                      <span class="nav-item-label" aria-hidden="true">chats</span>
           </router-link>
           <router-link
             to="/schedules"
@@ -62,6 +63,7 @@
               <line x1="19" y1="12" x2="21" y2="12" />
               <polyline points="12 8 12 12 15 14" />
             </svg>
+                      <span class="nav-item-label" aria-hidden="true">automations</span>
           </router-link>
           <router-link to="/settings" class="nav-item touch-hit" active-class="nav-item--active" title="settings" aria-label="settings">
             <!-- Sliders / equalizer: more direct than a gear, mono-grid friendly -->
@@ -74,6 +76,7 @@
               <rect x="7" y="10" width="4" height="4" fill="currentColor" />
               <rect x="15" y="15" width="4" height="4" fill="currentColor" />
             </svg>
+                      <span class="nav-item-label" aria-hidden="true">settings</span>
           </router-link>
           <NotificationBell class="sidebar-bell" />
         </div>
@@ -1384,23 +1387,59 @@ async function confirmDeleteChat(chatId: string) {
      icons to the far edge (the strip stops at 200px), and one dragged down to its
      180px minimum packs them back to the --space-1 floor instead of overflowing
      the rail. The strip is narrower on mobile, where the bell hides - see below. */
-  flex: 0 1 200px;
-  justify-content: space-between;
+  /* Sized to content now rather than a fixed strip: the active item carries an
+     expanding label, so the row's width depends on which page you are on. */
+  flex: 0 1 auto;
+  justify-content: flex-end;
   gap: var(--space-1);
   margin-left: auto;
+  min-width: 0;
 }
 
 .nav-item {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
+  gap: var(--space-1);
+  /* min-width, not width: the active item grows to fit its label. */
+  min-width: 30px;
   height: 30px;
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-sm);
   position: relative;
   isolation: isolate;
   color: var(--fg2);
   text-decoration: none;
   transition: color 120ms var(--ease);
+}
+
+/* The page you are on names itself, next to its own icon, instead of a separate
+   tag elsewhere in the window. Inactive items stay glyph-only, so the row reads
+   as one selected item among icons rather than a list of words. Collapsed with
+   max-width so it animates, and aria-hidden because .nav-item already carries a
+   full aria-label - otherwise the accessible name would read "automations
+   automations". */
+.nav-item-label {
+  max-width: 0;
+  overflow: hidden;
+  color: inherit;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  opacity: 0;
+  transition: max-width 160ms var(--ease), opacity 120ms var(--ease);
+}
+
+.nav-item--active .nav-item-label {
+  max-width: 9ch;
+  opacity: 1;
+}
+
+/* Truncate the label before the icons are pushed out of the rail. */
+@media (max-width: 900px) {
+  .nav-item--active .nav-item-label { max-width: 7ch; }
 }
 
 .nav-item:hover {

--- a/web/src/components/ProjectSidebar.vue
+++ b/web/src/components/ProjectSidebar.vue
@@ -65,7 +65,18 @@
             </svg>
                       <span class="nav-item-label" aria-hidden="true">automations</span>
           </router-link>
-          <router-link to="/settings" class="nav-item touch-hit" active-class="nav-item--active" title="settings" aria-label="settings">
+          <!-- mode, not active-class: every settings tab is its own route
+               (/settings/providers, /settings/models, ...) and none of them match
+               the /settings record, so active-class left this item inactive on
+               nearly every settings page - and with it the label collapsed. The
+               sibling links already key off mode for the same reason. -->
+          <router-link
+            to="/settings"
+            class="nav-item touch-hit"
+            :class="{ 'nav-item--active': mode === 'settings' }"
+            title="settings"
+            aria-label="settings"
+          >
             <!-- Sliders / equalizer: more direct than a gear, mono-grid friendly -->
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
                  stroke-width="2" stroke-linecap="square" stroke-linejoin="miter" aria-hidden="true">
@@ -100,7 +111,11 @@
           @click="selectAutomationWorkspace(workspace.name)"
         >
           <span v-if="workspaceShortcut(workspace.name)" class="workspace-shortcut" aria-hidden="true">{{ workspaceShortcut(workspace.name) }}</span>
-          {{ workspaceLabel(workspace.name) }}
+          <!-- Wrapped, not a bare text node: the buttons are nowrap so a long
+               workspace name needs a shrinkable element to ellipse inside, or it
+               overflows into its neighbour. The button's title carries the full
+               name. -->
+          <span class="workspace-name">{{ workspaceLabel(workspace.name) }}</span>
           <span
             v-if="missedCountFor(workspace.name) > 0"
             class="badge badge--missed"

--- a/web/src/components/ProjectSidebar.vue
+++ b/web/src/components/ProjectSidebar.vue
@@ -1740,6 +1740,17 @@ async function confirmDeleteChat(chatId: string) {
 }
 .project-name:hover { color: var(--fg); }
 
+/* The project header is a text button, not a flex row, so the state marks sit
+   flush against the last letter of the name. Space them the same 6px .badge
+   already gives itself, and align them to the text rather than the baseline.
+   Scoped here on purpose: the workspace pill puts the same marks in a flex row
+   with a gap, where a margin would double up. */
+.project-name .rollup-needs-dot,
+.project-name .rollup-ring {
+  margin-left: var(--space-2);
+  vertical-align: middle;
+}
+
 .edit-input {
   flex: 1;
   font-size: var(--text-sm);

--- a/web/src/components/ProjectSidebar.vue
+++ b/web/src/components/ProjectSidebar.vue
@@ -1391,7 +1391,9 @@ async function confirmDeleteChat(chatId: string) {
      expanding label, so the row's width depends on which page you are on. */
   flex: 0 1 auto;
   justify-content: flex-end;
-  gap: var(--space-1);
+  /* Wider than the old icon-only 4px: the active item now ends in text, and a
+     4px gap between a word and the next glyph reads as a collision. */
+  gap: var(--space-2);
   margin-left: auto;
   min-width: 0;
 }
@@ -1433,13 +1435,17 @@ async function confirmDeleteChat(chatId: string) {
 }
 
 .nav-item--active .nav-item-label {
-  max-width: 9ch;
+  /* Room for the longest label ("automations", 11 characters) plus a little, so
+     it is never clipped mid-word. At 9ch it read as "automatio" hard against the
+     next glyph. */
+  max-width: 12ch;
   opacity: 1;
 }
 
-/* Truncate the label before the icons are pushed out of the rail. */
+/* Below this the rail cannot hold a full label and every glyph at once, so trade
+   the label away rather than the icons. */
 @media (max-width: 900px) {
-  .nav-item--active .nav-item-label { max-width: 7ch; }
+  .nav-item--active .nav-item-label { max-width: 0; opacity: 0; }
 }
 
 .nav-item:hover {

--- a/web/src/components/ProjectSidebar.vue
+++ b/web/src/components/ProjectSidebar.vue
@@ -1598,7 +1598,7 @@ async function confirmDeleteChat(chatId: string) {
   align-items: center;
   justify-content: center;
   gap: 6px;
-  overflow-wrap: anywhere;
+  white-space: nowrap;
   transition: background 120ms var(--ease), border-color 120ms var(--ease), color 120ms var(--ease);
 }
 
@@ -1884,11 +1884,14 @@ async function confirmDeleteChat(chatId: string) {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .workspace-status-core,
-  .rollup-ring-core { animation: none; opacity: 0.65; }
+  .rollup-ring,
+  .workspace-status-ring { animation: none; }
+  .rollup-ring::before,
+  .workspace-status-ring::before { animation: none; opacity: 0.3; }
 }
 
 /* Shimmer placeholder shown in the sidebar while the server auto-titles

--- a/web/src/components/ProjectView.vue
+++ b/web/src/components/ProjectView.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="project" class="project-view">
-    <PaneHeader @open-sidebar="emit('open-sidebar')">
+    <PaneHeader page-tag="project" @open-sidebar="emit('open-sidebar')">
       <template #title>
         <div class="header-left">
           <button class="close-btn desktop-only" @click="$emit('close')" title="Close">&times;</button>

--- a/web/src/components/SchedulePanel.vue
+++ b/web/src/components/SchedulePanel.vue
@@ -2,10 +2,10 @@
   <div class="schedule-panel">
     <PaneHeader
       v-if="!schedule && !loop && !showNew"
-      title="automations"
+      page-tag="automations"
       @open-sidebar="emit('open-sidebar')"
     />
-    <PaneHeader v-else @open-sidebar="emit('open-sidebar')">
+    <PaneHeader v-else page-tag="automations" @open-sidebar="emit('open-sidebar')">
       <template #title>
         <div class="header-left">
           <button class="close-btn desktop-only" @click="closeSchedule" title="Close">&times;</button>

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="settings-pane">
-    <PaneHeader title="settings" @open-sidebar="emit('open-sidebar')" />
+    <PaneHeader page-tag="settings" @open-sidebar="emit('open-sidebar')" />
     <div class="pane-body">
 
       <!-- HOME TAB -->

--- a/web/src/components/__tests__/ChatLayout.test.ts
+++ b/web/src/components/__tests__/ChatLayout.test.ts
@@ -768,6 +768,25 @@ describe('ChatLayout home arrow navigation', () => {
     wrapper.unmount()
   })
 
+  // The global "+ personal chat / + work chat" pair used to stay on screen at
+  // narrow widths, where it duplicated each lane's own "+ new" and spent a
+  // saturated fill on a non-blocking action.
+  it('drops the global new-chat buttons once any chat exists', async () => {
+    const wrapper = await mountHome()
+    expect(wrapper.find('.empty-actions').exists()).toBe(false)
+    expect(wrapper.findAll('.home-lane-new').length).toBeGreaterThan(0)
+    wrapper.unmount()
+  })
+
+  it('keeps every lane expanded, with no peek row to collapse into', async () => {
+    const wrapper = await mountHome()
+    expect(wrapper.find('.home-lane-peek').exists()).toBe(false)
+    for (const lane of wrapper.findAll('.home-lane')) {
+      expect(lane.find('.home-lane-body').exists()).toBe(true)
+    }
+    wrapper.unmount()
+  })
+
   it('moves focus across lanes from a window keydown', async () => {
     const wrapper = await mountHome()
     const cards = wrapper.findAll('.home-chat-item')

--- a/web/src/components/__tests__/ChatLayout.test.ts
+++ b/web/src/components/__tests__/ChatLayout.test.ts
@@ -885,6 +885,60 @@ describe('ChatLayout home arrow navigation', () => {
     wrapper.unmount()
   })
 
+  // Reported in review: activeChatId stays populated when Settings is opened
+  // from a chat, so a chat-first Esc ran closeChat() on a chat that was not on
+  // screen - disconnecting it, and deleting it outright when it was an unused
+  // draft with an unsent composer message.
+  it('leaves a retained hidden chat alone when escaping Settings', async () => {
+    window.__CIAOBOT_DESKTOP__ = undefined
+    const wrapper = await mountHome()
+    const store = useProjectStore()
+    store.activeChatId = 'chat-1'
+    await router.push('/settings')
+    await flushPromises()
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await flushPromises()
+
+    expect(router.currentRoute.value.path).toBe('/')
+    expect(store.activeChatId).toBe('chat-1')
+    wrapper.unmount()
+  })
+
+  it('does the same escaping Automations', async () => {
+    window.__CIAOBOT_DESKTOP__ = undefined
+    const wrapper = await mountHome()
+    const store = useProjectStore()
+    store.activeChatId = 'chat-1'
+    await router.push('/schedules')
+    await flushPromises()
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await flushPromises()
+
+    expect(router.currentRoute.value.path).toBe('/')
+    expect(store.activeChatId).toBe('chat-1')
+    wrapper.unmount()
+  })
+
+  // A popover that handled Escape itself must not also navigate away.
+  it('defers to a nested control that consumed Escape', async () => {
+    window.__CIAOBOT_DESKTOP__ = undefined
+    const wrapper = await mountHome()
+    const store = useProjectStore()
+    store.activeChatId = null
+    await router.push('/settings')
+    await flushPromises()
+
+    const event = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+    event.preventDefault()
+    window.dispatchEvent(event)
+    await flushPromises()
+
+    expect(router.currentRoute.value.path).toBe('/settings')
+    wrapper.unmount()
+  })
+
   it('closes the chat with Esc on a project route too', async () => {
     // viewMode is 'project' on /project/:projectId, but it is the same layout
     // with the same open chat. Gating the shortcut on viewMode === 'chat' made

--- a/web/src/components/__tests__/ChatLayout.test.ts
+++ b/web/src/components/__tests__/ChatLayout.test.ts
@@ -698,13 +698,18 @@ describe('ChatLayout home arrow navigation', () => {
     vi.restoreAllMocks()
   })
 
+  // Hoisted so the Esc tests below can assert where navigation ended up.
+  let router: ReturnType<typeof createRouter>
+
   async function mountHome(startPath = '/') {
     Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1180 })
-    const router = createRouter({
+    router = createRouter({
       history: createMemoryHistory(),
       routes: [
         { path: '/', component: EmptyStub },
         { path: '/project/:projectId', component: EmptyStub },
+        { path: '/settings', component: EmptyStub },
+        { path: '/schedules', component: EmptyStub },
       ],
     })
     await router.push(startPath)
@@ -824,6 +829,39 @@ describe('ChatLayout home arrow navigation', () => {
     window.dispatchEvent(new KeyboardEvent('keydown', { key: '2', bubbles: true }))
     await flushPromises()
     expect(store.activeWorkspace).toBe('work')
+    wrapper.unmount()
+  })
+
+  // Esc used to do nothing at all on settings and automations, because those
+  // views are excluded from shortcutsActive. It is the universal way back.
+  it('returns to home on Esc from a full-screen view', async () => {
+    window.__CIAOBOT_DESKTOP__ = undefined
+    const wrapper = await mountHome()
+    const store = useProjectStore()
+    store.activeChatId = null
+    await router.push('/settings')
+    await flushPromises()
+    expect(router.currentRoute.value.path).toBe('/settings')
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await flushPromises()
+
+    expect(router.currentRoute.value.path).toBe('/')
+    wrapper.unmount()
+  })
+
+  it('leaves Esc alone when already on home with no chat open', async () => {
+    window.__CIAOBOT_DESKTOP__ = undefined
+    const wrapper = await mountHome()
+    const store = useProjectStore()
+    store.activeChatId = null
+    await router.push('/')
+    await flushPromises()
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await flushPromises()
+
+    expect(router.currentRoute.value.path).toBe('/')
     wrapper.unmount()
   })
 

--- a/web/src/components/__tests__/ChatPanelDock.test.ts
+++ b/web/src/components/__tests__/ChatPanelDock.test.ts
@@ -310,13 +310,18 @@ describe('ChatPanel workspace breadcrumb', () => {
   })
   afterEach(() => vi.restoreAllMocks())
 
-  it('names the workspace with its number key and hue', async () => {
+  // The number badge is gone: it existed to teach the 1-9 shortcut, and it does
+  // that on the home lanes and the sidebar pills where pressing the key visibly
+  // does something. In a chat header there is nothing to switch, so it read as a
+  // number with no referent. The shortcut survives in the tooltip.
+  it('names the workspace and hues it, without a number badge', async () => {
     const { wrapper } = await mountPanel()
     const crumb = wrapper.find('.breadcrumb-workspace')
     expect(crumb.exists()).toBe(true)
-    expect(crumb.text()).toContain('personal')
+    expect(crumb.text()).toBe('personal')
     expect(crumb.attributes('data-workspace-color')).toBe('emerald')
-    expect(wrapper.find('.breadcrumb-key').text()).toBe('1')
+    expect(wrapper.find('.breadcrumb-key').exists()).toBe(false)
+    expect(crumb.attributes('title')).toContain('press 1')
     wrapper.unmount()
   })
 })

--- a/web/src/components/__tests__/ChatSignals.test.ts
+++ b/web/src/components/__tests__/ChatSignals.test.ts
@@ -36,18 +36,30 @@ describe('ChatSignals', () => {
     expect(wrapper.find('.chat-signal--needs').attributes('aria-label')).toBe('Needs your answer')
   })
 
-  it('renders the working ring and background-agent count', () => {
+  // Working is the transcript's own activity pulse now, with no text label: the
+  // tier heading and sidebar context already say "working", so the chip was
+  // saying it twice. The accessible name still carries it.
+  it('renders the working pulse without a redundant label', () => {
     const { store } = seed()
     store.projectStreaming = { 'chat-1': true }
     const working = mount(ChatSignals, { props: { chatId: 'chat-1', density: 'card' } })
     expect(working.find('.chat-signal--working').exists()).toBe(true)
-    expect(working.text()).toContain('working')
+    expect(working.find('.chat-signal--working .activity-spinner').exists()).toBe(true)
+    expect(working.text()).toBe('')
+    expect(working.find('.chat-signal--working').attributes('aria-label')).toBe('Working')
+  })
 
-    store.projectStreaming = {}
+  it('shows a count only when more than one agent is running', () => {
+    const { store } = seed()
     store.backgroundAgents = { 'chat-1': 3 }
-    const agents = mount(ChatSignals, { props: { chatId: 'chat-1', density: 'card' } })
-    expect(agents.find('.chat-signal--agents').exists()).toBe(true)
-    expect(agents.text()).toContain('3 agents')
+    const many = mount(ChatSignals, { props: { chatId: 'chat-1', density: 'card' } })
+    expect(many.find('.chat-signal--agents').exists()).toBe(true)
+    expect(many.find('.chat-signal-count').text()).toBe('3')
+    expect(many.find('.chat-signal--agents').attributes('aria-label')).toContain('3 background agents')
+
+    store.backgroundAgents = { 'chat-1': 1 }
+    const one = mount(ChatSignals, { props: { chatId: 'chat-1', density: 'card' } })
+    expect(one.find('.chat-signal-count').exists()).toBe(false)
   })
 
   it('renders loop and retry modifiers with their accessible labels', () => {
@@ -79,10 +91,11 @@ describe('ChatSignals', () => {
     expect(wrapper.find('.chat-signal--needs').classes()).toContain('chat-signal--needs')
   })
 
-  it('exposes a reduced-motion hook on the pulsing core', () => {
+  it('exposes a reduced-motion hook on the pulse', () => {
     const { store } = seed()
     store.projectStreaming = { 'chat-1': true }
     const wrapper = mount(ChatSignals, { props: { chatId: 'chat-1' } })
-    expect(wrapper.find('.chat-signal-core--pulse').exists()).toBe(true)
+    // .activity-spinner is the element the prefers-reduced-motion block targets.
+    expect(wrapper.find('.activity-spinner').exists()).toBe(true)
   })
 })

--- a/web/src/components/__tests__/HomeRecentChats.test.ts
+++ b/web/src/components/__tests__/HomeRecentChats.test.ts
@@ -78,17 +78,38 @@ describe('HomeRecentChats lanes and tiers', () => {
     expect(wrapper.find('.home-chat-question').text()).toContain('Which launch date')
     expect(wrapper.find('.home-tier--working .home-chat-title').text()).toBe('Background work')
     expect(wrapper.find('.home-tier--quiet .home-chat-title').text()).toBe('A quiet chat')
-    expect(wrapper.find('.home-lane-older-toggle').text()).toContain('older than a week')
-    expect(wrapper.findAll('.home-chat-item')).toHaveLength(3)
+    // Older chats are listed in quiet now, not split behind a disclosure, so
+    // every seeded chat renders as a row.
+    expect(wrapper.find('.home-lane-older-toggle').exists()).toBe(false)
+    expect(wrapper.findAll('.home-chat-item')).toHaveLength(4)
   })
 
-  it('reports an empty needs-you tier and keeps zero-chat workspaces visible', async () => {
+  it('lists older chats inline with quiet instead of behind a disclosure', async () => {
+    const wrapper = await mountHome()
+    const quietTitles = wrapper.findAll('.home-tier--quiet .home-chat-title').map(n => n.text())
+    expect(quietTitles).toContain('A quiet chat')
+    expect(quietTitles).toContain('An older chat')
+    expect(wrapper.find('.home-tier--older').exists()).toBe(false)
+  })
+
+  it('hides the needs-you tier entirely when nothing needs the user', async () => {
     const store = seedChats()
     store.chats = store.chats.filter(chat => chat.chat_id !== 'needs')
     const { default: HomeRecentChats } = await import('../HomeRecentChats.vue')
     const wrapper = mount(HomeRecentChats)
-    expect(wrapper.findAll('.home-tier--needsYou')).toHaveLength(2)
-    expect(wrapper.findAll('.home-tier--needsYou')[1].text()).toContain('// nothing needs you here')
+    // Previously rendered an empty tier plus "// nothing needs you here" in
+    // every lane, which meant the loudest label on screen was usually a
+    // statement that there was nothing to do.
+    expect(wrapper.findAll('.home-tier--needsYou')).toHaveLength(0)
+    expect(wrapper.text()).not.toContain('nothing needs you here')
+  })
+
+  it('keeps tier labels lowercase', async () => {
+    const wrapper = await mountHome()
+    const labels = wrapper.findAll('.home-tier-label').map(n => n.text())
+    expect(labels).toContain('needs you')
+    expect(labels).toContain('working')
+    expect(labels.some(l => l === l.toUpperCase() && /[A-Z]/.test(l))).toBe(false)
   })
 
   it('keeps vertical motion within a lane and horizontal motion across lanes', async () => {
@@ -119,10 +140,9 @@ describe('HomeRecentChats lanes and tiers', () => {
     expect(emptyVm.onArrow('ArrowDown')).toBe(false)
   })
 
-  it('makes quiet rows and the older disclosure focusable buttons', async () => {
+  it('makes quiet rows focusable buttons', async () => {
     const wrapper = await mountHome()
     expect(wrapper.find('.home-tier--quiet .home-chat-item').element.tagName).toBe('BUTTON')
-    expect(wrapper.find('.home-lane-older-toggle').element.tagName).toBe('BUTTON')
   })
 })
 

--- a/web/src/components/__tests__/HomeRecentChats.test.ts
+++ b/web/src/components/__tests__/HomeRecentChats.test.ts
@@ -27,19 +27,19 @@ function seedChats(includeChats = true) {
     {
       chat_id: 'needs', project_id: 'personal-project', title: 'Needs an answer',
       pending_question: JSON.stringify({ questions: [{ question: 'Which launch date should we use?' }] }),
-      created_at: timestamp(60 * 60), last_activity_at: timestamp(60 * 60), archived: false, local: true,
+      created_at: timestamp(60 * 60), last_activity_at: timestamp(60 * 60), last_read_at: timestamp(60 * 60), archived: false, local: true,
     },
     {
       chat_id: 'working', project_id: 'work-project', title: 'Background work',
-      created_at: timestamp(2 * 60 * 60), last_activity_at: timestamp(2 * 60 * 60), archived: false, local: true,
+      created_at: timestamp(2 * 60 * 60), last_activity_at: timestamp(2 * 60 * 60), last_read_at: timestamp(2 * 60 * 60), archived: false, local: true,
     },
     {
       chat_id: 'quiet', project_id: 'personal-project', title: 'A quiet chat',
-      created_at: timestamp(2 * 24 * 60 * 60), last_activity_at: timestamp(2 * 24 * 60 * 60), archived: false, local: true,
+      created_at: timestamp(2 * 24 * 60 * 60), last_activity_at: timestamp(2 * 24 * 60 * 60), last_read_at: timestamp(2 * 24 * 60 * 60), archived: false, local: true,
     },
     {
       chat_id: 'older', project_id: 'work-project', title: 'An older chat',
-      created_at: timestamp(8 * 24 * 60 * 60), last_activity_at: timestamp(8 * 24 * 60 * 60), archived: false, local: true,
+      created_at: timestamp(8 * 24 * 60 * 60), last_activity_at: timestamp(8 * 24 * 60 * 60), last_read_at: timestamp(8 * 24 * 60 * 60), archived: false, local: true,
     },
   ] as unknown as typeof store.chats : [] as unknown as typeof store.chats
   store.activeWorkspace = 'personal'
@@ -194,7 +194,7 @@ describe('HomeRecentChats regressions', () => {
         chat_id: 'delegate', project_id: 'personal-project', title: 'Internal delegate',
         spawned_from_chat_id: 'quiet',
         pending_question: JSON.stringify({ questions: [{ question: 'Internal?' }] }),
-        created_at: timestamp(30), last_activity_at: timestamp(30), archived: false, local: true,
+        created_at: timestamp(30), last_activity_at: timestamp(30), last_read_at: timestamp(30), archived: false, local: true,
       },
     ] as unknown as typeof store.chats
     const taskStore = useTaskStore()

--- a/web/src/components/__tests__/PaneHeaderBrand.test.ts
+++ b/web/src/components/__tests__/PaneHeaderBrand.test.ts
@@ -1,0 +1,231 @@
+// @vitest-environment jsdom
+
+/**
+ * The pane header carries the brand mark and the page tag.
+ *
+ * The brand was moved out of the sidebar into the middle of this header, so what
+ * these tests protect is (a) the reload behaviour survived the move intact, and
+ * (b) the structure that makes the mark genuinely centred: the mark lives in its
+ * own grid column, a sibling of the title, so no title length can move it.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import { flushPromises, mount } from '@vue/test-utils'
+import { defineComponent, h, nextTick } from 'vue'
+import { useProjectStore } from '../../stores/projects'
+import { useTaskStore } from '../../stores/tasks'
+import BrandMark from '../BrandMark.vue'
+import PaneHeader from '../PaneHeader.vue'
+
+// The bell reaches for stores and a teleport target; neither is what is under
+// test here, and PaneHeader imports it directly so `stubs` cannot reach it.
+vi.mock('../NotificationBell.vue', () => ({
+  default: defineComponent({ name: 'NotificationBell', setup: () => () => h('div', { class: 'bell-stub' }) }),
+}))
+
+const LONG_TITLE = 'A chat title long enough to need every pixel of the header and then a great many more '.repeat(3)
+
+describe('BrandMark', () => {
+  const originalLocation = Object.getOwnPropertyDescriptor(window, 'location')
+  let replace: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    replace = vi.fn()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { href: 'http://localhost/chat/abc', replace },
+    })
+    // Reduced motion, so the pixel-jitter interval never starts and the test
+    // does not depend on a timer.
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true }) as unknown as typeof window.matchMedia
+  })
+
+  afterEach(() => {
+    if (originalLocation) Object.defineProperty(window, 'location', originalLocation)
+    vi.restoreAllMocks()
+  })
+
+  it('renders the wordmark', () => {
+    const wrapper = mount(BrandMark)
+    expect(wrapper.find('.brand-label').text()).toBe('ciaobot')
+    expect(wrapper.attributes('title')).toBe('Click to reload the latest app build')
+    expect(wrapper.attributes('aria-busy')).toBe('false')
+    wrapper.unmount()
+  })
+
+  it('reloads the latest build with a cache-busting query when clicked', async () => {
+    const wrapper = mount(BrandMark)
+    await wrapper.trigger('click')
+    await flushPromises()
+
+    expect(replace).toHaveBeenCalledTimes(1)
+    const target = new URL(replace.mock.calls[0][0] as string)
+    expect(target.pathname).toBe('/chat/abc')
+    expect(target.searchParams.get('_r')).toMatch(/^\d+$/)
+    wrapper.unmount()
+  })
+
+  it('reports the reload as busy and refuses a second click', async () => {
+    const wrapper = mount(BrandMark)
+    await wrapper.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.attributes('aria-busy')).toBe('true')
+    expect(wrapper.classes()).toContain('brand--refreshing')
+    expect(wrapper.attributes('title')).toBe('Reloading...')
+
+    await wrapper.trigger('click')
+    await flushPromises()
+    expect(replace).toHaveBeenCalledTimes(1)
+    wrapper.unmount()
+  })
+})
+
+describe('PaneHeader brand and page tag', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('puts the brand in its own column, outside the title', () => {
+    const wrapper = mount(PaneHeader, { props: { pageTag: 'home' } })
+
+    const centre = wrapper.get('.header-center')
+    expect(centre.find('.brand').exists()).toBe(true)
+    // Sibling of the title, not inside it: this is what makes the centring hold.
+    expect(wrapper.find('.header-title .brand').exists()).toBe(false)
+    expect(centre.element.parentElement).toBe(wrapper.get('.pane-header').element)
+    wrapper.unmount()
+  })
+
+  it('keeps the brand in the middle column when the title is very long', () => {
+    const wrapper = mount(PaneHeader, {
+      props: { pageTag: 'project' },
+      slots: { title: `<span class="pane-title">${LONG_TITLE}</span>` },
+      global: { stubs: { transition: false } },
+    })
+
+    // The long title is present, and the header still reads title | centre | trail
+    // in that order, with the brand in the centre column and nowhere else.
+    expect(wrapper.get('.pane-title').text().length).toBeGreaterThan(200)
+    const columns = Array.from(wrapper.get('.pane-header').element.children)
+      .map(el => el.className)
+      .filter(name => !name.includes('header-hamburger'))
+    expect(columns).toEqual(['header-title', 'header-center', 'header-trail'])
+    expect(wrapper.findAll('.brand')).toHaveLength(1)
+    expect(wrapper.get('.header-center').find('.brand').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('renders the page tag it is given, and nothing when given none', () => {
+    const tagged = mount(PaneHeader, { props: { pageTag: 'automations' } })
+    expect(tagged.get('.page-tag').text()).toBe('automations')
+    tagged.unmount()
+
+    const untagged = mount(PaneHeader)
+    expect(untagged.find('.page-tag').exists()).toBe(false)
+    expect(untagged.find('.brand').exists()).toBe(true)
+    untagged.unmount()
+  })
+
+  it('makes the tag the pane heading only when no title names the page', () => {
+    const bare = mount(PaneHeader, { props: { pageTag: 'settings' } })
+    expect(bare.get('.page-tag').element.tagName).toBe('H2')
+    expect(bare.find('.header-title').exists()).toBe(false)
+    bare.unmount()
+
+    const titled = mount(PaneHeader, {
+      props: { pageTag: 'project' },
+      slots: { title: '<h2 class="project-title">Wedding</h2>' },
+    })
+    expect(titled.get('.page-tag').element.tagName).toBe('SPAN')
+    expect(titled.findAll('h2')).toHaveLength(1)
+    titled.unmount()
+  })
+
+  it('drops the brand where a second mark would duplicate the main pane', () => {
+    const wrapper = mount(PaneHeader, { props: { brand: false } })
+    expect(wrapper.find('.brand').exists()).toBe(false)
+    expect(wrapper.find('.header-center').exists()).toBe(true)
+    wrapper.unmount()
+  })
+})
+
+describe('page tag per view', () => {
+  const seen: { pageTag: string; brand: boolean }[] = []
+
+  const RecordingPaneHeader = defineComponent({
+    name: 'PaneHeader',
+    props: {
+      pageTag: { type: String, default: '' },
+      brand: { type: Boolean, default: true },
+    },
+    setup(props) {
+      seen.push({ pageTag: props.pageTag, brand: props.brand })
+      return () => h('div', { class: 'pane-header-stub' })
+    },
+  })
+
+  const EmptyStub = defineComponent({ name: 'EmptyStub', setup: () => () => h('div') })
+
+  class MemoryStorage {
+    private values = new Map<string, string>()
+    getItem(key: string): string | null { return this.values.get(key) ?? null }
+    setItem(key: string, value: string): void { this.values.set(key, value) }
+    removeItem(key: string): void { this.values.delete(key) }
+    clear(): void { this.values.clear() }
+  }
+
+  beforeEach(() => {
+    seen.length = 0
+    setActivePinia(createPinia())
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1200 })
+    Object.defineProperty(globalThis, 'localStorage', { configurable: true, value: new MemoryStorage() })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('tags the home screen "home" and gives it no separate title', async () => {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: '/', component: EmptyStub }],
+    })
+    await router.push('/')
+    await router.isReady()
+
+    const store = useProjectStore()
+    store.bootstrapped = true
+    store.activeChatId = null
+    vi.spyOn(store, 'fetchAll').mockResolvedValue()
+
+    const taskStore = useTaskStore()
+    vi.spyOn(taskStore, 'fetchSchedules').mockResolvedValue()
+    vi.spyOn(taskStore, 'fetchLoops').mockResolvedValue()
+
+    const { default: ChatLayout } = await import('../ChatLayout.vue')
+    const wrapper = mount(ChatLayout, {
+      global: {
+        plugins: [router],
+        stubs: {
+          ChatPanel: EmptyStub,
+          ProjectSidebar: EmptyStub,
+          ProjectView: EmptyStub,
+          SchedulePanel: EmptyStub,
+          SettingsView: EmptyStub,
+          FileViewerModal: EmptyStub,
+          PinnedFilePanel: EmptyStub,
+          HomeRecentChats: EmptyStub,
+          PaneHeader: RecordingPaneHeader,
+        },
+      },
+    })
+    await flushPromises()
+    await nextTick()
+
+    expect(seen).toEqual([{ pageTag: 'home', brand: true }])
+    wrapper.unmount()
+  })
+})

--- a/web/src/components/__tests__/homeRenderShape.test.ts
+++ b/web/src/components/__tests__/homeRenderShape.test.ts
@@ -38,16 +38,16 @@ function seed(withNeedsYou: boolean) {
       ? [{
           chat_id: 'needs', project_id: 'p1', title: 'Needs an answer',
           pending_question: JSON.stringify({ questions: [{ question: 'Which date?' }] }),
-          created_at: timestamp(60), last_activity_at: timestamp(60), archived: false, local: true,
+          created_at: timestamp(60), last_activity_at: timestamp(60), last_read_at: timestamp(60), archived: false, local: true,
         }]
       : []),
     {
       chat_id: 'quiet', project_id: 'p1', title: 'A quiet chat',
-      created_at: timestamp(2 * 86400), last_activity_at: timestamp(2 * 86400), archived: false, local: true,
+      created_at: timestamp(2 * 86400), last_activity_at: timestamp(2 * 86400), last_read_at: timestamp(2 * 86400), archived: false, local: true,
     },
     {
       chat_id: 'old', project_id: 'p1', title: 'A three week old chat',
-      created_at: timestamp(21 * 86400), last_activity_at: timestamp(21 * 86400), archived: false, local: true,
+      created_at: timestamp(21 * 86400), last_activity_at: timestamp(21 * 86400), last_read_at: timestamp(21 * 86400), archived: false, local: true,
     },
   ] as unknown as typeof store.chats
   store.activeWorkspace = 'personal'
@@ -93,5 +93,30 @@ describe('home lane rendered shape', () => {
     expect(await render(false)).toEqual([
       'quiet: A quiet chat | A three week old chat',
     ])
+  })
+
+  // Reported from live use: a chat with an unread message was being listed
+  // under "quiet" while the sidebar showed an unread badge for it and the bell
+  // showed a count. The heading contradicted the rest of the screen.
+  it('does not call an unread chat quiet', async () => {
+    const store = seed(false)
+    // Same shape the server leaves behind: activity newer than the last read.
+    store.chats[0].last_read_at = new Date(Date.parse(store.chats[0].last_activity_at!) - 1000).toISOString()
+    const taskStore = useTaskStore()
+    taskStore.loops = [] as unknown as typeof taskStore.loops
+    const { default: HomeRecentChats } = await import('../HomeRecentChats.vue')
+    const wrapper = mount(HomeRecentChats)
+    await nextTick()
+
+    const tiers = wrapper.findAll('.home-tier').map(tier => ({
+      label: tier.find('.home-tier-label').text(),
+      rows: tier.findAll('.home-chat-title').map(t => t.text()),
+    }))
+    const unread = tiers.find(t => t.label === 'unread')
+    const quiet = tiers.find(t => t.label === 'quiet')
+
+    expect(unread?.rows).toContain('A quiet chat')
+    expect(quiet?.rows ?? []).not.toContain('A quiet chat')
+    wrapper.unmount()
   })
 })

--- a/web/src/components/__tests__/homeRenderShape.test.ts
+++ b/web/src/components/__tests__/homeRenderShape.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+/**
+ * Renders the home lanes and asserts the *shape* of what a user sees, as a
+ * readable snapshot of the reviewed feedback:
+ *
+ *   - older chats listed inline with quiet, no separate section or disclosure
+ *   - the needs-you tier absent entirely when nothing needs the user
+ *   - tier labels lowercase
+ *
+ * The per-behaviour assertions live in HomeRecentChats.test.ts; this exists so a
+ * regression shows up as a diff of the visible text rather than a failed
+ * selector, which is much faster to read.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import { useProjectStore } from '../../stores/projects'
+import { useTaskStore } from '../../stores/tasks'
+
+function timestamp(secondsAgo: number): string {
+  return new Date(Date.now() - secondsAgo * 1000).toISOString()
+}
+
+function seed(withNeedsYou: boolean) {
+  const store = useProjectStore()
+  store.workspaces = [
+    { name: 'personal', vault_root: '', default_provider: 'claude', default_model: '', gws_profile: '', model_bucket: '', color: 'emerald' },
+  ] as unknown as typeof store.workspaces
+  store.projects = [
+    { project_id: 'p1', name: 'Wedding', workspace: 'personal' },
+    { project_id: 'general', name: 'General', workspace: 'personal' },
+  ] as unknown as typeof store.projects
+  store.chats = [
+    ...(withNeedsYou
+      ? [{
+          chat_id: 'needs', project_id: 'p1', title: 'Needs an answer',
+          pending_question: JSON.stringify({ questions: [{ question: 'Which date?' }] }),
+          created_at: timestamp(60), last_activity_at: timestamp(60), archived: false, local: true,
+        }]
+      : []),
+    {
+      chat_id: 'quiet', project_id: 'p1', title: 'A quiet chat',
+      created_at: timestamp(2 * 86400), last_activity_at: timestamp(2 * 86400), archived: false, local: true,
+    },
+    {
+      chat_id: 'old', project_id: 'p1', title: 'A three week old chat',
+      created_at: timestamp(21 * 86400), last_activity_at: timestamp(21 * 86400), archived: false, local: true,
+    },
+  ] as unknown as typeof store.chats
+  store.activeWorkspace = 'personal'
+  store.bootstrapped = true
+  store.projectStreaming = {}
+  store.backgroundAgents = {}
+  return store
+}
+
+async function render(withNeedsYou: boolean): Promise<string[]> {
+  seed(withNeedsYou)
+  const taskStore = useTaskStore()
+  taskStore.loops = [] as unknown as typeof taskStore.loops
+  const { default: HomeRecentChats } = await import('../HomeRecentChats.vue')
+  const wrapper = mount(HomeRecentChats)
+  await nextTick()
+  const lines = [
+    ...wrapper.findAll('.home-tier').map(tier => {
+      const label = tier.find('.home-tier-label').text()
+      const rows = tier.findAll('.home-chat-title').map(t => t.text())
+      return `${label}: ${rows.join(' | ')}`
+    }),
+  ]
+  wrapper.unmount()
+  return lines
+}
+
+describe('home lane rendered shape', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.restoreAllMocks()
+    if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => {}
+  })
+
+  it('lists a three-week-old chat in quiet, with no older section', async () => {
+    expect(await render(true)).toEqual([
+      'needs you: Needs an answer',
+      'quiet: A quiet chat | A three week old chat',
+    ])
+  })
+
+  it('omits the needs-you tier when nothing needs the user', async () => {
+    expect(await render(false)).toEqual([
+      'quiet: A quiet chat | A three week old chat',
+    ])
+  })
+})

--- a/web/src/lib/__tests__/homeLanes.test.ts
+++ b/web/src/lib/__tests__/homeLanes.test.ts
@@ -35,12 +35,40 @@ describe('groupHomeTiers', () => {
       chats,
       id => id === 'needs' || id === 'needs-and-working',
       id => id === 'working' || id === 'needs-and-working',
+      () => false,
       now,
     )
 
     expect(tiers.needsYou.map(c => c.chat_id)).toEqual(['needs', 'needs-and-working'])
     expect(tiers.working.map(c => c.chat_id)).toEqual(['working'])
+    expect(tiers.unread).toEqual([])
     expect(tiers.quiet.map(c => c.chat_id)).toEqual(['quiet'])
     expect(tiers.older.map(c => c.chat_id)).toEqual(['older'])
+  })
+
+  // An unread chat is not quiet. Calling it quiet made the tier heading
+  // contradict the unread badge the sidebar showed for the same chat.
+  it('puts unread between working and quiet, ahead of the age check', () => {
+    const chats = [
+      chat('fresh-unread', 60),
+      chat('stale-unread', 9 * 24 * 60 * 60),
+      chat('plain-quiet', 120),
+      chat('busy-and-unread', 30),
+    ]
+
+    const tiers = groupHomeTiers(
+      chats,
+      () => false,
+      id => id === 'busy-and-unread',
+      id => id !== 'plain-quiet',
+      now,
+    )
+
+    // Working still wins over unread for a chat that is both.
+    expect(tiers.working.map(c => c.chat_id)).toEqual(['busy-and-unread'])
+    // A stale unread chat is surfaced as unread, not buried in older.
+    expect(tiers.unread.map(c => c.chat_id)).toEqual(['fresh-unread', 'stale-unread'])
+    expect(tiers.quiet.map(c => c.chat_id)).toEqual(['plain-quiet'])
+    expect(tiers.older).toEqual([])
   })
 })

--- a/web/src/lib/homeLanes.ts
+++ b/web/src/lib/homeLanes.ts
@@ -1,10 +1,11 @@
 import type { ChatInfo } from './types'
 
-export type HomeTierKey = 'needsYou' | 'working' | 'quiet' | 'older'
+export type HomeTierKey = 'needsYou' | 'working' | 'unread' | 'quiet' | 'older'
 
 export interface HomeTiers {
   needsYou: ChatInfo[]
   working: ChatInfo[]
+  unread: ChatInfo[]
   quiet: ChatInfo[]
   older: ChatInfo[]
 }
@@ -26,14 +27,20 @@ export function ageBucket(iso: string, now: Date = new Date()): 'fresh' | 'week'
 /**
  * Assign each active chat to exactly one home tier. The callbacks are kept
  * outside the helper so the store remains the source of truth for state.
+ *
+ * `unread` sits between working and quiet on purpose: a chat that finished
+ * while you were away is worth reading but is not blocking you, and calling it
+ * "quiet" was simply untrue - the tier heading contradicted the unread badge
+ * the sidebar was showing for the same chat.
  */
 export function groupHomeTiers(
   chats: ChatInfo[],
   isNeedsYou: (chatId: string) => boolean,
   isWorking: (chatId: string) => boolean,
+  isUnread: (chatId: string) => boolean,
   now: Date = new Date(),
 ): HomeTiers {
-  const tiers: HomeTiers = { needsYou: [], working: [], quiet: [], older: [] }
+  const tiers: HomeTiers = { needsYou: [], working: [], unread: [], quiet: [], older: [] }
   const ordered = chats.slice().sort((a, b) =>
     chatActivityTimestamp(b).localeCompare(chatActivityTimestamp(a)),
   )
@@ -43,6 +50,11 @@ export function groupHomeTiers(
       tiers.needsYou.push(chat)
     } else if (isWorking(chat.chat_id)) {
       tiers.working.push(chat)
+    } else if (isUnread(chat.chat_id)) {
+      // Ahead of the age check: an unread chat is worth surfacing even if its
+      // last activity is old, which is exactly the case a stale-but-unread chat
+      // hits.
+      tiers.unread.push(chat)
     } else if (ageBucket(chatActivityTimestamp(chat), now) === 'older') {
       tiers.older.push(chat)
     } else {


### PR DESCRIPTION
Five issues found using the shipped lanes on desktop and phone.

- **Older chats no longer get their own tier.** They were behind a `N more, older than a week` disclosure; they now list inline with quiet. The age opacity ramp still dims them, so "old" stays legible without a section and a count you have to expand to read.
- **The needs-you tier is omitted when nothing needs you.** It used to render in every lane with `// nothing needs you here` beside it, which made the loudest label on the screen a statement that there was nothing to do.
- **Tier labels are lowercase.** `NEEDS YOU` shouted in caps while `working` and `quiet` did not. That was accidental: `.home-tier-label` set `text-transform: uppercase` and a `span:last-child` rule cancelled it — which only fired for tiers that had a second span. The override is gone and all labels are lowercase.
- **Lanes no longer collapse at narrow widths.** The peek row read as a stray element rather than a control, and it hid that workspace's `+ new` button, so on a phone there was no way to start a chat in a non-active workspace. Lanes stack and stay open at every width.
- **The global `+ personal chat` / `+ work chat` pair is back to the true empty state only.** With lanes always open it duplicated each lane's own `+ new`, and spent a saturated fill on a non-blocking action — which the design system reserves for "needs the user".

Removes the now-dead `laneSummary`, `activateLane`, `isLaneExpanded`, `olderExpanded` and `isNarrow`, and simplifies arrow navigation to a single selector since every lane is always fully rendered.

## Validation

Three existing tests asserted the old behaviour and were updated to the new expectation rather than worked around. Added coverage for each reported issue, plus `homeRenderShape.test.ts`, which asserts the visible tier and row text so a regression reads as a diff:

```
needs you: Needs an answer
quiet: A quiet chat | A three week old chat
```

and with nothing pending, just the quiet line.

Gates: **57 files / 514 tests** (file count cross-checked against 57 on disk), `vue-tsc` clean, lint clean.

Not verified without a browser: real focus rings, touch targets and 200% zoom on the stacked mobile layout.