### PR TITLE
fix(pwa): follow up home lane review fixes

### DIFF
--- a/web/src/components/ChatLayout.vue
+++ b/web/src/components/ChatLayout.vue
@@ -897,6 +897,10 @@ onBeforeUnmount(() => {
   min-width: 0;
   min-height: 0;
   overflow: hidden;
+  /* PaneHeader must respond to the space left after the resizable sidebar,
+     not only to the browser viewport width. */
+  container-type: inline-size;
+  container-name: chat-pane;
 }
 
 .empty-shell {

--- a/web/src/components/PaneHeader.vue
+++ b/web/src/components/PaneHeader.vue
@@ -106,6 +106,14 @@ const hasTitle = computed(() => !!slots.title)
   .header-center { display: none; }
 }
 
+/* A wide viewport can still leave this pane narrow when the sidebar has been
+   dragged near its maximum. The header's action trail is unshrinkable, so
+   hide the decorative brand/tag based on the pane width as well as the
+   viewport width. */
+@container chat-pane (max-width: 460px) {
+  .header-center { display: none; }
+}
+
 /* Very narrow viewports: drop the mark outright rather than clip it. The trail's
    controls cannot shrink, so something has to go, and the mark is the only thing
    here that is not an action. */

--- a/web/src/components/ProjectSidebar.vue
+++ b/web/src/components/ProjectSidebar.vue
@@ -1421,7 +1421,9 @@ async function confirmDeleteChat(chatId: string) {
   /* min-width, not width: the active item grows to fit its label. */
   min-width: 30px;
   height: 30px;
-  padding: 0 var(--space-1);
+  /* Keep the vertical padding supplied by .touch-hit: the visible 30px
+     control still needs the shared 44px touch target. */
+  padding-inline: var(--space-1);
   border-radius: var(--radius-sm);
   position: relative;
   isolation: isolate;
@@ -1585,7 +1587,7 @@ async function confirmDeleteChat(chatId: string) {
   height: 16px;
   padding: 0 3px;
   border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xs);
   color: var(--fg3);
   font-size: 10px;
   line-height: 1;
@@ -1671,7 +1673,7 @@ async function confirmDeleteChat(chatId: string) {
   height: 14px;
   padding: 0 5px;
   margin-left: 6px;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   background: var(--bg3);
   color: var(--fg2);
   font-size: calc(9px * var(--font-scale));


### PR DESCRIPTION
## Summary
- Preserve the shared 44px touch target for sidebar navigation items
- Use the documented extra-small radius token for compact sidebar chips
- Hide the decorative pane header brand when the resizable chat pane is narrow

## Context
PR #270 was merged before these final review fixes were pushed. This follow-up carries the remaining review findings into develop.

## Testing
- npm test (531 tests)
- npm run lint
- npm run build