### PR TITLE
feat(pwa): tabbed sections in the project view

### DIFF
--- a/ciao/web/static/index.html
+++ b/ciao/web/static/index.html
@@ -13,7 +13,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-180.png" />
     <title>Ciaobot</title>
-    <script type="module" crossorigin src="/assets/index-BJ9Cwqyr.js"></script>
+    <script type="module" crossorigin src="/assets/index-Djk0kvr2.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DninbV5Y.css">
   </head>
   <body>

--- a/ciao/web/static/index.html
+++ b/ciao/web/static/index.html
@@ -13,7 +13,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-180.png" />
     <title>Ciaobot</title>
-    <script type="module" crossorigin src="/assets/index-Djk0kvr2.js"></script>
+    <script type="module" crossorigin src="/assets/index-B30PkNKv.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DninbV5Y.css">
   </head>
   <body>

--- a/web/src/components/ProjectView.vue
+++ b/web/src/components/ProjectView.vue
@@ -350,11 +350,6 @@ const project = computed(() => store.projects.find(p => p.project_id === props.p
 
 type ProjectTab = 'overview' | 'loops' | 'schedules'
 const activeTab = ref<ProjectTab>('overview')
-const projectTabs = computed(() => [
-  { key: 'overview' as const, label: 'Overview' },
-  { key: 'loops' as const, label: 'Loops', count: projectLoops.value.length },
-  { key: 'schedules' as const, label: 'Schedules', count: projectSchedules.value.length },
-])
 
 watch(project, (p) => {
   if (p && p.workspace && p.workspace !== store.activeWorkspace) {
@@ -373,6 +368,11 @@ const projectSchedules = computed(() =>
       || (schedule.web_chat_id !== null && projectChatIds.value.has(schedule.web_chat_id)),
   ),
 )
+const projectTabs = computed(() => [
+  { key: 'overview' as const, label: 'Overview' },
+  { key: 'loops' as const, label: 'Loops', count: projectLoops.value.length },
+  { key: 'schedules' as const, label: 'Schedules', count: projectSchedules.value.length },
+])
 const activeChats = computed(() =>
   allChats.value
     // Hide remote chats (session lives on another device, not openable here).

--- a/web/src/components/ProjectView.vue
+++ b/web/src/components/ProjectView.vue
@@ -57,6 +57,24 @@
       <template v-if="archivedChats.length"> · {{ archivedChats.length }} archived</template>
     </p>
 
+    <nav class="project-tabs" aria-label="Project sections">
+      <button
+        v-for="tab in projectTabs"
+        :key="tab.key"
+        type="button"
+        class="project-tab"
+        :class="{ active: activeTab === tab.key }"
+        :aria-selected="activeTab === tab.key"
+        :data-tab="tab.key"
+        role="tab"
+        @click="activeTab = tab.key"
+      >
+        {{ tab.label }}
+        <span v-if="tab.count !== undefined" class="tab-count">{{ tab.count }}</span>
+      </button>
+    </nav>
+
+    <template v-if="activeTab === 'overview'">
     <section class="card">
       <div class="card-header">
         <h3>project context</h3>
@@ -227,6 +245,73 @@
         >Next</button>
       </div>
     </section>
+    </template>
+
+    <section v-else-if="activeTab === 'loops'" class="card automation-card">
+      <div class="card-header">
+        <div>
+          <h3>loops ({{ projectLoops.length }})</h3>
+          <p class="card-hint">Prompts that repeat inside a chat in this project.</p>
+        </div>
+      </div>
+      <div v-if="projectLoops.length" class="automation-list">
+        <button
+          v-for="loop in projectLoops"
+          :key="loop.loop_id"
+          type="button"
+          class="automation-row"
+          @click="openAutomation(loop.loop_id)"
+        >
+          <span class="automation-row-main">
+            <span class="automation-title">{{ loop.title || promptTitle(loop.prompt) }}</span>
+            <span class="automation-status" :class="{ running: loop.running }">
+              {{ loop.running ? 'running' : 'stopped' }}
+            </span>
+          </span>
+          <span class="automation-row-meta">
+            <span>every {{ loop.interval_minutes }} min</span>
+            <span class="dot">·</span>
+            <span>{{ loopTargetLabel(loop) }}</span>
+            <span class="dot">·</span>
+            <span>last {{ automationTimestamp(loop.last_run_at) }}</span>
+          </span>
+        </button>
+      </div>
+      <div v-else class="empty-row">// no loops send prompts into this project</div>
+    </section>
+
+    <section v-else-if="activeTab === 'schedules'" class="card automation-card">
+      <div class="card-header">
+        <div>
+          <h3>schedules ({{ projectSchedules.length }})</h3>
+          <p class="card-hint">Scheduled prompts delivered to this project or one of its chats.</p>
+        </div>
+      </div>
+      <div v-if="projectSchedules.length" class="automation-list">
+        <button
+          v-for="schedule in projectSchedules"
+          :key="schedule.schedule_id"
+          type="button"
+          class="automation-row"
+          @click="openAutomation(schedule.schedule_id)"
+        >
+          <span class="automation-row-main">
+            <span class="automation-title">{{ schedule.title || promptTitle(schedule.prompt) }}</span>
+            <span class="automation-status" :class="{ running: schedule.enabled }">
+              {{ schedule.enabled ? 'enabled' : 'paused' }}
+            </span>
+          </span>
+          <span class="automation-row-meta">
+            <span>{{ scheduleFrequencyLabel(schedule) }}</span>
+            <span class="dot">·</span>
+            <span>{{ scheduleTargetLabel(schedule) }}</span>
+            <span class="dot">·</span>
+            <span>next {{ automationTimestamp(schedule.next_run) }}</span>
+          </span>
+        </button>
+      </div>
+      <div v-else class="empty-row">// no schedules deliver prompts to this project</div>
+    </section>
   </div>
   <div v-else class="empty-state">// project not found.</div>
 </template>
@@ -235,6 +320,7 @@
 import { ref, computed, watch, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useProjectStore } from '../stores/projects'
+import { useTaskStore } from '../stores/tasks'
 import { useFileViewerStore } from '../stores/fileViewer'
 import { askConfirm } from '../lib/confirm'
 import { formatRelative } from '../lib/relativeTime'
@@ -243,7 +329,7 @@ import { colorForWorkspace } from '../lib/workspaceColors'
 import PaneHeader from './PaneHeader.vue'
 import ChatSignals from './ChatSignals.vue'
 import AppIcon from './AppIcon.vue'
-import type { ChatInfo } from '../lib/types'
+import type { ChatInfo, Loop, Schedule } from '../lib/types'
 
 interface ProjectFile {
   path: string
@@ -257,9 +343,18 @@ const props = defineProps<{ projectId: string }>()
 const emit = defineEmits<{ close: [], 'open-sidebar': [] }>()
 
 const store = useProjectStore()
+const taskStore = useTaskStore()
 const router = useRouter()
 
 const project = computed(() => store.projects.find(p => p.project_id === props.projectId) || null)
+
+type ProjectTab = 'overview' | 'loops' | 'schedules'
+const activeTab = ref<ProjectTab>('overview')
+const projectTabs = computed(() => [
+  { key: 'overview' as const, label: 'Overview' },
+  { key: 'loops' as const, label: 'Loops', count: projectLoops.value.length },
+  { key: 'schedules' as const, label: 'Schedules', count: projectSchedules.value.length },
+])
 
 watch(project, (p) => {
   if (p && p.workspace && p.workspace !== store.activeWorkspace) {
@@ -268,6 +363,16 @@ watch(project, (p) => {
 }, { immediate: true })
 
 const allChats = computed(() => store.chats.filter(c => c.project_id === props.projectId))
+const projectChatIds = computed(() => new Set(allChats.value.map(chat => chat.chat_id)))
+const projectLoops = computed(() =>
+  taskStore.loops.filter(loop => projectChatIds.value.has(loop.web_chat_id)),
+)
+const projectSchedules = computed(() =>
+  taskStore.schedules.filter(schedule =>
+    schedule.web_project_id === props.projectId
+      || (schedule.web_chat_id !== null && projectChatIds.value.has(schedule.web_chat_id)),
+  ),
+)
 const activeChats = computed(() =>
   allChats.value
     // Hide remote chats (session lives on another device, not openable here).
@@ -298,6 +403,46 @@ const workspaceHue = computed(() =>
 
 function chatActivity(chat: ChatInfo): string {
   return chatActivityTimestamp(chat)
+}
+
+function promptTitle(prompt: string): string {
+  const first = prompt.split('\n')[0].trim()
+  return first.length > 60 ? first.slice(0, 57) + '...' : first
+}
+
+function loopTargetLabel(loop: Loop): string {
+  return loop.context_label || allChats.value.find(chat => chat.chat_id === loop.web_chat_id)?.title || 'Unavailable chat'
+}
+
+function scheduleTargetLabel(schedule: Schedule): string {
+  if (schedule.web_project_id === props.projectId) return 'new chat per run'
+  if (schedule.web_chat_id) {
+    return allChats.value.find(chat => chat.chat_id === schedule.web_chat_id)?.title
+      || schedule.context_label
+      || 'Unavailable chat'
+  }
+  return schedule.context_label || 'General'
+}
+
+function scheduleFrequencyLabel(schedule: Schedule): string {
+  if (schedule.frequency === 'once') return `once · ${schedule.run_at_date || 'date pending'}`
+  if (schedule.frequency === 'manual') return 'manual'
+  if (schedule.frequency === 'monthly') return `monthly · day ${schedule.day_of_month || '—'}`
+  if (schedule.frequency === 'weekly') {
+    return schedule.days_of_week?.length ? `weekly · ${schedule.days_of_week.join(', ')}` : 'weekly'
+  }
+  return 'daily'
+}
+
+function automationTimestamp(iso: string | null | undefined): string {
+  if (!iso) return 'never'
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return iso
+  return date.toLocaleString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
+}
+
+function openAutomation(id: string): void {
+  router.push(`/schedules/${id}`)
 }
 
 const ARCHIVED_PER_PAGE = 10
@@ -550,7 +695,10 @@ async function reloadAll() {
 onMounted(reloadAll)
 // Re-fetch when the user navigates between projects without unmounting
 // the component (Vue keeps it alive across :projectId changes).
-watch(() => props.projectId, reloadAll)
+watch(() => props.projectId, async () => {
+  activeTab.value = 'overview'
+  await reloadAll()
+})
 </script>
 
 <style scoped>
@@ -672,6 +820,46 @@ watch(() => props.projectId, reloadAll)
   color: var(--fg3);
 }
 
+.project-tabs {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 0;
+  overflow-x: auto;
+}
+
+.project-tab {
+  min-height: 44px;
+  padding: 8px 12px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--fg2);
+  cursor: pointer;
+  font: 600 var(--text-sm) var(--font);
+  white-space: nowrap;
+}
+.project-tab:hover { color: var(--fg); background: var(--bg3); }
+.project-tab.active {
+  border-bottom-color: var(--accent);
+  color: var(--fg);
+}
+.tab-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  margin-left: 4px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: var(--bg3);
+  color: var(--fg2);
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+}
+.project-tab.active .tab-count { background: var(--accent2); color: var(--fg); }
+
 .card {
   background: var(--bg2);
   border: 1px solid var(--border);
@@ -696,6 +884,12 @@ watch(() => props.projectId, reloadAll)
   text-transform: uppercase;
   letter-spacing: 0.4px;
   color: var(--fg2);
+}
+
+.card-hint {
+  margin: 4px 0 0;
+  color: var(--fg3);
+  font-size: var(--text-xs);
 }
 
 .card-actions {
@@ -801,6 +995,54 @@ watch(() => props.projectId, reloadAll)
   color: var(--fg2);
   font-style: italic;
   padding: 4px 0;
+}
+
+.automation-card { min-height: 180px; }
+.automation-list { display: flex; flex-direction: column; }
+.automation-row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+  min-height: 64px;
+  padding: 10px 4px;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+  color: var(--fg);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+.automation-row:last-child { border-bottom: none; }
+.automation-row:hover { background: var(--bg3); }
+.automation-row:focus-visible,
+.project-tab:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.automation-row-main,
+.automation-row-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.automation-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--text-base);
+}
+.automation-status {
+  flex-shrink: 0;
+  color: var(--fg3);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.35px;
+}
+.automation-status.running { color: var(--success); }
+.automation-row-meta {
+  flex-wrap: wrap;
+  color: var(--fg2);
+  font-size: var(--text-xs);
 }
 
 .empty-state {
@@ -911,5 +1153,7 @@ watch(() => props.projectId, reloadAll)
 @media (max-width: 768px) {
   .project-stats { grid-template-columns: repeat(2, 1fr); }
   .file-meta { display: none; }
+  .automation-row-meta { display: block; line-height: 1.5; }
+  .automation-row-meta .dot { margin: 0 4px; }
 }
 </style>

--- a/web/src/components/__tests__/ProjectViewSignals.test.ts
+++ b/web/src/components/__tests__/ProjectViewSignals.test.ts
@@ -49,6 +49,7 @@ function seed() {
   store.bootstrapped = true
   const taskStore = useTaskStore()
   taskStore.loops = [] as unknown as typeof taskStore.loops
+  taskStore.schedules = [] as unknown as typeof taskStore.schedules
   return store
 }
 
@@ -100,5 +101,120 @@ describe('ProjectView chat rows', () => {
     store.activeWorkspace = 'personal'
     const wrapper = await mountView()
     expect(wrapper.find('.chat-signals').attributes('data-workspace-color')).toBe('emerald')
+  })
+
+  it('lists only loops and schedules associated with the project', async () => {
+    seed()
+    const taskStore = useTaskStore()
+    taskStore.loops = [{
+      loop_id: 'loop-project',
+      prompt: 'Check the project PRs',
+      web_chat_id: 'chat-read',
+      created_at: '2026-08-01T00:00:00Z',
+      interval_minutes: 10,
+      title: 'PR watcher',
+      autostart: false,
+      last_run_at: '',
+      last_status: '',
+      running: true,
+      context_label: 'Read chat',
+      next_run: null,
+    }, {
+      loop_id: 'loop-other',
+      prompt: 'Check another project',
+      web_chat_id: 'chat-missing',
+      created_at: '2026-08-01T00:00:00Z',
+      interval_minutes: 20,
+      title: 'Other watcher',
+      autostart: false,
+      last_run_at: '',
+      last_status: '',
+      running: false,
+      context_label: 'Other chat',
+      next_run: null,
+    }] as unknown as typeof taskStore.loops
+    taskStore.schedules = [{
+      schedule_id: 'schedule-project',
+      daily_time_utc: '09:00',
+      prompt: 'Send the daily brief',
+      chat_id: 0,
+      created_at: '2026-08-01T00:00:00Z',
+      timezone_name: 'Europe/Zurich',
+      last_triggered_on: '',
+      days_of_week: null,
+      thread_id: null,
+      context_label: '',
+      frequency: 'daily',
+      day_of_month: null,
+      run_at_date: null,
+      web_chat_id: null,
+      web_project_id: 'project-1',
+      workspace: 'personal',
+      model: '',
+      next_run: null,
+      last_expected_run: null,
+      missed: false,
+      enabled: true,
+      archive_policy: 'manual',
+    }, {
+      schedule_id: 'schedule-chat',
+      daily_time_utc: '10:00',
+      prompt: 'Send the chat brief',
+      chat_id: 0,
+      created_at: '2026-08-01T00:00:00Z',
+      timezone_name: 'Europe/Zurich',
+      last_triggered_on: '',
+      days_of_week: null,
+      thread_id: null,
+      context_label: '',
+      frequency: 'weekly',
+      day_of_month: null,
+      run_at_date: null,
+      web_chat_id: 'chat-read',
+      web_project_id: null,
+      workspace: 'personal',
+      model: '',
+      next_run: null,
+      last_expected_run: null,
+      missed: false,
+      enabled: false,
+      archive_policy: 'manual',
+    }, {
+      schedule_id: 'schedule-other',
+      daily_time_utc: '11:00',
+      prompt: 'Send another brief',
+      chat_id: 0,
+      created_at: '2026-08-01T00:00:00Z',
+      timezone_name: 'Europe/Zurich',
+      last_triggered_on: '',
+      days_of_week: null,
+      thread_id: null,
+      context_label: '',
+      frequency: 'daily',
+      day_of_month: null,
+      run_at_date: null,
+      web_chat_id: 'chat-missing',
+      web_project_id: null,
+      workspace: 'personal',
+      model: '',
+      next_run: null,
+      last_expected_run: null,
+      missed: false,
+      enabled: true,
+      archive_policy: 'manual',
+    }] as unknown as typeof taskStore.schedules
+
+    const wrapper = await mountView()
+
+    await wrapper.get('[data-tab="loops"]').trigger('click')
+    expect(wrapper.get('.automation-card').text()).toContain('PR watcher')
+    expect(wrapper.get('.automation-card').text()).not.toContain('Other watcher')
+    expect(wrapper.get('[data-tab="loops"]').text()).toContain('1')
+
+    await wrapper.get('[data-tab="schedules"]').trigger('click')
+    expect(wrapper.get('.automation-card').text()).toContain('Send the daily brief')
+    expect(wrapper.get('.automation-card').text()).toContain('Send the chat brief')
+    expect(wrapper.get('.automation-card').text()).not.toContain('Send another brief')
+    expect(wrapper.get('[data-tab="schedules"]').text()).toContain('2')
   })
 })


### PR DESCRIPTION
## What

Splits the project view into three tabs: **Overview**, **Loops**, and **Schedules**.

- Overview keeps the existing content (context, active chats, files, archived).
- Loops lists in-chat loops that target chats in this project, with running/stopped status, interval, target chat, and last run.
- Schedules lists schedules that deliver to this project or one of its chats, with frequency, target, enabled state, and next run.
- Tab counts show how many loops/schedules exist; clicking a row opens the automation detail view.
- Switching projects resets to the Overview tab.

## Why

The project view was a single long scroll mixing project state with automation. Loops and schedules that target a project's chats were only visible from the global Schedules page, so it was hard to see at a glance what automation a project owns.

## Notes

- `openAutomation` routes to `/schedules/:id`, which `ChatLayout` already resolves for both schedule and loop ids.
- Loops/schedules come from the task store, loaded once at the app shell level.
- Rebuilt the static bundle so `ciao/web/static/index.html` references the current asset hash.

## Tests

- `ProjectViewSignals.test.ts` covers tab switching, per-project filtering of loops and schedules, and tab counts.
- Full web suite: 463 passed. `vue-tsc --noEmit` and eslint clean.