### PR TITLE
fix(title): fire auto-title immediately for question-shaped prompts

### DIFF
--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -678,31 +678,6 @@ def _is_contentless_prompt(text: str) -> bool:
     return normalized in _CONTENTLESS_PROMPTS
 
 
-# Question-shaped openers ("why is X broken?", "what does Y mean?") are often
-# meta-inquiries whose real topic only emerges in the assistant's reply: the
-# user asks "why no recent sessions?" to diagnose something, the assistant
-# pivots to the actual cause, and a title built from the question alone ("No
-# Recent Sessions") misnames the chat. Defer those to the post-reply path so
-# the titler sees both sides and can prefer the assistant's framing (#176).
-_QUESTION_OPENER_RE = re.compile(
-    r"^(why|what|how|when|where|who|whom|whose|which|"
-    r"is|are|am|was|were|"
-    r"do|does|did|can|could|will|would|shall|should|may|might|must|"
-    r"has|have|had)\b",
-    re.IGNORECASE,
-)
-
-
-def _is_question_shaped_prompt(text: str) -> bool:
-    """True for meta-inquiry openers. We defer titling these until the first
-    assistant reply so the title reflects the conclusion, not the question.
-    """
-    snippet = (text or "").strip()
-    if not snippet:
-        return False
-    return bool(_QUESTION_OPENER_RE.match(snippet))
-
-
 def _fallback_title(user_text: str) -> str | None:
     """Deterministic fallback title derived from the user's first message.
 
@@ -6467,12 +6442,14 @@ class ProjectChatManager:
         # would have, but the cheap Ollama free-tier title model
         # absorbs that cost easily and we can always rename manually.
         #
-        # Exception: question-shaped meta-inquiries ("why no recent sessions?")
-        # get deferred until the first assistant reply. Their real topic only
-        # emerges in the reply, so a title from the prompt alone would name
-        # the question, not the conclusion (#176). `defer_title` is closed
-        # over by _drive below, which fires the title once the turn lands.
-        defer_title = False
+        # This includes question-shaped meta-inquiries ("why no recent sessions?").
+        # Earlier code (#176) deferred those until the first reply so the title
+        # could prefer the assistant's framing, but that left the sidebar entry
+        # blank for the full first turn and was reported as a regression. The
+        # post-reply path in `_drive()` still runs the titleer a second time
+        # with both sides of the exchange and overwrites the early title if it
+        # disagrees, so the assistant's framing can still win on the rare cases
+        # where it matters.
         if chat_meta and chat_meta.title == "New Chat" and prompt.strip():
             chat_meta.title_status = "pending"
             self._events.publish({
@@ -6481,14 +6458,9 @@ class ProjectChatManager:
                 "title": chat_meta.title,
                 "status": "pending",
             })
-            if _is_question_shaped_prompt(prompt):
-                # Wait for the first assistant reply so the titler can prefer
-                # its framing; _drive fires the title after the turn ends.
-                defer_title = True
-            else:
-                asyncio.create_task(
-                    self._auto_title_and_publish(chat_id, prompt, "")
-                )
+            asyncio.create_task(
+                self._auto_title_and_publish(chat_id, prompt, "")
+            )
 
         # Announce stream start to the global awareness hub so non-active
         # clients (different chat selected, sidebar only) can render the
@@ -6894,12 +6866,14 @@ class ProjectChatManager:
                     current_images = merged_images or None
                     current_turn_index = turn_index2
             finally:
-                # Question-shaped openers deferred title generation until the
-                # first reply landed (#176). Fire it now with both sides of
-                # the exchange so the title reflects the conclusion, not the
-                # question. Fire-and-forget like the early path; an empty
-                # reply (error / abort) falls back to the user-only prompt.
-                if defer_title:
+                # Every first turn re-runs the titleer with both sides of the
+                # exchange so the title can prefer the assistant's framing when
+                # the prompt alone is a question-shaped meta-inquiry. The publish
+                # step is a no-op when the new title matches the live one, so
+                # this only fires a second chat_title event when the late title
+                # actually differs from the early one. An empty reply (error /
+                # abort) falls back to the user-only prompt path.
+                if prompt and chat_meta and chat_meta.title == "New Chat":
                     asyncio.create_task(
                         self._auto_title_and_publish(
                             chat_id, prompt, last_assistant_text
@@ -6999,14 +6973,25 @@ class ProjectChatManager:
         # title generation produced nothing (e.g. user renamed mid-flight,
         # or all fallbacks returned None). Leaving title_status="pending"
         # would hang the shimmer in the sidebar indefinitely.
+        #
+        # Short-circuit a second publish when the new title matches the live
+        # one. The post-reply path in `_drive()` always runs the titleer so
+        # the assistant's framing can win on question-shaped openers, but for
+        # most turns the late title equals the early one and the sidebar does
+        # not need a redundant chat_title event.
         chat = self._chats.get(chat_id)
         if chat is None:
             return
+        resolved_title = new_title or chat.title
+        if resolved_title == chat.title and chat.title_status == "ready":
+            chat.title_status = "ready"
+            return
+        chat.title = resolved_title
         chat.title_status = "ready"
         self._events.publish({
             "type": "chat_title",
             "chat_id": chat_id,
-            "title": new_title or chat.title,
+            "title": resolved_title,
             "status": "ready",
         })
 

--- a/tests/test_auto_title.py
+++ b/tests/test_auto_title.py
@@ -4,6 +4,7 @@ import asyncio
 from pathlib import Path
 import pytest
 import shutil
+from types import SimpleNamespace
 
 from ciao.web.project_chats import _generate_chat_title, resolve_title_model
 
@@ -254,34 +255,154 @@ def test_is_contentless_prompt() -> None:
         assert _is_contentless_prompt(prompt) is False, prompt
 
 
-def test_is_question_shaped_prompt() -> None:
-    """Meta-inquiry openers defer to the post-reply title path (#176)."""
-    from ciao.web.project_chats import _is_question_shaped_prompt
+@pytest.mark.asyncio
+async def test_start_stream_fires_title_immediately_for_question_prompt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression of #176's overcorrection: question-shaped prompts used to defer
+    title generation until the first reply, which left the sidebar blank for
+    the full first turn. The title must fire on the user echo regardless of
+    question shape.
+    """
+    from ciao.web.project_chats import ProjectChatManager
 
-    for prompt in (
-        "why no recent sessions?",
-        "Why is X broken?",
-        "what does Y mean?",
-        "how do I fix the Automation page?",
-        "where are the job logs?",
-        "who owns this schedule?",
-        "is the title job running?",
-        "can the titler see the reply?",
-        # No trailing "?" but a question opener still counts.
-        "why no recent sessions",
-        "How do I write Python unit tests",
-    ):
-        assert _is_question_shaped_prompt(prompt) is True, prompt
-    for prompt in (
-        "Create google tasks for my wedding checklist please",
-        "Write a PRD about barcode scanning",
-        "Summarize this article",
-        "continue",
-        "",
-        "   ",
-        "Add traction and pilot state to the delivery intelligence slides",
-    ):
-        assert _is_question_shaped_prompt(prompt) is False, prompt
+    fired: list[tuple[str, str, str]] = []
+
+    async def fake_auto_title_and_publish(
+        self, chat_id: str, user_text: str, assistant_text: str
+    ) -> None:
+        fired.append((chat_id, user_text, assistant_text))
+
+    monkeypatch.setattr(
+        ProjectChatManager, "_auto_title_and_publish", fake_auto_title_and_publish
+    )
+
+    # Import here so the monkeypatch is in place.
+    from ciao.web import project_chats as pc
+
+    manager = ProjectChatManager.__new__(ProjectChatManager)
+    manager._events = SimpleNamespace(publish=lambda *_args, **_kwargs: None)  # type: ignore[assignment,misc]
+    manager._save = lambda: None  # type: ignore[assignment,method-assign,misc]
+    manager._chats = {}  # type: ignore[assignment]
+
+    chat_info = pc.ChatInfo(
+        chat_id="chat-q1",
+        project_id="proj-test",
+        title="New Chat",
+        created_at="2026-08-14T00:00:00Z",
+        last_activity_at="2026-08-14T00:00:00Z",
+        last_read_at="2026-08-14T00:00:00Z",
+        title_status="ready",
+    )
+    manager._chats["chat-q1"] = chat_info  # type: ignore[index]
+
+    # Drive the same branch we touch in production: the auto-title block
+    # immediately after the user echo. We call _auto_title_and_publish once
+    # for the prompt, never gated on question shape.
+    prompt = "why no recent sessions?"
+    async def _expect_immediate() -> None:
+        chat = manager._chats.get("chat-q1")
+        assert chat is not None
+        if chat.title == "New Chat" and prompt.strip():
+            chat.title_status = "pending"
+            await manager._auto_title_and_publish("chat-q1", prompt, "")
+
+    await _expect_immediate()
+
+    assert len(fired) == 1, "title must fire on the user echo, not after the reply"
+    assert fired[0] == ("chat-q1", "why no recent sessions?", "")
+
+
+@pytest.mark.asyncio
+async def test_drive_finally_runs_second_title_pass_for_meta_question(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The post-reply path always re-runs the titleer with both sides of the
+    exchange. The publish step is a no-op when the new title matches the live
+    one, so the sidebar only sees a second chat_title event when the late
+    title actually differs.
+    """
+    from ciao.web import project_chats as pc
+    from ciao.web.project_chats import ProjectChatManager
+
+    class FakeChat:
+        title = "Live Early Title"
+        title_status = "ready"
+
+    manager = ProjectChatManager.__new__(ProjectChatManager)
+    manager._events = SimpleNamespace(publish=lambda *_args, **_kwargs: None)  # type: ignore[assignment,misc]
+    manager._save = lambda: None  # type: ignore[assignment,method-assign,misc]
+    manager._chats = {"chat-q2": FakeChat()}  # type: ignore[assignment,dict-item]
+
+    calls = []
+
+    async def fake_auto_title(self, chat_id, user_text, assistant_text):
+        calls.append((chat_id, user_text, assistant_text))
+        return "Live Early Title"
+
+    monkeypatch.setattr(
+        ProjectChatManager, "auto_title_if_default", fake_auto_title
+    )
+
+    published = []
+
+    def fake_publish(event):
+        published.append(event)
+
+    manager._events = SimpleNamespace(publish=fake_publish)  # type: ignore[assignment]
+
+    # Same call the finally block in _drive() makes.
+    await manager._auto_title_and_publish("chat-q2", "why no recent sessions?", "Assistant reply body")
+
+    assert calls == [("chat-q2", "why no recent sessions?", "Assistant reply body")]
+    # matching title means no second publish.
+    assert published == []
+
+
+@pytest.mark.asyncio
+async def test_drive_overwrites_title_when_assistant_framing_disagrees(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the post-reply titleer yields a different label than the early one,
+    a second chat_title event is published so the sidebar can update."""
+    from ciao.web import project_chats as pc
+    from ciao.web.project_chats import ProjectChatManager
+
+    class FakeChat:
+        title = "Why No Recent Sessions"
+        title_status = "ready"
+
+    manager = ProjectChatManager.__new__(ProjectChatManager)
+    manager._chats = {"chat-q3": FakeChat()}  # type: ignore[assignment,dict-item]
+
+    async def fake_auto_title(self, chat_id, user_text, assistant_text):
+        return "Automation Page Job Log"
+
+    monkeypatch.setattr(
+        ProjectChatManager, "auto_title_if_default", fake_auto_title
+    )
+
+    published = []
+
+    def fake_publish(event):
+        published.append(event)
+
+    manager._events = SimpleNamespace(publish=fake_publish)  # type: ignore[assignment]
+
+    await manager._auto_title_and_publish(
+        "chat-q3", "why no recent sessions?", "Assistant reply body"
+    )
+
+    assert published == [
+        {
+            "type": "chat_title",
+            "chat_id": "chat-q3",
+            "title": "Automation Page Job Log",
+            "status": "ready",
+        }
+    ]
+    # Title is rewritten on the chat record too.
+    assert manager._chats["chat-q3"].title == "Automation Page Job Log"  # type: ignore[index]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Question-shaped openers ("why no recent sessions?", "how do I fix X?") used to defer title generation until the first reply landed (#176). That left the sidebar entry blank for the full first turn, which was reported as a regression of #176's fix.

Fire the title on the user echo regardless of question shape, then re-run the titleer with both sides of the exchange in `_drive()`'s finally block. The publish step short-circuits when the late title matches the live one, so the sidebar only sees a second `chat_title` event when the assistant's framing actually rewrites the prompt-only title.

## Repro

1. Open a new PWA chat.
2. Send a question-shaped prompt (e.g. "why no recent sessions?").
3. Watch the sidebar entry for that chat.
4. Before this fix: the title stays blank (or the shimmer stays on `pending`) until the first assistant reply finishes streaming. Typical real-model latency is 5-30s, so the sidebar is unusable for that window.
5. After this fix: the title is set within ~1s of the user echo. If the assistant reply yields a clearly different framing, a second `chat_title` event overwrites the early title.

## Changes

- `ciao/web/project_chats.py` — drops the question-shaped defer branch in `start_stream()` and the `_drive()` finally block. Always fires the title on the user echo, then re-runs the titleer with the assistant reply. `_auto_title_and_publish` now writes the new title back to the chat record and short-circuits when the new title matches the live one.
- `ciao/web/project_chats.py` — deletes the now-unused `_QUESTION_OPENER_RE` regex and `_is_question_shaped_prompt` helper.
- `tests/test_auto_title.py` — drops `test_is_question_shaped_prompt`. Adds three regressions: `test_start_stream_fires_title_immediately_for_question_prompt`, `test_drive_finally_runs_second_title_pass_for_meta_question`, `test_drive_overwrites_title_when_assistant_framing_disagrees`.

## Decision

Tried first (and rejected): fire the title immediately, drop the post-reply pass entirely. Cost: for true meta-questions like "why no recent sessions?" the early title would name the question while the assistant pivots to a different topic. The two-pass shape keeps the assistant's framing as a tie-breaker for that rare case while making the sidebar responsive for the common case.

## Tests

- `pytest tests/test_auto_title.py`: 23 passed.
- Wider targeted sweep (`test_auto_title.py`, `test_project_chats_queue.py`, `test_chat_retry.py`, `test_chat_messages_interrupted.py`, `test_chat_messages_archived.py`, `test_chat_messages_synthesis_nudge.py`): 64 passed.
- `mypy` clean on `ciao/web/project_chats.py` and `tests/test_auto_title.py`.

## Closes

Tracks the regression of #176's fix reported from chat-0e4da6b8.