### PR TITLE
feat(gws): one-click 'Sign in with Google' via the loopback re-login flow

### DIFF
--- a/ciao/gws_auth.py
+++ b/ciao/gws_auth.py
@@ -234,6 +234,31 @@ def load_client_secret(config_dir: Path) -> dict[str, Any]:
     return installed
 
 
+def client_uses_loopback(config_dir: Path | None) -> bool:
+    """Whether a profile's OAuth client can use the random-port loopback redirect.
+
+    ``GwsReloginManager.start`` always redirects to ``http://127.0.0.1:<port>/``.
+    Installed/desktop clients accept any loopback port, but *web* clients require
+    an exact authorized redirect URI match, so the one-click flow cannot complete
+    for them. Returns ``False`` when the client is a ``web`` app, and ``True``
+    for an ``installed``/desktop client (or when the file is absent, so the UI
+    can still offer the button before an upload).
+    """
+    if config_dir is None:
+        return True
+    secret_path = config_dir / "client_secret.json"
+    if not secret_path.is_file():
+        return True
+    try:
+        with open(secret_path, "r", encoding="utf-8") as handle:
+            secret = json.load(handle)
+    except (OSError, ValueError):
+        return True
+    # A web section (with no installed section) is the incompatible case.
+    return bool(secret.get("installed")) or not bool(secret.get("web"))
+
+
+
 # ── Consent URL + token exchange (shared by all flows) ───────────────────
 
 

--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -1440,6 +1440,11 @@ def _gws_profile_payload(
         token_error = str(health.get("token_error") or "")
         needs_relogin = not token_valid
 
+    # Installed/desktop OAuth clients accept any loopback port, so the one-click
+    # loopback flow works for them; web clients require a registered redirect
+    # URI and must use the manual paste flow instead.
+    loopback_eligible = bool(gws_auth.client_uses_loopback(config_dir))
+
     return {
         "name": profile,
         "label": meta["label"],
@@ -1458,6 +1463,7 @@ def _gws_profile_payload(
         "token_valid": token_valid,
         "token_error": token_error,
         "needs_relogin": needs_relogin,
+        "loopback_eligible": loopback_eligible,
     }
 
 

--- a/tests/test_gws_auth.py
+++ b/tests/test_gws_auth.py
@@ -162,6 +162,26 @@ def test_store_credentials_omits_scopes_when_none_granted(tmp_path: Path) -> Non
     assert "scopes" not in creds
 
 
+def test_client_uses_loopback_detects_web_clients(tmp_path: Path) -> None:
+    config_dir = tmp_path / "secrets" / "gws-personal"
+    config_dir.mkdir(parents=True)
+    # Web-only client: the one-click loopback flow cannot work.
+    (config_dir / "client_secret.json").write_text(
+        json.dumps({"web": {"client_id": "cid", "client_secret": "s"}}),
+        encoding="utf-8",
+    )
+    assert gws_auth.client_uses_loopback(config_dir) is False
+    # Desktop/installed client (with no web section): loopback is fine.
+    (config_dir / "client_secret.json").write_text(
+        json.dumps({"installed": {"client_id": "cid", "client_secret": "s"}}),
+        encoding="utf-8",
+    )
+    assert gws_auth.client_uses_loopback(config_dir) is True
+    # Missing file / no dir → True so the UI can still offer the button.
+    assert gws_auth.client_uses_loopback(tmp_path / "nope") is True
+    assert gws_auth.client_uses_loopback(None) is True
+
+
 def test_exchange_and_store_uses_injected_exchange(tmp_path: Path, monkeypatch) -> None:
     cfg = _config(tmp_path)
     config_dir = gws_auth.profile_config_dir(cfg, "personal")

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -3251,6 +3251,10 @@ async function handleClientSecretUpload(event: Event, profileName: string) {
 
 async function startGwsAuth(profileName: string) {
   gwsSavingProfile.value = profileName
+  // A prior one-click failure (e.g. the remote-browser guard) leaves an error
+  // that would otherwise win over the manual-flow box and hide it.
+  delete gwsReloginError.value[profileName]
+  delete gwsReloginPending.value[profileName]
   try {
     const res = await api.post<{ auth_url: string }>('/api/integrations/gws/auth-url', {
       profile: profileName,

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -3079,13 +3079,14 @@ function gwsReloginHelpUrl(): string {
 
 // The loopback re-login listener binds to the *engine's* 127.0.0.1, so the
 // consent redirect only reaches it when the browser is on the engine host
-// (localhost). From a phone, LAN browser, or client-mode node the popup's
-// redirect would target the client's own loopback and never arrive — those
-// users must use the manual paste flow instead.
+// (localhost) and the integration API is not proxied to a remote host. From a
+// phone, LAN browser, or client-mode node the popup's redirect would target
+// the client's own loopback and never arrive — those users must use the
+// manual paste flow instead.
 function gwsOnEngineHost(): boolean {
-  if (inDesktopApp) return true
+  if (inDesktopApp && !isNodeClient.value) return true
   const host = window.location.hostname
-  return host === 'localhost' || host === '127.0.0.1' || host === '[::1]'
+  return !isNodeClient.value && (host === 'localhost' || host === '127.0.0.1' || host === '[::1]')
 }
 
 async function gwsReloginStart(profileName: string) {
@@ -3122,6 +3123,16 @@ async function gwsReloginStart(profileName: string) {
   }
 }
 
+function gwsClearRelogin(profileName: string) {
+  delete gwsReloginPending.value[profileName]
+  delete gwsReloginError.value[profileName]
+  // The fallback auth URL belongs to a now-finished loopback session; clearing
+  // it keeps the card out of a stale manual-flow state and un-hides the
+  // authenticated controls on success.
+  delete gwsAuthUrls.value[profileName]
+  delete gwsRedirectUrls.value[profileName]
+}
+
 function gwsPollRelogin(profileName: string) {
   if (gwsReloginTimer) return
   gwsReloginTimer = setInterval(async () => {
@@ -3141,30 +3152,30 @@ function gwsPollRelogin(profileName: string) {
           `/api/integrations/gws/relogin/status?profile=${encodeURIComponent(name)}`,
         )
         if (status.status === 'completed') {
-          delete gwsReloginPending.value[name]
-          delete gwsReloginError.value[name]
+          gwsClearRelogin(name)
           await fetchGwsIntegration()
           notifySaved('Google account connected.')
         } else if (status.status === 'error' || status.status === 'none') {
-          delete gwsReloginPending.value[name]
-          gwsReloginError.value[name] =
+          const msg =
             status.error ||
             (status.status === 'none'
               ? 'The sign-in timed out before you finished it. Try again.'
               : 'The sign-in failed.')
+          gwsClearRelogin(name)
+          gwsReloginError.value[name] = msg
           await fetchGwsIntegration()
         }
       } catch (e) {
-        delete gwsReloginPending.value[name]
-        gwsReloginError.value[name] = errorMessage(e, 'Could not check the sign-in status.')
+        const msg = errorMessage(e, 'Could not check the sign-in status.')
+        gwsClearRelogin(name)
+        gwsReloginError.value[name] = msg
       }
     }
   }, 2000)
 }
 
 function gwsReloginCancel(profileName: string) {
-  delete gwsReloginPending.value[profileName]
-  delete gwsReloginError.value[profileName]
+  gwsClearRelogin(profileName)
   api.post('/api/integrations/gws/relogin/cancel', { profile: profileName }).catch(() => {})
 }
 

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -1372,6 +1372,14 @@
                           Re-authenticate
                         </button>
                         <button
+                          v-if="profile.needs_relogin"
+                          class="btn-small"
+                          :disabled="gwsSavingProfile === profile.name"
+                          @click="startGwsAuth(profile.name)"
+                        >
+                          Manual connect (paste code)
+                        </button>
+                        <button
                           class="btn-small btn-danger"
                           @click="disconnectGwsProfile(profile.name, false)"
                           :disabled="gwsSavingProfile === profile.name"
@@ -1398,6 +1406,39 @@
                         <button class="btn-small" @click="gwsReloginCancel(profile.name)">Cancel</button>
                       </p>
                       <p v-else-if="gwsReloginError[profile.name]" class="gws-action-hint hint--warn">{{ gwsReloginError[profile.name] }}</p>
+                      <div v-else-if="gwsAuthUrls[profile.name]" class="gws-auth-flow-box">
+                        <p class="gws-flow-step">
+                          1. Follow the Google auth flow. If the browser did not open, click here:
+                          <a :href="gwsAuthUrls[profile.name]" target="_blank" class="gws-auth-link">Open authorization page</a>
+                        </p>
+                        <p class="gws-flow-step">
+                          2. After signing in, copy the full redirect URL (even if it fails to load) or authorization code, and paste it below:
+                        </p>
+                        <input
+                          type="text"
+                          class="routine-input gws-auth-input"
+                          v-model="gwsRedirectUrls[profile.name]"
+                          placeholder="Paste redirect URL (http://localhost/?code=...) or code"
+                          :disabled="gwsSavingProfile === profile.name"
+                          @keyup.enter="exchangeGwsCode(profile.name)"
+                        />
+                        <div class="gws-flow-buttons">
+                          <button
+                            class="btn-primary btn-small"
+                            @click="exchangeGwsCode(profile.name)"
+                            :disabled="!gwsRedirectUrls[profile.name]?.trim() || gwsSavingProfile === profile.name"
+                          >
+                            {{ gwsSavingProfile === profile.name ? 'Connecting...' : 'Complete Sign-In' }}
+                          </button>
+                          <button
+                            class="btn-small"
+                            @click="cancelGwsAuth(profile.name)"
+                            :disabled="gwsSavingProfile === profile.name"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
                     </template>
                   </div>
                 </div>

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -1103,16 +1103,26 @@
                         <li>Install <code>gws</code> (button below or <code>npm install -g @googleworkspace/cli</code>).</li>
                         <li>Add the account below and give it a short name.</li>
                         <li>
-                          In
-                          <a href="https://console.cloud.google.com/apis/credentials" target="_blank" rel="noopener noreferrer">Google Cloud Console &rarr; Credentials</a>,
-                          create an OAuth client (Desktop app, or Web app with redirect URI <code>http://localhost</code>).
+                          Click <strong>Sign in with Google</strong> on the account card and approve access in the browser
+                          tab that opens. It connects automatically (no copy-paste).
                         </li>
-                        <li>Download the JSON file Google gives you (often named like <code>client_secret_….json</code>).</li>
-                        <li>Upload it below as <code>client_secret.json</code>, then click <strong>Connect Google Account</strong>.</li>
                       </ol>
+                      <p><strong>Alternative setups</strong></p>
+                      <ul class="field-info-steps">
+                        <li>
+                          <strong>gcloud (no console needed):</strong> install the
+                          <a href="https://cloud.google.com/sdk/docs/install" target="_blank" rel="noopener noreferrer">gcloud CLI</a>,
+                          authenticate once, then run
+                          <code>scripts/gws-profile.sh &lt;profile&gt; auth setup</code>. Ciaobot auto-detects the account.
+                        </li>
+                        <li>
+                          <strong>Bring your own client:</strong> in
+                          <a href="https://console.cloud.google.com/apis/credentials" target="_blank" rel="noopener noreferrer">Google Cloud Console &rarr; Credentials</a>
+                          create an OAuth client (Desktop app), download the JSON, and upload it as <code>client_secret.json</code>.
+                        </li>
+                      </ul>
                       <p>
                         Enable the APIs you need in your GCP project (Gmail, Calendar, Drive, Docs, Sheets, Slides, Tasks).
-                        Terminal alternative: <code>scripts/gws-profile.sh &lt;profile&gt; auth login --full</code>.
                       </p>
                     </div>
                   </details>
@@ -1256,10 +1266,15 @@
                     <!-- State 1: Needs client_secret.json -->
                     <template v-if="!profile.client_secret_present">
                       <p class="gws-action-hint">
-                        Upload your OAuth <code>client_secret.json</code> to start (see the ⓘ button above for Google Cloud setup steps).
+                        First, create an OAuth client. Easiest: run
+                        <code>scripts/gws-profile.sh {{ profile.name }} auth setup</code>
+                        in a terminal with the
+                        <a :href="gwsReloginHelpUrl()" target="_blank" rel="noopener noreferrer">gcloud CLI</a>
+                        installed — it creates the client for you. Or upload one you made in
+                        <a href="https://console.cloud.google.com/apis/credentials" target="_blank" rel="noopener noreferrer">Google Cloud Console</a>.
                       </p>
                       <label class="btn-small file-upload-btn">
-                        Choose JSON file
+                        Upload client_secret.json
                         <input
                           type="file"
                           accept=".json"
@@ -1272,13 +1287,20 @@
 
                     <!-- State 2: Ready to authenticate -->
                     <template v-else-if="!profile.configured">
-                      <div v-if="!gwsAuthUrls[profile.name]" class="gws-btn-group">
+                      <div v-if="!gwsAuthUrls[profile.name] && !gwsReloginPending[profile.name]" class="gws-btn-group">
                         <button
                           class="btn-primary btn-small"
-                          @click="startGwsAuth(profile.name)"
                           :disabled="gwsSavingProfile === profile.name"
+                          @click="gwsReloginStart(profile.name)"
                         >
-                          Connect Google Account
+                          Sign in with Google
+                        </button>
+                        <button
+                          class="btn-small"
+                          :disabled="gwsSavingProfile === profile.name"
+                          @click="startGwsAuth(profile.name)"
+                        >
+                          Manual connect (paste code)
                         </button>
                         <button
                           class="btn-small btn-danger"
@@ -1288,7 +1310,12 @@
                           Remove OAuth Client
                         </button>
                       </div>
-                      <div v-else class="gws-auth-flow-box">
+                      <p v-if="gwsReloginPending[profile.name]" class="gws-action-hint">
+                        Sign-in in progress: complete it in the browser tab that opened. It will connect automatically.
+                        <button class="btn-small" @click="gwsReloginCancel(profile.name)">Cancel</button>
+                      </p>
+                      <p v-else-if="gwsReloginError[profile.name]" class="gws-action-hint hint--warn">{{ gwsReloginError[profile.name] }}</p>
+                      <div v-else-if="gwsAuthUrls[profile.name]" class="gws-auth-flow-box">
                         <p class="gws-flow-step">
                           1. Follow the Google auth flow. If the browser did not open, click here:
                           <a :href="gwsAuthUrls[profile.name]" target="_blank" class="gws-auth-link">Open authorization page</a>
@@ -1327,10 +1354,17 @@
                     <template v-else>
                       <p v-if="profile.needs_relogin" class="gws-action-hint hint--warn">
                         This login has expired or been revoked<span v-if="profile.token_error"> ({{ profile.token_error }})</span>.
-                        Re-authenticate: click <strong>Disconnect Account</strong> then <strong>Connect Google Account</strong>,
-                        or ask the assistant to re-login (it uses the server-managed re-login endpoint).
+                        Sign back in to restore Gmail, Calendar, Drive, and scheduled Google tasks.
                       </p>
-                      <div class="gws-btn-group">
+                      <div v-if="!gwsAuthUrls[profile.name] && !gwsReloginPending[profile.name]" class="gws-btn-group">
+                        <button
+                          v-if="profile.needs_relogin"
+                          class="btn-primary btn-small"
+                          :disabled="gwsSavingProfile === profile.name"
+                          @click="gwsReloginStart(profile.name)"
+                        >
+                          Re-authenticate
+                        </button>
                         <button
                           class="btn-small btn-danger"
                           @click="disconnectGwsProfile(profile.name, false)"
@@ -1347,6 +1381,11 @@
                           Remove Client & Credentials
                         </button>
                       </div>
+                      <p v-if="gwsReloginPending[profile.name]" class="gws-action-hint">
+                        Re-authentication in progress: complete it in the browser tab that opened. It will connect automatically.
+                        <button class="btn-small" @click="gwsReloginCancel(profile.name)">Cancel</button>
+                      </p>
+                      <p v-else-if="gwsReloginError[profile.name]" class="gws-action-hint hint--warn">{{ gwsReloginError[profile.name] }}</p>
                     </template>
                   </div>
                 </div>
@@ -2012,7 +2051,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { api } from '../lib/api'
 import { errorMessage, apiErrorMessage, errorPayload, errorPayloadList } from '../lib/errorMessage'
@@ -3013,6 +3052,84 @@ async function installGws() {
 const gwsSavingProfile = ref<string | null>(null)
 const gwsAuthUrls = ref<Record<string, string>>({})
 const gwsRedirectUrls = ref<Record<string, string>>({})
+
+// One-click "Sign in with Google" loopback flow (issue #145). Tracks, per
+// profile, whether a server-managed re-login is pending so the Settings card
+// can poll `relogin/status` until it completes instead of copy-pasting a
+// redirect URL. Mirrors the manual JSON-upload flow as the power-user path.
+const gwsReloginPending = ref<Record<string, boolean>>({})
+const gwsReloginError = ref<Record<string, string>>({})
+let gwsReloginTimer: ReturnType<typeof setInterval> | null = null
+
+function gwsReloginHelpUrl(): string {
+  return 'https://cloud.google.com/sdk/docs/install'
+}
+
+async function gwsReloginStart(profileName: string) {
+  gwsReloginError.value[profileName] = ''
+  gwsSavingProfile.value = profileName
+  try {
+    const res = await api.post<{ auth_url: string }>('/api/integrations/gws/relogin/start', {
+      profile: profileName,
+    })
+    gwsReloginPending.value[profileName] = true
+    window.open(res.auth_url, '_blank')
+    gwsPollRelogin(profileName)
+  } catch (e) {
+    gwsReloginError.value[profileName] = errorMessage(e, 'Could not start the sign-in flow.')
+  } finally {
+    gwsSavingProfile.value = null
+  }
+}
+
+function gwsPollRelogin(profileName: string) {
+  if (gwsReloginTimer) return
+  gwsReloginTimer = setInterval(async () => {
+    const pending = Object.entries(gwsReloginPending.value)
+      .filter(([, p]) => p)
+      .map(([name]) => name)
+    if (!pending.length) {
+      if (gwsReloginTimer) {
+        clearInterval(gwsReloginTimer)
+        gwsReloginTimer = null
+      }
+      return
+    }
+    for (const name of pending) {
+      try {
+        const status = await api.get<{ status: string; email?: string; error?: string }>(
+          `/api/integrations/gws/relogin/status?profile=${encodeURIComponent(name)}`,
+        )
+        if (status.status === 'completed') {
+          delete gwsReloginPending.value[name]
+          delete gwsReloginError.value[name]
+          await fetchGwsIntegration()
+          notifySaved('Google account connected.')
+        } else if (status.status === 'error') {
+          delete gwsReloginPending.value[name]
+          gwsReloginError.value[name] = status.error || 'The sign-in failed.'
+          await fetchGwsIntegration()
+        }
+      } catch (e) {
+        delete gwsReloginPending.value[name]
+        gwsReloginError.value[name] = errorMessage(e, 'Could not check the sign-in status.')
+      }
+    }
+  }, 2000)
+}
+
+function gwsReloginCancel(profileName: string) {
+  delete gwsReloginPending.value[profileName]
+  delete gwsReloginError.value[profileName]
+  api.post('/api/integrations/gws/relogin/cancel', { profile: profileName }).catch(() => {})
+}
+
+onUnmounted(() => {
+  if (gwsReloginTimer) {
+    clearInterval(gwsReloginTimer)
+    gwsReloginTimer = null
+  }
+})
 
 async function handleClientSecretUpload(event: Event, profileName: string) {
   const target = event.target as HTMLInputElement

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -1311,7 +1311,13 @@
                         </button>
                       </div>
                       <p v-if="gwsReloginPending[profile.name]" class="gws-action-hint">
-                        Sign-in in progress: complete it in the browser tab that opened. It will connect automatically.
+                        <template v-if="gwsAuthUrls[profile.name]">
+                          The sign-in tab was blocked. Open this link, then finish in the browser — it connects automatically:
+                          <a :href="gwsAuthUrls[profile.name]" target="_blank" class="gws-auth-link">Open authorization page</a>
+                        </template>
+                        <template v-else>
+                          Sign-in in progress: complete it in the browser tab that opened. It will connect automatically.
+                        </template>
                         <button class="btn-small" @click="gwsReloginCancel(profile.name)">Cancel</button>
                       </p>
                       <p v-else-if="gwsReloginError[profile.name]" class="gws-action-hint hint--warn">{{ gwsReloginError[profile.name] }}</p>
@@ -1382,7 +1388,13 @@
                         </button>
                       </div>
                       <p v-if="gwsReloginPending[profile.name]" class="gws-action-hint">
-                        Re-authentication in progress: complete it in the browser tab that opened. It will connect automatically.
+                        <template v-if="gwsAuthUrls[profile.name]">
+                          The re-auth tab was blocked. Open this link, then finish in the browser — it connects automatically:
+                          <a :href="gwsAuthUrls[profile.name]" target="_blank" class="gws-auth-link">Open authorization page</a>
+                        </template>
+                        <template v-else>
+                          Re-authentication in progress: complete it in the browser tab that opened. It will connect automatically.
+                        </template>
                         <button class="btn-small" @click="gwsReloginCancel(profile.name)">Cancel</button>
                       </p>
                       <p v-else-if="gwsReloginError[profile.name]" class="gws-action-hint hint--warn">{{ gwsReloginError[profile.name] }}</p>
@@ -3065,17 +3077,45 @@ function gwsReloginHelpUrl(): string {
   return 'https://cloud.google.com/sdk/docs/install'
 }
 
+// The loopback re-login listener binds to the *engine's* 127.0.0.1, so the
+// consent redirect only reaches it when the browser is on the engine host
+// (localhost). From a phone, LAN browser, or client-mode node the popup's
+// redirect would target the client's own loopback and never arrive — those
+// users must use the manual paste flow instead.
+function gwsOnEngineHost(): boolean {
+  if (inDesktopApp) return true
+  const host = window.location.hostname
+  return host === 'localhost' || host === '127.0.0.1' || host === '[::1]'
+}
+
 async function gwsReloginStart(profileName: string) {
   gwsReloginError.value[profileName] = ''
+  if (!gwsOnEngineHost()) {
+    gwsReloginError.value[profileName] =
+      'One-click sign-in only works from a browser on this machine. Use Manual connect (paste code) instead.'
+    return
+  }
   gwsSavingProfile.value = profileName
+  // Open a placeholder tab synchronously so the browser does not treat it as a
+  // popup (blocked outside the click's user-activation window); navigate it to
+  // the consent URL once the backend hands one back. If the popup is blocked,
+  // surface the link so the flow can still proceed manually.
+  const tab = window.open('', '_blank')
   try {
     const res = await api.post<{ auth_url: string }>('/api/integrations/gws/relogin/start', {
       profile: profileName,
     })
     gwsReloginPending.value[profileName] = true
-    window.open(res.auth_url, '_blank')
+    if (tab && tab.location) {
+      tab.location.href = res.auth_url
+    } else {
+      gwsReloginError.value[profileName] =
+        'The sign-in tab was blocked by the browser. Open this link, then finish here:'
+      gwsAuthUrls.value[profileName] = res.auth_url
+    }
     gwsPollRelogin(profileName)
   } catch (e) {
+    if (tab) tab.close()
     gwsReloginError.value[profileName] = errorMessage(e, 'Could not start the sign-in flow.')
   } finally {
     gwsSavingProfile.value = null
@@ -3105,9 +3145,13 @@ function gwsPollRelogin(profileName: string) {
           delete gwsReloginError.value[name]
           await fetchGwsIntegration()
           notifySaved('Google account connected.')
-        } else if (status.status === 'error') {
+        } else if (status.status === 'error' || status.status === 'none') {
           delete gwsReloginPending.value[name]
-          gwsReloginError.value[name] = status.error || 'The sign-in failed.'
+          gwsReloginError.value[name] =
+            status.error ||
+            (status.status === 'none'
+              ? 'The sign-in timed out before you finished it. Try again.'
+              : 'The sign-in failed.')
           await fetchGwsIntegration()
         }
       } catch (e) {

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -1289,6 +1289,7 @@
                     <template v-else-if="!profile.configured">
                       <div v-if="!gwsAuthUrls[profile.name] && !gwsReloginPending[profile.name]" class="gws-btn-group">
                         <button
+                          v-if="profile.loopback_eligible"
                           class="btn-primary btn-small"
                           :disabled="gwsSavingProfile === profile.name"
                           @click="gwsReloginStart(profile.name)"
@@ -1364,7 +1365,7 @@
                       </p>
                       <div v-if="!gwsAuthUrls[profile.name] && !gwsReloginPending[profile.name]" class="gws-btn-group">
                         <button
-                          v-if="profile.needs_relogin"
+                          v-if="profile.needs_relogin && profile.loopback_eligible"
                           class="btn-primary btn-small"
                           :disabled="gwsSavingProfile === profile.name"
                           @click="gwsReloginStart(profile.name)"

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -651,6 +651,10 @@ export interface GwsIntegrationProfile {
   token_valid: boolean | null
   token_error: string
   needs_relogin: boolean
+  // Whether the OAuth client accepts the random-port loopback redirect used by
+  // the one-click sign-in flow (false for web-type clients, which need an
+  // exact authorized redirect URI and therefore the manual paste flow).
+  loopback_eligible: boolean
 }
 
 export interface GwsIntegrationSettings {


### PR DESCRIPTION
## What

Wire the already-built server-managed GWS re-login endpoints into the Settings UI as a one-click `Sign in with Google` connect — no more copy-pasting redirect URLs.

## Background

The loopback OAuth flow (`GwsReloginManager`, issue #145) and its three routes (`/api/integrations/gws/relogin/{start,status,cancel}`) already existed, but nothing in the UI or agent could reach them: the profile card only offered the manual upload-`client_secret.json` → open-URL → paste-code path. This wires that existing machinery into a real button.

## Changes

`web/src/components/SettingsView.vue`:
- **State 1** (no client): clearer guidance — gcloud `auth setup` shortcut (with install link) or upload `client_secret.json`.
- **State 2** (client present, not authed): primary **Sign in with Google** button that calls `relogin/start`, opens the consent URL, and polls `relogin/status` until it completes. **Manual connect (paste code)** kept as a secondary path.
- **State 3** (authed, login expired): a **Re-authenticate** button reuses the same loopback flow.
- Polling is debounced per-profile and cleaned up on unmount.

The JSON-upload `client_secret.json` method is unchanged.

## Verification
- `pytest tests/test_gws_relogin_routes.py tests/test_gws_auth.py tests/test_gws_skills.py` → 46 passed (loopback endpoints already covered).
- `cd web && npm run build` → type-check (`vue-tsc --noEmit`) + build succeed.