### PR TITLE
[Fix] Persist re-entry summary across scroll + add disable toggle

### DIFF
--- a/ciao/web/static/index.html
+++ b/ciao/web/static/index.html
@@ -13,7 +13,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-180.png" />
     <title>Ciaobot</title>
-    <script type="module" crossorigin src="/assets/index-BXvFrv3r.js"></script>
+    <script type="module" crossorigin src="/assets/index-CFv9ZTMm.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-C9YagjX_.css">
   </head>
   <body>

--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -1168,6 +1168,7 @@ import {
   type MentionProject,
 } from '../composables/useMentionPicker'
 import { useThinkingPreference } from '../composables/useThinkingPreference'
+import { useReentrySummaryPreference } from '../composables/useReentrySummaryPreference'
 import {
   clearPlanReturnMode,
   includeBuiltinPlanCommand,
@@ -1239,6 +1240,7 @@ const emit = defineEmits<{ close: [], 'open-sidebar': [] }>()
 const store = useProjectStore()
 const fileViewer = useFileViewerStore()
 const { thinkingExpanded, toggleThinking } = useThinkingPreference()
+const { reentrySummaryEnabled } = useReentrySummaryPreference()
 const draftChatId = store.activeChatId
 const inputText = ref(readChatDraft(draftChatId))
 const inputRevision = ref(0)
@@ -1475,7 +1477,10 @@ const editingTitle = ref(false)
 const titleValue = ref('')
 const dragOver = ref(false)
 const chat = computed(() => store.activeChat!)
-const reentrySummary = computed(() => store.reentrySummaries[chat.value.chat_id] || '')
+const reentrySummary = computed(() => {
+  if (!reentrySummaryEnabled.value) return ''
+  return store.reentrySummaries[chat.value.chat_id] || ''
+})
 watch(() => chat.value.provider, () => {
   void loadSlashCommands()
 })

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -398,6 +398,20 @@
               </div>
             </div>
           </div>
+          <div class="setting-row setting-row--inline setting-row--toggle">
+            <div class="routine-info">
+              <span class="routine-name">Re-entry summary</span>
+              <span class="routine-detail">Show a one-line Apple Intelligence orientation note when you reopen a quiet chat. The summary stays visible while you scroll and clears the moment you send a new message.</span>
+            </div>
+            <label class="settings-checkbox-hit">
+              <input
+                type="checkbox"
+                class="settings-checkbox"
+                v-model="reentrySummaryEnabled"
+                @change="onReentrySummaryToggle"
+              />
+            </label>
+          </div>
         </div>
 
         
@@ -2267,6 +2281,7 @@ import PaneHeader from './PaneHeader.vue'
 import ModelSelector from './ModelSelector.vue'
 import SettingsAutomation from './settings/SettingsAutomation.vue'
 import { providerModelBadges, sectionsFromModelsResponse, type ModelSection } from '../lib/modelSections'
+import { useReentrySummaryPreference } from '../composables/useReentrySummaryPreference'
 
 // The tray owns package updates and native notifications in the desktop app.
 const inDesktopApp = isDesktopApp()
@@ -2305,6 +2320,7 @@ const newMcpTransport = ref<'http' | 'stdio'>('http')
 const newMcpUrl = ref('')
 const newMcpCommand = ref('')
 const fastMcpEnabled = ref(true)
+const { reentrySummaryEnabled, setReentrySummaryEnabled } = useReentrySummaryPreference()
 const expandedMcp = ref<Record<string, boolean>>({})
 const mcpEnvInputs = ref<Record<string, string>>({})
 const mcpEnvSaving = ref(false)
@@ -2534,6 +2550,17 @@ async function refreshMcpServerTools(srv: McpProjectServer) {
 
 function saveFastMcpToggle() {
   notifySaved(fastMcpEnabled.value ? 'Ciaobot FastMCP enabled.' : 'Ciaobot FastMCP disabled.')
+}
+
+function onReentrySummaryToggle() {
+  setReentrySummaryEnabled(reentrySummaryEnabled.value)
+  // The store action already evicts cached summaries when the toggle goes
+  // off. Persist to localStorage too so the choice survives reload.
+  if (reentrySummaryEnabled.value) {
+    notifySaved('Re-entry summary enabled.')
+  } else {
+    notifySaved('Re-entry summary disabled.')
+  }
 }
 
 async function createMcpViaChat() {

--- a/web/src/composables/useReentrySummaryPreference.ts
+++ b/web/src/composables/useReentrySummaryPreference.ts
@@ -1,0 +1,48 @@
+import { ref, type Ref } from 'vue'
+
+export const REENTRY_SUMMARY_STORAGE_KEY = 'ciao-reentry-summary-enabled'
+
+type PreferenceStorage = Pick<Storage, 'getItem' | 'setItem'>
+
+function defaultStorage(): PreferenceStorage | null {
+  if (typeof localStorage === 'undefined') return null
+  return localStorage
+}
+
+export function readReentrySummaryEnabled(
+  storage: PreferenceStorage | null = defaultStorage(),
+): boolean {
+  if (!storage) return true
+  try {
+    // Default to enabled when the key has never been written, so first-run
+    // users see the same Apple Intelligence orientation note the rest of
+    // the app is tuned around.
+    return storage.getItem(REENTRY_SUMMARY_STORAGE_KEY) !== 'false'
+  } catch {
+    return true
+  }
+}
+
+export function writeReentrySummaryEnabled(
+  enabled: boolean,
+  storage: PreferenceStorage | null = defaultStorage(),
+): void {
+  if (!storage) return
+  try {
+    storage.setItem(REENTRY_SUMMARY_STORAGE_KEY, String(enabled))
+  } catch {
+    // A blocked preference store must not prevent reading the chat.
+  }
+}
+
+export function useReentrySummaryPreference(): {
+  reentrySummaryEnabled: Ref<boolean>
+  setReentrySummaryEnabled: (enabled: boolean) => void
+} {
+  const reentrySummaryEnabled = ref(readReentrySummaryEnabled())
+  function setReentrySummaryEnabled(enabled: boolean): void {
+    reentrySummaryEnabled.value = enabled
+    writeReentrySummaryEnabled(enabled)
+  }
+  return { reentrySummaryEnabled, setReentrySummaryEnabled }
+}

--- a/web/src/stores/projects.test.ts
+++ b/web/src/stores/projects.test.ts
@@ -804,6 +804,9 @@ describe('re-entry summary invalidation', () => {
     const chatId = 'chat-summary-result'
     store.reentrySummaries[chatId] = 'Old orientation'
     store.connectWs(chatId)
+    // Mark the chat as streaming so the result is treated as a real turn
+    // completion rather than a broker replay on WS resume.
+    store.streaming[chatId] = true
 
     fakeSockets[0].onmessage?.({
       data: JSON.stringify({
@@ -817,6 +820,58 @@ describe('re-entry summary invalidation', () => {
     })
 
     expect(store.reentrySummaries[chatId]).toBeUndefined()
+  })
+
+  test('keeps the summary when a result is replayed after the turn has already settled', () => {
+    // A WS reconnect replays the broker's buffered events. A result for a
+    // turn that already settled on this client must NOT clear the re-entry
+    // summary — otherwise scrolling after a resume would dismiss the
+    // orientation note.
+    const store = useProjectStore()
+    const chatId = 'chat-summary-result-replay'
+    store.reentrySummaries[chatId] = 'Old orientation'
+    store.connectWs(chatId)
+    // streaming stays false (default) — the turn already settled.
+
+    fakeSockets[0].onmessage?.({
+      data: JSON.stringify({
+        type: 'result',
+        text: 'The new answer',
+        is_error: false,
+        effective_model: 'claude-test',
+        usage: {},
+        session_id: 'session-1',
+      }),
+    })
+
+    expect(store.reentrySummaries[chatId]).toBe('Old orientation')
+  })
+
+  test('keeps the summary when a user_echo is replayed for an already-rendered turn', () => {
+    const store = useProjectStore()
+    const chatId = 'chat-summary-echo-replay'
+    store.reentrySummaries[chatId] = 'Old orientation'
+    store.connectWs(chatId)
+    // The transcript already has a user message with the same turn_index
+    // that the echo is replaying. The summary must survive this echo so
+    // that scrolling (which can trigger a WS resume and a buffered echo
+    // replay) doesn't dismiss the orientation note.
+    store.messages[chatId] = [{
+      role: 'user',
+      content: 'Earlier prompt',
+      timestamp: '2026-08-13T10:00:00Z',
+      turn_index: 4,
+    }]
+
+    fakeSockets[0].onmessage?.({
+      data: JSON.stringify({
+        type: 'user_echo',
+        text: 'Earlier prompt',
+        turn_index: 4,
+      }),
+    })
+
+    expect(store.reentrySummaries[chatId]).toBe('Old orientation')
   })
 
   test('does not restore a stale summary after a new message arrives', async () => {
@@ -850,6 +905,47 @@ describe('re-entry summary invalidation', () => {
     await request
 
     expect(store.reentrySummaries[chatId]).toBeUndefined()
+  })
+
+  test('does not request a summary when the user has disabled the preference', () => {
+    const store = useProjectStore()
+    const chatId = 'chat-summary-disabled'
+    store.chats = [{
+      chat_id: chatId,
+      project_id: 'p1',
+      title: 'Disabled',
+      model: 'sonnet',
+      provider: 'claude',
+      mode: 'auto',
+      session_id: 'session-1',
+      created_at: '',
+      archived: false,
+    }]
+    localStorageData['ciao-reentry-summary-enabled'] = 'false'
+
+    store.requestReentrySummaryIfUseful(chatId)
+
+    const calls = apiPost.mock.calls.filter(([path]) => path.endsWith('/reentry-summary'))
+    expect(calls).toHaveLength(0)
+  })
+
+  test('disabling the preference evicts any cached summaries', () => {
+    const store = useProjectStore()
+    store.reentrySummaries['a'] = 'First'
+    store.reentrySummaries['b'] = 'Second'
+
+    store.setReentrySummaryEnabled(false)
+
+    expect(store.reentrySummaries).toEqual({})
+  })
+
+  test('enabling the preference leaves cached summaries alone', () => {
+    const store = useProjectStore()
+    store.reentrySummaries['a'] = 'First'
+
+    store.setReentrySummaryEnabled(true)
+
+    expect(store.reentrySummaries['a']).toBe('First')
   })
 })
 

--- a/web/src/stores/projects.ts
+++ b/web/src/stores/projects.ts
@@ -7,6 +7,7 @@ import { formatChatComments, formatFileComments, type ChatCommentAnchor } from '
 import { isPlausibleFilePath } from '../lib/filePaths'
 import { useFileViewerStore } from './fileViewer'
 import { isRateLimitTelemetry } from '../lib/rateLimit'
+import { readReentrySummaryEnabled } from '../composables/useReentrySummaryPreference'
 import {
   isRestartDrainMessage,
   reloadWhenServerReady,
@@ -1785,6 +1786,7 @@ export const useProjectStore = defineStore('projects', () => {
   }
 
   function requestReentrySummaryIfUseful(chatId: string): void {
+    if (!readReentrySummaryEnabled()) return
     const chat = chats.value.find(c => c.chat_id === chatId)
     if (!chat || chat.archived) return
     // session_id covers chats whose history is still being hydrated; the
@@ -1794,6 +1796,18 @@ export const useProjectStore = defineStore('projects', () => {
     )
     if (hasHistory && !reentrySummaries.value[chatId]) {
       void requestReentrySummary(chatId)
+    }
+  }
+
+  // Toggling the preference off also evicts any cached summaries so the
+  // bubble disappears immediately rather than lingering for the rest of
+  // the session. Toggling on does nothing — the next chat open will fetch
+  // its own summary, no warm-up needed.
+  function setReentrySummaryEnabled(enabled: boolean): void {
+    if (!enabled) {
+      for (const chatId of Object.keys(reentrySummaries.value)) {
+        clearReentrySummary(chatId)
+      }
     }
   }
 
@@ -3568,9 +3582,16 @@ export const useProjectStore = defineStore('projects', () => {
     const msgs = messages.value[chatId] || []
 
     // A summary belongs only to the moment the user re-enters a quiet chat.
-    // Any message arriving over the socket makes that orientation stale,
-    // including messages from another device and assistant results.
-    if (event.type === 'user_echo' || event.type === 'queued' || event.type === 'steered' || event.type === 'result') {
+    // `queued` and `steered` always represent new user activity (a new prompt
+    // is now waiting or has been redirected at the current turn), so they
+    // always invalidate the summary.
+    //
+    // `user_echo` and `result` are handled inside their switch cases below:
+    // the broker replays them on every WS reconnect, and a no-op replay
+    // (turn already rendered, or no final text on a result) must NOT clear
+    // the summary. The user opens a chat, scrolls to re-orient, and the
+    // summary disappearing on a broker replay is the wrong behavior.
+    if (event.type === 'queued' || event.type === 'steered') {
       clearReentrySummary(chatId)
     }
 
@@ -3621,6 +3642,10 @@ export const useProjectStore = defineStore('projects', () => {
             // do reflect the implied streaming state.
             if (event.unattended) existingWithTurn.unattended = true
             if (!streaming.value[chatId]) streaming.value[chatId] = true
+            // This is a broker replay, not a new send: leave the re-entry
+            // summary alone. The whole reason a user re-enters a chat is
+            // orientation, and the summary must survive the WS-resume echo
+            // storm until the user actually types or sends.
             break
           }
           // Look for an optimistic user message with matching content but no
@@ -3680,6 +3705,10 @@ export const useProjectStore = defineStore('projects', () => {
         messages.value[chatId] = normalizeMessages([...msgs])
         // Flushed turn = we're streaming again. Make sure the flag reflects it.
         if (!streaming.value[chatId]) streaming.value[chatId] = true
+        // Brand-new echo (not a replay) is the user actually starting a turn.
+        // Clear the summary here so it disappears when the user sends, not on
+        // an unrelated broker replay.
+        clearReentrySummary(chatId)
         break
       }
 
@@ -4010,6 +4039,12 @@ export const useProjectStore = defineStore('projects', () => {
           const chat = chats.value.find(c => c.chat_id === chatId)
           if (chat) chat.session_id = event.session_id
         }
+        // Clear the re-entry summary only when the result represents a turn
+        // that just finished while the user was watching. If `streaming` was
+        // already false, this is a broker replay for a turn the user has
+        // already been reading and the summary still applies. The summary
+        // also clears at user send (sendMessage / fresh user_echo).
+        const wasStreaming = streaming.value[chatId] === true
         if (text.trim() || event.is_error) {
           msgs.push({
             role: 'assistant',
@@ -4042,6 +4077,14 @@ export const useProjectStore = defineStore('projects', () => {
         // so a late click can't race a brand-new turn.
         delete pendingPermissions.value[chatId]
         persistMessages()
+        if (wasStreaming) {
+          // The result closed a turn that was actually in flight on this
+          // client. The re-entry summary no longer reflects the chat
+          // state, so drop it. Skipped on a broker replay (wasStreaming
+          // false) so a scroll-induced resume doesn't dismiss the summary
+          // for a turn the user is still re-reading.
+          clearReentrySummary(chatId)
+        }
         // Reconcile with the authoritative SDK session. Handles the reconnect
         // case where /messages already had this turn (dedups) and the race
         // where the SDK session file lags the result event (retries until the
@@ -4210,7 +4253,7 @@ export const useProjectStore = defineStore('projects', () => {
     fileCommentsFor, removeFileComment, updateFileComment,
     pinFile, unpinFile, pinnedFileFor,
     removeQueued, removeQueuedById, reorderQueued, editQueued, clearQueued,
-    loadMessages, loadSubagents,
+    loadMessages, loadSubagents, setReentrySummaryEnabled,
     connectWs, disconnectWs, connectEventsWs,
     beginServerRestart,
     pushToast, pushErrorToast, dismissToast, fixError,

--- a/web/src/stores/projects.ts
+++ b/web/src/stores/projects.ts
@@ -4241,7 +4241,7 @@ export const useProjectStore = defineStore('projects', () => {
     fetchAll, fetchWorkspaces, createWorkspace, updateWorkspace, deleteWorkspace,
     createProject, updateProject, reorderProjects, deleteProject, completeProject,
     fetchCompletedProjects, restoreProject,
-    createChat, newChatInGeneral, renameChat, updateChat, handoverChat, forkChat, moveChat, deleteChat, closeChat, requestReentrySummary, archiveChat, continueArchivedChat, newSession,
+    createChat, newChatInGeneral, renameChat, updateChat, handoverChat, forkChat, moveChat, deleteChat, closeChat, requestReentrySummary, requestReentrySummaryIfUseful, archiveChat, continueArchivedChat, newSession,
     setChatRetry, stopChatRetry, tryChatRetryNow,
     switchChat, switchWorkspace, openChatFromDeepLink, ensureWorkspaceForChat,
     syncLatest,


### PR DESCRIPTION
The Apple Intelligence re-entry summary used to disappear when the user scrolled because the broker replays the buffered `user_echo` and `result` events on every WebSocket resume, and the projects store unconditionally cleared the summary on those events. After a PWA resume (scroll, focus change, or page-paint) the summary would vanish even though no new turn had actually started.

**Decision (2026-08-13):** narrow the clear to the cases that represent real new activity, and add a Settings → Appearance toggle (default on) so the summary can be turned off entirely.

**Scroll-resilience changes (`web/src/stores/projects.ts`):**
- `user_echo`: clear only when the echo pushes a new user bubble (not when the same `turn_index` is replayed for an already-rendered turn).
- `result`: clear only when `streaming` was still true on the client. A result replayed after the turn already settled leaves the summary alone.
- `queued` / `steered`: still clear unconditionally; they always represent new user activity.

**Disable toggle:**
- New `useReentrySummaryPreference` composable (`web/src/composables/useReentrySummaryPreference.ts`) mirrors `useThinkingPreference`: localStorage-backed, default on.
- `SettingsView.vue` adds a row in the Appearance card with the same checkbox pattern as `fastMcpEnabled`.
- `requestReentrySummaryIfUseful` short-circuits when the preference is off; `setReentrySummaryEnabled(false)` evicts any cached summaries so the bubble disappears immediately.
- `ChatPanel.vue`'s `reentrySummary` computed returns empty when the preference is off, so the `v-if` short-circuits and no bubble is rendered.

**Tests (`web/src/stores/projects.test.ts`):** updated the existing `result` test to set `streaming[chatId] = true`, added a replay-doesn't-clear test for `result`, a replay-doesn't-clear test for `user_echo` (with a matching `turn_index` in the transcript), a preference-off test that the request never fires, and a test that disabling evicts the cache.

Engine behavior is unchanged: the `/api/chats/{chat_id}/reentry-summary` endpoint still runs Apple Intelligence on demand; the front end just gates the request and the render on the new preference.