### PR TITLE
fix(settings): surface npm output on gws install failure

### DIFF
--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -3106,8 +3106,15 @@ async function installGws() {
       gwsInstallResult.value = gwsInstallOutput.value ? `${base}: ${gwsInstallOutput.value.slice(0, 500)}` : base
     }
   } catch (e) {
+    // A failed `npm install` returns HTTP 500 carrying the diagnostic stream
+    // in `payload.output`; the api wrapper throws an ApiError for that status,
+    // so the `res.ok === false` branch above is unreachable here. Surface the
+    // output so Fix in Chat gets the real reason (e.g. EACCES), not just the
+    // exit code.
+    const payload = errorPayload(e)
+    const output = typeof payload?.output === 'string' ? payload.output : ''
     gwsInstallResult.value = `Error installing gws: ${errorMessage(e)}`
-    gwsInstallOutput.value = errorMessage(e)
+    gwsInstallOutput.value = output || errorMessage(e)
   } finally {
     gwsInstalling.value = false
   }


### PR DESCRIPTION
## Summary

Addresses the Codex review comment on the `installGws` catch in `web/src/components/SettingsView.vue`: the Fix in Chat action never received the npm diagnostic output it was added to diagnose.

## Problem

When `npm install -g` exits nonzero, the backend `gws_install` returns HTTP 500 with the diagnostic stream in `payload.output` (`ciao/web/routes_api.py:1561-1569`). The shared `api` wrapper throws an `ApiError` for that status carrying the payload, so the `res.ok === false` branch in `installGws` is unreachable. The catch only surfaced `errorMessage(e)` — e.g. `npm exited with code 243` — dropping the EACCES details Fix in Chat needs.

## Fix

In the catch, read `output` from the error payload via the existing `errorPayload` helper, falling back to the message when no output is present:

```ts
const payload = errorPayload(e)
const output = typeof payload?.output === 'string' ? payload.output : ''
gwsInstallResult.value = `Error installing gws: ${errorMessage(e)}`
gwsInstallOutput.value = output || errorMessage(e)
```

`errorPayload` was already imported. `fixGwsInstallErrorInChat` already feeds `gwsInstallOutput` into the chat, so the EACCES detail now reaches the agent.

## Tests

`cd web && npm run lint` — 0 errors. `npm run test` — 826 passed.