### PR TITLE
fix(desktop-drop): stage cloud placeholders and name the failure

### DIFF
--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import functools
 import json
 import logging
@@ -1988,16 +1989,33 @@ def _desktop_drop_read_error(path: Path, exc: OSError) -> str:
     no staged copy, because the shell is older than that fix or the drop was not
     an image, the raw errno tells the user nothing they can act on.
 
-    Three tiers, narrowest first. An NSIRD path gets screenshot-specific advice.
-    Any other permission denial still gets actionable text, just without naming
-    a screenshot, so a plain unreadable drop is not mislabelled and does not
-    regress to a raw errno. Anything else falls through to the errno, which is
-    all we know about it.
+    Four tiers, narrowest first. An NSIRD path gets screenshot-specific advice.
+    ``EDEADLK`` means a cloud placeholder (see below). Any other permission
+    denial still gets actionable text, just without naming a screenshot, so a
+    plain unreadable drop is not mislabelled and does not regress to a raw
+    errno. Anything else falls through to the errno, which is all we know
+    about it.
     """
     if _looks_like_nsird_screenshot(path):
         return (
             "macOS won't let us read this screenshot directly. "
             "Save it to disk first, then drag it in."
+        )
+    if exc.errno == errno.EDEADLK:
+        # A file dragged out of iCloud Drive (or any other File Provider) whose
+        # bytes are not on disk: `stat` reports the real size, so the grant's
+        # existence check passes, and the read is then refused with EDEADLK
+        # ("Resource deadlock avoided") because this process may not ask the
+        # provider to materialise it. Unlike EPERM the errno is unambiguous
+        # here, so it needs no corroborating path check. The desktop shell
+        # stages images past this (`needs_drop_staging` in
+        # desktop/src-tauri/src/lib.rs); an image over the staging limit, an
+        # older shell, or a client node transferring a non-image still lands
+        # here. A non-image dropped on a host does not: the path is handed to
+        # the agent unread, so the agent hits the same errno on its own.
+        return (
+            f"{path.name} is not downloaded to this Mac yet. Right-click it in "
+            "Finder, choose Download Now, then drag it in again."
         )
     if isinstance(exc, PermissionError):
         return (

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -85,13 +85,48 @@ const DROP_IMAGE_EXTENSIONS: [&str; 5] = ["png", "jpg", "jpeg", "gif", "webp"];
 // never close; a promise-backed drag of something else can be.
 const DROP_STAGING_MAX_BYTES: u64 = 64 * 1024 * 1024;
 
-/// True for a promise-backed drag the Python server will not be able to read.
+// `SF_DATALESS`, from `sys/stat.h`. macOS sets it on a cloud file whose bytes
+// live only in the provider: `stat` reports the real size, `st_blocks` is 0, and
+// a read has to materialise the file first.
+const SF_DATALESS: u32 = 0x4000_0000;
+
+/// True for `st_flags` marking a file the File Provider has not materialised.
 ///
-/// Dragging straight from the macOS screenshot thumbnail hands over a path in
-/// `.../TemporaryItems/NSIRD_screencaptureui_*/`. macOS grants that read to the
-/// app which received the drop, this process, and denies it to every other one,
-/// so the server's `read_bytes()` failed with `EPERM` and the screenshot was
-/// dropped on the floor (issue #238).
+/// Split out from the `stat` call so the bit test is unit-testable: a dataless
+/// file cannot be created in a temp dir.
+fn flags_are_dataless(flags: u32) -> bool {
+    flags & SF_DATALESS != 0
+}
+
+#[cfg(target_os = "macos")]
+fn is_dataless(metadata: &std::fs::Metadata) -> bool {
+    use std::os::macos::fs::MetadataExt;
+    flags_are_dataless(metadata.st_flags())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn is_dataless(_metadata: &std::fs::Metadata) -> bool {
+    false
+}
+
+/// True for an image drop the Python server will not be able to read itself.
+///
+/// Two cases, both of which left the drop on the floor as a raw errno:
+///
+/// - Dragging straight from the macOS screenshot thumbnail hands over a path in
+///   `.../TemporaryItems/NSIRD_screencaptureui_*/`. macOS grants that read to
+///   the app which received the drop, this process, and denies it to every other
+///   one, so the server's `read_bytes()` failed with `EPERM` (issue #238).
+/// - Dragging a file out of iCloud Drive (or any other File Provider) hands over
+///   a path whose bytes are not on disk. Materialising it is refused for a
+///   process that may not talk to the provider, which the server is, so its
+///   `read_bytes()` failed with `EDEADLK` — "Resource deadlock avoided".
+///
+/// This app *is* allowed both reads, so staging a copy here is what makes the
+/// drop work at all. Gated rather than applied to every image so an ordinary
+/// local drag stays zero-copy, because staging a dataless file means waiting for
+/// iCloud to hand the bytes over. The caller keeps that wait off the window
+/// event thread.
 fn needs_drop_staging(path: &std::path::Path) -> bool {
     let is_image = path
         .extension()
@@ -99,13 +134,16 @@ fn needs_drop_staging(path: &std::path::Path) -> bool {
         .is_some_and(|extension| {
             DROP_IMAGE_EXTENSIONS.contains(&extension.to_ascii_lowercase().as_str())
         });
-    is_image
-        && path.components().any(|component| {
-            component
-                .as_os_str()
-                .to_str()
-                .is_some_and(|name| name.starts_with("NSIRD_"))
-        })
+    if !is_image {
+        return false;
+    }
+    let is_promise_backed = path.components().any(|component| {
+        component
+            .as_os_str()
+            .to_str()
+            .is_some_and(|name| name.starts_with("NSIRD_"))
+    });
+    is_promise_backed || std::fs::metadata(path).is_ok_and(|metadata| is_dataless(&metadata))
 }
 
 /// Copy one dropped file into this grant's staging dir, returning the new path.
@@ -731,14 +769,30 @@ fn build_windows(
                     ));
                 }
                 WindowEvent::DragDrop(DragDropEvent::Drop { paths, .. }) => {
-                    let detail = match create_desktop_drop_grant(&runtime_root, paths) {
-                        Ok((grant_id, paths)) => serde_json::json!({
-                            "grantId": grant_id,
-                            "paths": paths,
-                        }),
-                        Err(error) => serde_json::json!({ "error": error }),
-                    };
-                    let _ = window.eval(browser_event_script("ciao:native-file-drop", &detail));
+                    // Off the window event thread, because building the grant
+                    // stages files and staging a cloud placeholder has to
+                    // materialise it first — a download, not a copy (see
+                    // `needs_drop_staging`). Run inline, that is the whole window
+                    // frozen until iCloud answers. Clear the drag highlight now
+                    // rather than leaving it lit for that wait; the page clears it
+                    // again when the grant lands.
+                    let _ = window.eval(browser_event_script(
+                        "ciao:native-file-drag-leave",
+                        &serde_json::json!({}),
+                    ));
+                    let window = window.clone();
+                    let runtime_root = runtime_root.clone();
+                    let paths = paths.clone();
+                    thread::spawn(move || {
+                        let detail = match create_desktop_drop_grant(&runtime_root, &paths) {
+                            Ok((grant_id, paths)) => serde_json::json!({
+                                "grantId": grant_id,
+                                "paths": paths,
+                            }),
+                            Err(error) => serde_json::json!({ "error": error }),
+                        };
+                        let _ = window.eval(browser_event_script("ciao:native-file-drop", &detail));
+                    });
                 }
                 WindowEvent::CloseRequested { api, .. } => {
                     // Closing the window leaves Ciaobot running in the menu bar;
@@ -1471,8 +1525,8 @@ pub fn run() {
 mod tests {
     use super::{
         append_log, browser_event_script, create_desktop_drop_grant, engine_already_current,
-        engine_launch_action, is_external_link, is_trusted_main_navigation, needs_drop_staging,
-        requires_confirmation, should_show_main_window,
+        engine_launch_action, flags_are_dataless, is_external_link, is_trusted_main_navigation,
+        needs_drop_staging, requires_confirmation, should_show_main_window,
     };
     use crate::service::ServiceResult;
 
@@ -1564,11 +1618,12 @@ mod tests {
         }
     }
 
-    // Only a promise-backed image drop gets copied. A screenshot outside an
-    // NSIRD dir, and a non-image inside one, both stay pass-through: the server
-    // can read the first, and the agent needs to keep reading the second.
+    // Only an image drop the server cannot read itself gets copied. A readable
+    // local screenshot, and a non-image inside an NSIRD dir, both stay
+    // pass-through: the server can read the first, and the agent needs to keep
+    // reading the second.
     #[test]
-    fn only_a_promise_backed_image_drop_needs_staging() {
+    fn only_an_unreadable_image_drop_needs_staging() {
         let temporary =
             std::path::Path::new("/var/folders/zj/x/T/TemporaryItems/NSIRD_screencaptureui_1Pr326");
         assert!(needs_drop_staging(
@@ -1576,9 +1631,25 @@ mod tests {
         ));
         assert!(needs_drop_staging(&temporary.join("SHOT.JPEG")));
         assert!(!needs_drop_staging(&temporary.join("notes.pdf")));
-        assert!(!needs_drop_staging(std::path::Path::new(
-            "/Users/someone/Desktop/Screenshot.png"
-        )));
+
+        // An ordinary local image, on disk and materialised. Written for real
+        // rather than named: the dataless check stats the path, so a bare
+        // nonexistent path would pass this assertion without exercising it.
+        let root = tempfile::tempdir().unwrap();
+        let local = root.path().join("Screenshot.png");
+        std::fs::write(&local, b"\x89PNG\r\n\x1a\n").unwrap();
+        assert!(!needs_drop_staging(&local));
+    }
+
+    // The bit test behind the dataless check. macOS sets SF_DATALESS (0x40000000)
+    // on an iCloud file whose bytes are not on disk; the flags below are real
+    // values read off this machine, materialised and not.
+    #[test]
+    fn dataless_flags_are_recognised() {
+        assert!(flags_are_dataless(0x4000_0060));
+        assert!(flags_are_dataless(0x4000_0000));
+        assert!(!flags_are_dataless(0x0000_0060));
+        assert!(!flags_are_dataless(0));
     }
 
     #[test]

--- a/tests/test_project_files.py
+++ b/tests/test_project_files.py
@@ -10,6 +10,7 @@ filenames, and oversized or disallowed extensions.
 
 from __future__ import annotations
 
+import errno
 import json
 import time
 import uuid
@@ -539,6 +540,58 @@ def test_native_desktop_drop_keeps_generic_error_for_non_screenshot(tmp_path: Pa
     assert "Errno" not in error["error"]
     assert dropped_image.name in error["error"]
     assert "Save the file to a folder first" in error["error"]
+
+
+def test_native_desktop_drop_explains_an_undownloaded_cloud_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A cloud placeholder gets download advice, not a raw ``[Errno 11]``.
+
+    Dragging a file out of iCloud Drive whose bytes are not on disk clears the
+    grant's existence check — ``stat`` reports the real size — and then fails the
+    read with ``EDEADLK``, because this process may not ask the File Provider to
+    materialise the file. macOS raises that errno only for this case, so the test
+    raises it directly: a dataless file cannot be created in a temp dir, and
+    ``EDEADLK`` is what the server has to key off anyway.
+    """
+    pcm = _make_manager(tmp_path)
+    config = pcm._config
+    project = next(iter(pcm.list_projects()))
+    chat = pcm.create_chat(project.project_id, title="Drop test")
+    dropped_image = tmp_path / "Screenshot 2026-02-20 at 21.33.14.png"
+    dropped_image.write_bytes(b"\x89PNG\r\n\x1a\n")
+    grant_id = _write_desktop_drop_grant(config, [dropped_image.resolve()])
+    client = _make_client(pcm, config)
+
+    unpatched_read_bytes = Path.read_bytes
+
+    def refuse_unmaterialised_read(self: Path) -> bytes:
+        if self == dropped_image.resolve():
+            raise OSError(errno.EDEADLK, "Resource deadlock avoided")
+        return unpatched_read_bytes(self)
+
+    monkeypatch.setattr(Path, "read_bytes", refuse_unmaterialised_read)
+
+    response = client.post(
+        "/api/desktop-drop",
+        json={
+            "grant_id": grant_id,
+            "project_id": project.project_id,
+            "chat_id": chat.chat_id,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["image_refs"] == []
+    assert len(body["errors"]) == 1
+    error = body["errors"][0]
+    assert error["filename"] == dropped_image.name
+    assert "Download Now" in error["error"]
+    # The complaint that started this: the user saw only the errno.
+    assert "Errno" not in error["error"]
+    assert "deadlock" not in error["error"]
+    assert str(dropped_image) not in error["error"]
 
 
 def test_native_desktop_drop_clears_staged_copies(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

Dragging a file out of iCloud Drive into a chat produced `Could not attach Screenshot … — [Errno 11] Resource deadlock avoided`.

The file was an evicted placeholder: `stat` reports the real size but `st_blocks` is 0, so the grant's existence check passes, and `path.read_bytes()` is then refused with `EDEADLK` because the server process may not ask the File Provider to materialise it. Reproduced on a real file (`size=32844 blocks=0 flags=0x40000060`); reading it from a process that *is* allowed to materialise succeeds, which is the control.

Staging in the shell did not cover it: `needs_drop_staging` only staged images under an `NSIRD_` path, the fix for #238 (`EPERM` from screenshot-thumbnail drags).

## Changes

- **`needs_drop_staging` also stages a dataless image** (`st_flags & SF_DATALESS`). The shell is allowed the read the server is refused, so a staged copy is what makes the drop work. Gated rather than applied to every image so an ordinary local drag stays zero-copy.
- **Grant creation moves off the window event thread.** Staging a placeholder waits for a download; inline, that is the whole window frozen until iCloud answers — a freeze the NSIRD-only gate never reached, since those are local temp files. The drag highlight is now cleared when the drop arrives rather than when the grant is ready.
- **`_desktop_drop_read_error` gains an `EDEADLK` tier**, so what still reaches the server unreadable — an image over the 64 MB staging limit, an older shell, or a client node transferring a non-image — says what to do instead of leaking the errno. Unlike `EPERM` the errno is unambiguous here, so it needs no corroborating path check.

## Known limits

- A drop that stages slowly lands in whichever chat is active when it completes; the page reads `chat_id` when the grant event arrives. Previously the frozen window made switching impossible.
- `DROP_STAGING_MAX_BYTES` (64 MB) is larger than the default `max_image_size_bytes` (10 MB), so a mid-sized placeholder can be downloaded and then rejected as `image too large`. Pre-existing constant; the shell cannot see the server's configured limit.
- A non-image placeholder dropped on a host is handed to the agent unread, so the agent hits `EDEADLK` itself. Covering that means the server flagging dataless non-images — new behaviour, left out.

## Verification

- `pytest tests/` — 2305 passed, 1 skipped.
- `./scripts/check-desktop.sh --fast` — `cargo fmt --check`, `clippy -D warnings`, 43 Rust tests.
- New tests: `test_native_desktop_drop_explains_an_undownloaded_cloud_file` (raises `EDEADLK` directly — a dataless file cannot be created in a temp dir), `dataless_flags_are_recognised`, and `only_an_unreadable_image_drop_needs_staging` now writes a real local image, since the old assertion passed only because the path did not exist.
- Not verified by an automated test: the end-to-end drag in a built app, which needs a real evicted iCloud file.