### PR TITLE
fix(settings): drop dead Save Keys UI, unstick Claude MCP/skill detection

### DIFF
--- a/ciao/setup_status.py
+++ b/ciao/setup_status.py
@@ -25,6 +25,16 @@ from ciao import provider_registry
 # Claude MCP / skill discovery shells out; cache briefly so Settings refreshes
 # stay responsive without freezing status until process restart.
 _CLAUDE_DISCOVERY_TTL_SECONDS = 300.0
+# An empty discovery is usually a timeout or a transient health-check failure,
+# not a real "nothing connected" answer. Serve it only briefly so the
+# stale-while-revalidate retry lands within seconds instead of showing "(0)"
+# for the full success TTL.
+_CLAUDE_DISCOVERY_EMPTY_TTL_SECONDS = 15.0
+# ``claude mcp list`` health-checks every configured connector before printing.
+# With ~30 claude.ai connectors a healthy run measures ~11-12s, and under load
+# it blows past 12s — at which point the old timeout swallowed the error and
+# cached the empty list for five minutes. Give the health pass real headroom.
+_CLAUDE_MCP_LIST_TIMEOUT_SECONDS = 30.0
 logger = logging.getLogger(__name__)
 
 _claude_mcps_cache: tuple[float, str, tuple[str, ...]] | None = None
@@ -176,7 +186,7 @@ def _cli_version(binary: str) -> str:
 
 
 def discover_claude_system_skills() -> list[str]:
-    """Discover enabled Claude Code plugins via CLI, falling back to installed_plugins.json."""
+    """Discover enabled Claude Code plugins plus standalone ~/.claude/skills."""
     global _claude_skills_cache
     now = time.monotonic()
     if (
@@ -190,7 +200,13 @@ def discover_claude_system_skills() -> list[str]:
     return skills
 
 
+def _claude_standalone_skills_dir() -> Path:
+    """Directory of standalone (non-plugin) Claude skills, injectable for tests."""
+    return Path.home() / ".claude" / "skills"
+
+
 def _discover_claude_system_skills_uncached() -> list[str]:
+    skills: set[str] = set()
     binary = claude_cli_path()
     if binary:
         try:
@@ -202,7 +218,6 @@ def _discover_claude_system_skills_uncached() -> list[str]:
             # Claude Code uses a multi-line block format:
             #   ❯ plugin-name@source
             #     Status: ✔ enabled  (or ✘ disabled)
-            skills: set[str] = set()
             current_name: str | None = None
             for line in output.splitlines():
                 stripped = line.strip()
@@ -212,27 +227,27 @@ def _discover_claude_system_skills_uncached() -> list[str]:
                     if "enabled" in stripped and "disabled" not in stripped:
                         skills.add(current_name)
                     current_name = None
-            if skills:
-                return sorted(skills)
         except Exception:
             pass
-    # Fallback: read installed_plugins.json (all installed regardless of enabled state)
-    skills_fb: set[str] = set()
-    installed_json = Path.home() / ".claude" / "plugins" / "installed_plugins.json"
-    if installed_json.is_file():
-        try:
-            data = json.loads(installed_json.read_text(encoding="utf-8"))
-            plugins = data.get("plugins", {})
-            for key in plugins.keys():
-                skills_fb.add(str(key).split("@")[0])
-        except Exception:
-            pass
-    skills_dir = Path.home() / ".claude" / "skills"
+    # Standalone skills under ~/.claude/skills never appear in `claude plugin
+    # list`, so merge them in whether or not the CLI reported plugins.
+    skills_dir = _claude_standalone_skills_dir()
     if skills_dir.is_dir():
-        for f in skills_dir.glob("*"):
-            if f.is_dir() or f.name.endswith(".md"):
-                skills_fb.add(f.stem)
-    return sorted(skills_fb)
+        for entry in skills_dir.glob("*"):
+            if entry.is_dir() or entry.name.endswith(".md"):
+                skills.add(entry.stem)
+    if not skills:
+        # Nothing enabled and no standalone skills: fall back to listing every
+        # installed plugin so the page still shows something actionable.
+        installed_json = Path.home() / ".claude" / "plugins" / "installed_plugins.json"
+        if installed_json.is_file():
+            try:
+                data = json.loads(installed_json.read_text(encoding="utf-8"))
+                for key in (data.get("plugins") or {}).keys():
+                    skills.add(str(key).split("@")[0])
+            except Exception:
+                pass
+    return sorted(skills)
 
 
 def discover_claude_mcps(
@@ -246,19 +261,26 @@ def discover_claude_mcps(
     in the per-project ``/mcp`` panel. Those disables live in
     ``~/.claude.json`` → ``projects.<path>.disabledMcpServers``.
 
-    Served stale-while-revalidate: ``claude mcp list`` measures ~12s on a real
-    install, and it is on the Settings -> Providers load path, so a plain TTL
-    made every visit after the window pay the full cost. An expired entry is
-    returned immediately and refreshed on a background thread, so only the first
-    call after startup ever waits.
+    Served stale-while-revalidate: ``claude mcp list`` health-checks every
+    connector and measures ~12s on a real install, and discovery is on the
+    Settings -> Providers load path, so a plain TTL made every visit after the
+    window pay the full cost. An expired entry is returned immediately and
+    refreshed on a background thread, so only the first call after startup ever
+    waits. Empty results expire fast (see ``_CLAUDE_DISCOVERY_EMPTY_TTL_SECONDS``)
+    because they usually mean the probe timed out, not that nothing is connected.
     """
     global _claude_mcps_cache
     now = time.monotonic()
     ws_key = str(_resolve_root(workspace_root)) if workspace_root else ""
     cached = _claude_mcps_cache
+    ttl = (
+        _CLAUDE_DISCOVERY_TTL_SECONDS
+        if cached is not None and cached[2]
+        else _CLAUDE_DISCOVERY_EMPTY_TTL_SECONDS
+    )
     fresh = (
         cached is not None
-        and now - cached[0] < _CLAUDE_DISCOVERY_TTL_SECONDS
+        and now - cached[0] < ttl
         and cached[1] == ws_key
     )
     if cached is not None and cached[1] == ws_key:
@@ -272,6 +294,25 @@ def discover_claude_mcps(
     )
     _claude_mcps_cache = (now, ws_key, tuple(connected))
     return connected
+
+
+def warm_claude_discovery_cache(workspace_root: Path | str | None = None) -> None:
+    """Pre-populate the Claude MCP/skill caches off the request path.
+
+    ``claude mcp list`` health-checks every connector (~12s on a real install),
+    so run it at app startup instead of letting the first Settings -> Providers
+    visit block on it. Fire-and-forget: a failure just leaves the cache cold
+    and the first request pays the cost as before.
+    """
+
+    def run() -> None:
+        try:
+            discover_claude_mcps(workspace_root)
+            discover_claude_system_skills()
+        except Exception:  # noqa: BLE001 - warm-up must never break startup
+            logger.debug("Claude discovery warm-up failed", exc_info=True)
+
+    threading.Thread(target=run, name="claude-discovery-warmup", daemon=True).start()
 
 
 def _refresh_claude_mcps_async(ws_key: str, config_path: Path | None) -> None:
@@ -395,7 +436,7 @@ def _discover_claude_mcps_uncached(
             [binary, "mcp", "list"],
             capture_output=True,
             text=True,
-            timeout=12.0,
+            timeout=_CLAUDE_MCP_LIST_TIMEOUT_SECONDS,
             check=False,
         )
         output = (res.stdout or "") + "\n" + (res.stderr or "")

--- a/ciao/setup_status.py
+++ b/ciao/setup_status.py
@@ -40,6 +40,10 @@ logger = logging.getLogger(__name__)
 _claude_mcps_cache: tuple[float, str, tuple[str, ...]] | None = None
 _claude_mcps_refreshing = False
 _claude_mcps_lock = threading.Lock()
+# Set while one runner (startup warm-up or a request thread) is executing the
+# ``claude mcp list`` probe, so latecomers wait for it instead of stacking a
+# second full health pass.
+_claude_mcps_inflight: threading.Event | None = None
 _claude_skills_cache: tuple[float, tuple[str, ...]] | None = None
 
 
@@ -61,8 +65,11 @@ def _resolve_root(raw: Any) -> Path:
 
 def clear_claude_discovery_cache() -> None:
     """Drop Claude MCP/skill discovery caches (tests and forced refresh)."""
-    global _claude_mcps_cache, _claude_skills_cache
+    global _claude_mcps_cache, _claude_mcps_inflight, _claude_skills_cache
     _claude_mcps_cache = None
+    # A still-running warm-up keeps its own event reference and only clears the
+    # global if it still owns it, so dropping the pointer here is safe.
+    _claude_mcps_inflight = None
     _claude_skills_cache = None
 
 
@@ -207,6 +214,10 @@ def _claude_standalone_skills_dir() -> Path:
 
 def _discover_claude_system_skills_uncached() -> list[str]:
     skills: set[str] = set()
+    # A clean `claude plugin list` exit is authoritative even when zero plugins
+    # are enabled; only a failure (missing binary, timeout, nonzero exit) needs
+    # the installed_plugins.json fallback below.
+    cli_ok = False
     binary = claude_cli_path()
     if binary:
         try:
@@ -214,6 +225,7 @@ def _discover_claude_system_skills_uncached() -> list[str]:
                 [binary, "plugin", "list"],
                 capture_output=True, text=True, timeout=8.0, check=False,
             )
+            cli_ok = res.returncode == 0
             output = (res.stdout or "") + "\n" + (res.stderr or "")
             # Claude Code uses a multi-line block format:
             #   ❯ plugin-name@source
@@ -228,7 +240,7 @@ def _discover_claude_system_skills_uncached() -> list[str]:
                         skills.add(current_name)
                     current_name = None
         except Exception:
-            pass
+            cli_ok = False
     # Standalone skills under ~/.claude/skills never appear in `claude plugin
     # list`, so merge them in whether or not the CLI reported plugins.
     skills_dir = _claude_standalone_skills_dir()
@@ -236,8 +248,8 @@ def _discover_claude_system_skills_uncached() -> list[str]:
         for entry in skills_dir.glob("*"):
             if entry.is_dir() or entry.name.endswith(".md"):
                 skills.add(entry.stem)
-    if not skills:
-        # Nothing enabled and no standalone skills: fall back to listing every
+    if not cli_ok:
+        # The CLI could not report (missing, failed, timed out): list every
         # installed plugin so the page still shows something actionable.
         installed_json = Path.home() / ".claude" / "plugins" / "installed_plugins.json"
         if installed_json.is_file():
@@ -269,7 +281,7 @@ def discover_claude_mcps(
     waits. Empty results expire fast (see ``_CLAUDE_DISCOVERY_EMPTY_TTL_SECONDS``)
     because they usually mean the probe timed out, not that nothing is connected.
     """
-    global _claude_mcps_cache
+    global _claude_mcps_cache, _claude_mcps_inflight
     now = time.monotonic()
     ws_key = str(_resolve_root(workspace_root)) if workspace_root else ""
     cached = _claude_mcps_cache
@@ -288,26 +300,71 @@ def discover_claude_mcps(
             _refresh_claude_mcps_async(ws_key, config_path)
         return list(cached[2])
 
-    connected = _discover_claude_mcps_uncached(
-        workspace_root=Path(ws_key) if ws_key else None,
-        config_path=config_path,
-    )
-    _claude_mcps_cache = (now, ws_key, tuple(connected))
-    return connected
+    # Single-flight: the startup warm-up (or another request thread) may
+    # already be paying for the probe. Wait for it instead of stacking a
+    # second ``claude mcp list`` that would block this request for another
+    # full health pass.
+    with _claude_mcps_lock:
+        inflight = _claude_mcps_inflight
+        if inflight is None:
+            _claude_mcps_inflight = inflight = threading.Event()
+            owner = True
+        else:
+            owner = False
+    if not owner:
+        inflight.wait(timeout=_CLAUDE_MCP_LIST_TIMEOUT_SECONDS + 5.0)
+        cached = _claude_mcps_cache
+        if cached is not None and cached[1] == ws_key:
+            return list(cached[2])
+        # The in-flight probe failed or targeted another workspace root;
+        # fall through and pay for our own discovery.
+
+    try:
+        connected = _discover_claude_mcps_uncached(
+            workspace_root=Path(ws_key) if ws_key else None,
+            config_path=config_path,
+        )
+        _claude_mcps_cache = (time.monotonic(), ws_key, tuple(connected))
+        return connected
+    finally:
+        inflight.set()
+        with _claude_mcps_lock:
+            if _claude_mcps_inflight is inflight:
+                _claude_mcps_inflight = None
 
 
-def warm_claude_discovery_cache(workspace_root: Path | str | None = None) -> None:
+def _claude_config_path_from_env(source: Mapping[str, str] | None = None) -> Path:
+    """The Claude config file the provider payload would read.
+
+    Honors ``CLAUDE_CONFIG_PATH`` so the startup warm-up probes the same
+    connector set the Settings -> Providers route will report.
+    """
+    src = source if source is not None else os.environ
+    raw = str(src.get("CLAUDE_CONFIG_PATH", "")).strip()
+    return Path(raw).expanduser() if raw else Path.home() / ".claude.json"
+
+
+def warm_claude_discovery_cache(
+    workspace_root: Path | str | None = None,
+    *,
+    config_path: Path | None = None,
+) -> None:
     """Pre-populate the Claude MCP/skill caches off the request path.
 
     ``claude mcp list`` health-checks every connector (~12s on a real install),
     so run it at app startup instead of letting the first Settings -> Providers
-    visit block on it. Fire-and-forget: a failure just leaves the cache cold
-    and the first request pays the cost as before.
+    visit block on it. ``config_path`` defaults to the same ``CLAUDE_CONFIG_PATH``
+    derivation the payload uses, so the warmed cache cannot disagree with what
+    the route would report. Fire-and-forget: a failure just leaves the cache
+    cold and the first request pays the cost as before.
     """
 
     def run() -> None:
         try:
-            discover_claude_mcps(workspace_root)
+            discover_claude_mcps(
+                workspace_root,
+                config_path=config_path or _claude_config_path_from_env(),
+            )
             discover_claude_system_skills()
         except Exception:  # noqa: BLE001 - warm-up must never break startup
             logger.debug("Claude discovery warm-up failed", exc_info=True)
@@ -713,12 +770,7 @@ def setup_status(
         or (Path(raw_credentials_path).expanduser() if raw_credentials_path else None)
         or Path.home() / ".claude" / ".credentials.json"
     )
-    raw_config_path = source.get("CLAUDE_CONFIG_PATH", "").strip()
-    config_path = (
-        claude_config_path
-        or (Path(raw_config_path).expanduser() if raw_config_path else None)
-        or Path.home() / ".claude.json"
-    )
+    config_path = claude_config_path or _claude_config_path_from_env(source)
 
     checks = [
         _check(

--- a/ciao/setup_status.py
+++ b/ciao/setup_status.py
@@ -64,12 +64,18 @@ def _resolve_root(raw: Any) -> Path:
 
 
 def clear_claude_discovery_cache() -> None:
-    """Drop Claude MCP/skill discovery caches (tests and forced refresh)."""
-    global _claude_mcps_cache, _claude_mcps_inflight, _claude_skills_cache
+    """Drop Claude MCP/skill discovery caches (tests and forced refresh).
+
+    An in-flight probe is deliberately left registered: the Verify endpoint
+    calls this while the startup warm-up may still be running, and
+    unregistering the probe would let the next payload claim single-flight
+    ownership and stack a second blocking ``claude mcp list``. The running
+    owner still finishes, stamps the cache, and clears the pointer itself.
+    Tests that need a clean single-flight state reset ``_claude_mcps_inflight``
+    directly.
+    """
+    global _claude_mcps_cache, _claude_skills_cache
     _claude_mcps_cache = None
-    # A still-running warm-up keeps its own event reference and only clears the
-    # global if it still owns it, so dropping the pointer here is safe.
-    _claude_mcps_inflight = None
     _claude_skills_cache = None
 
 

--- a/ciao/setup_status.py
+++ b/ciao/setup_status.py
@@ -353,6 +353,10 @@ def discover_claude_mcps(
             break
         with _claude_mcps_lock:
             running = _claude_mcps_inflight
+        if running is None:
+            # The owner finished between our failed acquire and this read;
+            # loop to serve its freshly stamped cache or take over.
+            continue
         running.wait()
         cached = _claude_mcps_cache
         if (

--- a/ciao/setup_status.py
+++ b/ciao/setup_status.py
@@ -37,13 +37,17 @@ _CLAUDE_DISCOVERY_EMPTY_TTL_SECONDS = 15.0
 _CLAUDE_MCP_LIST_TIMEOUT_SECONDS = 30.0
 logger = logging.getLogger(__name__)
 
-_claude_mcps_cache: tuple[float, str, tuple[str, ...]] | None = None
+_claude_mcps_cache: tuple[float, str, tuple[str, ...], int] | None = None
 _claude_mcps_refreshing = False
 _claude_mcps_lock = threading.Lock()
-# Set while one runner (startup warm-up or a request thread) is executing the
-# ``claude mcp list`` probe, so latecomers wait for it instead of stacking a
-# second full health pass.
+# Set while one runner (startup warm-up, a request thread, or the stale-TTL
+# background refresh) is executing the ``claude mcp list`` probe, so
+# latecomers wait for it instead of stacking a second full health pass.
 _claude_mcps_inflight: threading.Event | None = None
+# Bumped on every ``clear_claude_discovery_cache`` so a probe result produced
+# from a pre-clear configuration (e.g. the startup warm-up finishing right
+# after Verify) is not served or cached as current.
+_claude_mcps_generation = 0
 _claude_skills_cache: tuple[float, tuple[str, ...]] | None = None
 
 
@@ -69,14 +73,40 @@ def clear_claude_discovery_cache() -> None:
     An in-flight probe is deliberately left registered: the Verify endpoint
     calls this while the startup warm-up may still be running, and
     unregistering the probe would let the next payload claim single-flight
-    ownership and stack a second blocking ``claude mcp list``. The running
-    owner still finishes, stamps the cache, and clears the pointer itself.
-    Tests that need a clean single-flight state reset ``_claude_mcps_inflight``
-    directly.
+    ownership and stack a second blocking ``claude mcp list``. Instead the
+    generation bump marks any result that pre-clear probe produces as stale,
+    so the next discovery waits it out and then re-probes with current
+    configuration. Tests that need a clean single-flight state reset
+    ``_claude_mcps_inflight`` directly.
     """
-    global _claude_mcps_cache, _claude_skills_cache
+    global _claude_mcps_cache, _claude_skills_cache, _claude_mcps_generation
     _claude_mcps_cache = None
     _claude_skills_cache = None
+    _claude_mcps_generation += 1
+
+
+def _acquire_mcps_probe() -> threading.Event | None:
+    """Try to become the sole ``claude mcp list`` runner.
+
+    Returns the event this caller owns (``release_mcps_probe`` must be called
+    on it), or ``None`` when another probe is already in flight.
+    """
+    global _claude_mcps_inflight
+    with _claude_mcps_lock:
+        if _claude_mcps_inflight is not None:
+            return None
+        event: threading.Event = threading.Event()
+        _claude_mcps_inflight = event
+        return event
+
+
+def _release_mcps_probe(event: threading.Event) -> None:
+    """Finish this caller's probe run and hand single-flight back."""
+    global _claude_mcps_inflight
+    event.set()
+    with _claude_mcps_lock:
+        if _claude_mcps_inflight is event:
+            _claude_mcps_inflight = None
 
 
 def detect_nested_workspaces(vault_path: Path) -> list[str]:
@@ -287,7 +317,7 @@ def discover_claude_mcps(
     waits. Empty results expire fast (see ``_CLAUDE_DISCOVERY_EMPTY_TTL_SECONDS``)
     because they usually mean the probe timed out, not that nothing is connected.
     """
-    global _claude_mcps_cache, _claude_mcps_inflight
+    global _claude_mcps_cache
     now = time.monotonic()
     ws_key = str(_resolve_root(workspace_root)) if workspace_root else ""
     cached = _claude_mcps_cache
@@ -300,48 +330,53 @@ def discover_claude_mcps(
         cached is not None
         and now - cached[0] < ttl
         and cached[1] == ws_key
+        and cached[3] == _claude_mcps_generation
     )
     if cached is not None and cached[1] == ws_key:
         if not fresh:
             _refresh_claude_mcps_async(ws_key, config_path)
         return list(cached[2])
 
-    # Single-flight: the startup warm-up (or another request thread) may
-    # already be paying for the probe. Wait for it to finish instead of
-    # stacking a second ``claude mcp list``; only become a runner once no
-    # other probe is in flight. The wait is unbounded on purpose: the owner's
-    # ``finally`` always fires and the probe itself is bounded by the
-    # subprocess timeout, so the event cannot stay unset forever. A waiter
-    # whose owner finished without a usable entry for this root (failed probe
-    # or different workspace root) loops and reacquires ownership — it never
-    # times out into running a duplicate probe alongside the in-flight one.
+    # Single-flight: the startup warm-up, the stale-TTL background refresh, or
+    # another request thread may already be paying for the probe. Wait for it
+    # to finish instead of stacking a second ``claude mcp list``; only become
+    # a runner once no other probe is in flight. The wait is unbounded on
+    # purpose: the owner's ``finally`` always fires and the probe itself is
+    # bounded by the subprocess timeout, so the event cannot stay unset
+    # forever. A waiter whose owner finished without a usable entry for this
+    # root (failed probe, different workspace root, or a result invalidated by
+    # a cache clear mid-probe) loops and reacquires ownership — it never times
+    # out into running a duplicate probe alongside the in-flight one.
     while True:
-        with _claude_mcps_lock:
-            inflight = _claude_mcps_inflight
-            if inflight is None:
-                _claude_mcps_inflight = inflight = threading.Event()
-                owner = True
-            else:
-                owner = False
-        if owner:
+        inflight = _acquire_mcps_probe()
+        if inflight is not None:
             break
-        inflight.wait()
+        with _claude_mcps_lock:
+            running = _claude_mcps_inflight
+        running.wait()
         cached = _claude_mcps_cache
-        if cached is not None and cached[1] == ws_key:
+        if (
+            cached is not None
+            and cached[1] == ws_key
+            and cached[3] == _claude_mcps_generation
+        ):
             return list(cached[2])
 
+    probe_generation = _claude_mcps_generation
     try:
         connected = _discover_claude_mcps_uncached(
             workspace_root=Path(ws_key) if ws_key else None,
             config_path=config_path,
         )
-        _claude_mcps_cache = (time.monotonic(), ws_key, tuple(connected))
+        _claude_mcps_cache = (
+            time.monotonic(),
+            ws_key,
+            tuple(connected),
+            probe_generation,
+        )
         return connected
     finally:
-        inflight.set()
-        with _claude_mcps_lock:
-            if _claude_mcps_inflight is inflight:
-                _claude_mcps_inflight = None
+        _release_mcps_probe(inflight)
 
 
 def _claude_config_path_from_env(source: Mapping[str, str] | None = None) -> Path:
@@ -386,8 +421,12 @@ def warm_claude_discovery_cache(
 def _refresh_claude_mcps_async(ws_key: str, config_path: Path | None) -> None:
     """Re-discover in the background, at most one refresh in flight.
 
-    Failures are swallowed on purpose: the stale list already went out to the
-    caller, and a discovery error must not surface as a broken Settings page.
+    The refresh joins the same single-flight as the warm-up and the request
+    path: if another probe is running it skips entirely (that probe's result
+    is at least as fresh), and while it runs, Verify's cache bust cannot stack
+    a second probe on top of it. Failures are swallowed on purpose: the stale
+    list already went out to the caller, and a discovery error must not
+    surface as a broken Settings page.
     """
     global _claude_mcps_refreshing
     with _claude_mcps_lock:
@@ -397,15 +436,28 @@ def _refresh_claude_mcps_async(ws_key: str, config_path: Path | None) -> None:
 
     def run() -> None:
         global _claude_mcps_cache, _claude_mcps_refreshing
+        inflight = _acquire_mcps_probe()
         try:
+            if inflight is None:
+                return  # a newer probe is already running; its result wins
+            # Record the generation before probing: a cache clear mid-probe
+            # must invalidate this result just like the request path's.
+            probe_generation = _claude_mcps_generation
             connected = _discover_claude_mcps_uncached(
                 workspace_root=Path(ws_key) if ws_key else None,
                 config_path=config_path,
             )
-            _claude_mcps_cache = (time.monotonic(), ws_key, tuple(connected))
+            _claude_mcps_cache = (
+                time.monotonic(),
+                ws_key,
+                tuple(connected),
+                probe_generation,
+            )
         except Exception:  # noqa: BLE001 - a stale list is already serving
             logger.debug("background Claude MCP discovery failed", exc_info=True)
         finally:
+            if inflight is not None:
+                _release_mcps_probe(inflight)
             with _claude_mcps_lock:
                 _claude_mcps_refreshing = False
 

--- a/ciao/setup_status.py
+++ b/ciao/setup_status.py
@@ -301,23 +301,28 @@ def discover_claude_mcps(
         return list(cached[2])
 
     # Single-flight: the startup warm-up (or another request thread) may
-    # already be paying for the probe. Wait for it instead of stacking a
-    # second ``claude mcp list`` that would block this request for another
-    # full health pass.
-    with _claude_mcps_lock:
-        inflight = _claude_mcps_inflight
-        if inflight is None:
-            _claude_mcps_inflight = inflight = threading.Event()
-            owner = True
-        else:
-            owner = False
-    if not owner:
-        inflight.wait(timeout=_CLAUDE_MCP_LIST_TIMEOUT_SECONDS + 5.0)
+    # already be paying for the probe. Wait for it to finish instead of
+    # stacking a second ``claude mcp list``; only become a runner once no
+    # other probe is in flight. The wait is unbounded on purpose: the owner's
+    # ``finally`` always fires and the probe itself is bounded by the
+    # subprocess timeout, so the event cannot stay unset forever. A waiter
+    # whose owner finished without a usable entry for this root (failed probe
+    # or different workspace root) loops and reacquires ownership — it never
+    # times out into running a duplicate probe alongside the in-flight one.
+    while True:
+        with _claude_mcps_lock:
+            inflight = _claude_mcps_inflight
+            if inflight is None:
+                _claude_mcps_inflight = inflight = threading.Event()
+                owner = True
+            else:
+                owner = False
+        if owner:
+            break
+        inflight.wait()
         cached = _claude_mcps_cache
         if cached is not None and cached[1] == ws_key:
             return list(cached[2])
-        # The in-flight probe failed or targeted another workspace root;
-        # fall through and pay for our own discovery.
 
     try:
         connected = _discover_claude_mcps_uncached(

--- a/ciao/web/app.py
+++ b/ciao/web/app.py
@@ -421,6 +421,12 @@ def create_app(config, app_settings=None, mcp_service=None) -> Starlette:
     @asynccontextmanager
     async def _lifespan(_app):
         from ciao.node_proxy import close_shared_client
+        from ciao.setup_status import warm_claude_discovery_cache
+
+        # `claude mcp list` health-checks every connector and can take ~12s;
+        # warm the discovery cache at startup so the first Settings -> Providers
+        # visit serves a populated list instead of blocking on the probe.
+        warm_claude_discovery_cache(getattr(config, "workspace_root", None))
 
         try:
             if mcp_service is not None:

--- a/tests/test_setup_status.py
+++ b/tests/test_setup_status.py
@@ -1338,3 +1338,68 @@ def test_requests_wait_for_an_in_flight_warmup(monkeypatch, tmp_path):
     waiter.join(timeout=5)
     assert results == [["Airtable"]]
     assert len(calls) == 1, "request must reuse the warm-up probe"
+
+
+def test_waiter_reacquires_ownership_when_warmup_targets_another_root(
+    monkeypatch, tmp_path
+):
+    """A waiter never starts a probe while another is in flight.
+
+    If the in-flight warm-up finishes without a usable entry for the waiter's
+    workspace root (here: a different root), the waiter loops and reacquires
+    ownership instead of running a duplicate probe alongside it.
+    """
+    import threading
+    import time as _time
+
+    from ciao import setup_status as ss
+
+    other_root = tmp_path.parent / "other-ws-root"
+    other_root.mkdir()
+
+    calls: list[object] = []
+    order: list[str] = []
+    release = threading.Event()
+    request_done = threading.Event()
+
+    def probe(workspace_root=None, **kwargs):
+        calls.append(workspace_root)
+        if workspace_root == other_root:
+            order.append("request-start")
+            return ["Other"]
+        order.append("warmup-start")
+        release.wait(timeout=5)
+        order.append("warmup-end")
+        return ["Warm"]
+
+    monkeypatch.setattr(ss, "_discover_claude_mcps_uncached", probe)
+    monkeypatch.setattr(ss, "_claude_mcps_cache", None)
+    monkeypatch.setattr(ss, "_claude_mcps_refreshing", False)
+    monkeypatch.setattr(ss, "_claude_mcps_inflight", None)
+
+    ss.warm_claude_discovery_cache(tmp_path)
+
+    deadline = _time.monotonic() + 5
+    while not calls and _time.monotonic() < deadline:
+        _time.sleep(0.01)
+    assert order == ["warmup-start"], "warm-up probe never started"
+
+    results: list[list[str]] = []
+
+    def request() -> None:
+        results.append(ss.discover_claude_mcps(other_root))
+        request_done.set()
+
+    waiter = threading.Thread(target=request)
+    waiter.start()
+    _time.sleep(0.05)
+    assert calls == [tmp_path], "waiter must not probe while warm-up owns"
+
+    release.set()
+    assert request_done.wait(timeout=5), "waiter never reacquired ownership"
+    waiter.join(timeout=5)
+    assert results == [["Other"]]
+    assert order == ["warmup-start", "warmup-end", "request-start"], (
+        "request probe must start only after the warm-up finished"
+    )
+    assert calls == [tmp_path, other_root]

--- a/tests/test_setup_status.py
+++ b/tests/test_setup_status.py
@@ -1019,6 +1019,7 @@ def test_discover_claude_system_skills_filters_enabled_and_caches(
             "  Status: ✘ disabled\n"
         )
         stderr = ""
+        returncode = 0
 
     def fake_run(*_args, **_kwargs):
         calls["n"] += 1
@@ -1050,6 +1051,7 @@ def test_discover_claude_system_skills_merges_standalone_skills(
     class FakeResult:
         stdout = "❯ skill-creator@claude-plugins-official\n  Status: ✔ enabled\n"
         stderr = ""
+        returncode = 0
 
     monkeypatch.setattr(setup_status.shutil, "which", lambda _name: "/bin/claude")
     monkeypatch.setattr(
@@ -1092,6 +1094,44 @@ def test_discover_claude_system_skills_falls_back_to_installed_plugins(
     assert setup_status.discover_claude_system_skills() == ["legacy-plugin"]
 
 
+def test_discover_claude_system_skills_falls_back_when_cli_fails(
+    monkeypatch, tmp_path
+) -> None:
+    """A failed `claude plugin list` must not hide installed plugins.
+
+    Fallback eligibility tracks CLI success, not the merged result: otherwise
+    one standalone skill would suppress the installed_plugins recovery whenever
+    the CLI transiently fails or times out.
+    """
+    import subprocess as _subprocess
+
+    from ciao import setup_status
+
+    setup_status.clear_claude_discovery_cache()
+
+    def boom(*_args, **_kwargs):
+        raise _subprocess.TimeoutExpired(cmd="claude plugin list", timeout=8)
+
+    monkeypatch.setattr(setup_status.shutil, "which", lambda _name: "/bin/claude")
+    monkeypatch.setattr(setup_status.subprocess, "run", boom)
+    skills_dir = tmp_path / "skills"
+    (skills_dir / "ego-browser").mkdir(parents=True)
+    monkeypatch.setattr(
+        setup_status, "_claude_standalone_skills_dir", lambda: skills_dir
+    )
+    plugins_dir = tmp_path / ".claude" / "plugins"
+    plugins_dir.mkdir(parents=True)
+    (plugins_dir / "installed_plugins.json").write_text(
+        json.dumps({"plugins": {"legacy-plugin@source": {}}}), encoding="utf-8"
+    )
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    assert setup_status.discover_claude_system_skills() == [
+        "ego-browser",
+        "legacy-plugin",
+    ]
+
+
 # ── Claude MCP discovery cache ──────────────────────────────────────────
 # `claude mcp list` measures ~12s on a real install and sits on the
 # Settings -> Providers load path, so the cache decides whether that tab is
@@ -1116,6 +1156,7 @@ def test_expired_mcp_cache_serves_stale_and_refreshes_in_background(monkeypatch)
     monkeypatch.setattr(ss, "_discover_claude_mcps_uncached", slow_discovery)
     monkeypatch.setattr(ss, "_claude_mcps_cache", None)
     monkeypatch.setattr(ss, "_claude_mcps_refreshing", False)
+    monkeypatch.setattr(ss, "_claude_mcps_inflight", None)
 
     # First call has nothing to serve, so it waits.
     assert ss.discover_claude_mcps(None) == ["mcp-1"]
@@ -1146,6 +1187,7 @@ def test_a_fresh_mcp_cache_does_not_refresh(monkeypatch):
     )
     monkeypatch.setattr(ss, "_claude_mcps_cache", None)
     monkeypatch.setattr(ss, "_claude_mcps_refreshing", False)
+    monkeypatch.setattr(ss, "_claude_mcps_inflight", None)
 
     ss.discover_claude_mcps(None)
     ss.discover_claude_mcps(None)
@@ -1166,6 +1208,7 @@ def test_a_fresh_empty_mcp_cache_serves_without_refresh(monkeypatch):
     )
     monkeypatch.setattr(ss, "_claude_mcps_cache", None)
     monkeypatch.setattr(ss, "_claude_mcps_refreshing", False)
+    monkeypatch.setattr(ss, "_claude_mcps_inflight", None)
 
     assert ss.discover_claude_mcps(None) == []
     assert ss.discover_claude_mcps(None) == []
@@ -1190,6 +1233,7 @@ def test_an_empty_mcp_cache_expires_fast_and_recovers(monkeypatch):
     monkeypatch.setattr(ss, "_discover_claude_mcps_uncached", discovery)
     monkeypatch.setattr(ss, "_claude_mcps_cache", None)
     monkeypatch.setattr(ss, "_claude_mcps_refreshing", False)
+    monkeypatch.setattr(ss, "_claude_mcps_inflight", None)
 
     assert ss.discover_claude_mcps(None) == []
     assert calls == [1]
@@ -1216,6 +1260,7 @@ def test_warm_claude_discovery_cache_populates_both_caches(monkeypatch, tmp_path
 
     monkeypatch.setattr(ss, "_claude_mcps_cache", None)
     monkeypatch.setattr(ss, "_claude_mcps_refreshing", False)
+    monkeypatch.setattr(ss, "_claude_mcps_inflight", None)
     monkeypatch.setattr(ss, "_claude_skills_cache", None)
     seen = []
 
@@ -1241,3 +1286,55 @@ def test_warm_claude_discovery_cache_populates_both_caches(monkeypatch, tmp_path
     assert ss._claude_mcps_cache[2] == ("Airtable",)
     assert ss._claude_skills_cache is not None
     assert ss._claude_skills_cache[1] == ("skill-creator",)
+
+
+def test_requests_wait_for_an_in_flight_warmup(monkeypatch, tmp_path):
+    """A request arriving mid-warm-up reuses the probe instead of stacking one.
+
+    The warm-up thread and the request path must share a single
+    `claude mcp list` run: otherwise a Providers visit right after startup
+    blocks for another full health pass and pays for a duplicate probe.
+    """
+    import threading
+    import time as _time
+
+    from ciao import setup_status as ss
+
+    calls = []
+    release = threading.Event()
+    request_done = threading.Event()
+
+    def slow_probe(**kwargs):
+        calls.append(1)
+        release.wait(timeout=5)
+        return ["Airtable"]
+
+    monkeypatch.setattr(ss, "_discover_claude_mcps_uncached", slow_probe)
+    monkeypatch.setattr(ss, "_claude_mcps_cache", None)
+    monkeypatch.setattr(ss, "_claude_mcps_refreshing", False)
+    monkeypatch.setattr(ss, "_claude_mcps_inflight", None)
+
+    ss.warm_claude_discovery_cache(tmp_path)
+
+    # Wait until the warm-up thread owns the in-flight probe.
+    deadline = _time.monotonic() + 5
+    while not calls and _time.monotonic() < deadline:
+        _time.sleep(0.01)
+    assert calls == [1], "warm-up probe never started"
+
+    results: list[list[str]] = []
+
+    def request() -> None:
+        results.append(ss.discover_claude_mcps(tmp_path))
+        request_done.set()
+
+    waiter = threading.Thread(target=request)
+    waiter.start()
+    _time.sleep(0.05)
+    assert len(calls) == 1, "a second probe must not start mid-warm-up"
+
+    release.set()
+    assert request_done.wait(timeout=5), "request never served"
+    waiter.join(timeout=5)
+    assert results == [["Airtable"]]
+    assert len(calls) == 1, "request must reuse the warm-up probe"

--- a/tests/test_setup_status.py
+++ b/tests/test_setup_status.py
@@ -1003,7 +1003,9 @@ async def test_provider_verify_action_busts_claude_discovery_cache(
     assert calls == {"clear": 1, "payload": 2}
 
 
-def test_discover_claude_system_skills_filters_enabled_and_caches(monkeypatch) -> None:
+def test_discover_claude_system_skills_filters_enabled_and_caches(
+    monkeypatch, tmp_path
+) -> None:
     from ciao import setup_status
 
     setup_status.clear_claude_discovery_cache()
@@ -1024,10 +1026,70 @@ def test_discover_claude_system_skills_filters_enabled_and_caches(monkeypatch) -
 
     monkeypatch.setattr(setup_status.shutil, "which", lambda _name: "/bin/claude")
     monkeypatch.setattr(setup_status.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        setup_status, "_claude_standalone_skills_dir", lambda: tmp_path / "absent"
+    )
 
     assert setup_status.discover_claude_system_skills() == ["skill-creator"]
     assert setup_status.discover_claude_system_skills() == ["skill-creator"]
     assert calls["n"] == 1
+
+
+def test_discover_claude_system_skills_merges_standalone_skills(
+    monkeypatch, tmp_path
+) -> None:
+    """Standalone ~/.claude/skills entries show up alongside enabled plugins.
+
+    `claude plugin list` only knows about plugins, so a user with a hand-installed
+    skill directory would otherwise never see it on the Providers tab.
+    """
+    from ciao import setup_status
+
+    setup_status.clear_claude_discovery_cache()
+
+    class FakeResult:
+        stdout = "❯ skill-creator@claude-plugins-official\n  Status: ✔ enabled\n"
+        stderr = ""
+
+    monkeypatch.setattr(setup_status.shutil, "which", lambda _name: "/bin/claude")
+    monkeypatch.setattr(
+        setup_status.subprocess, "run", lambda *_a, **_k: FakeResult()
+    )
+    skills_dir = tmp_path / "skills"
+    (skills_dir / "ego-browser").mkdir(parents=True)
+    (skills_dir / "note-taking.md").write_text("---\n---\n", encoding="utf-8")
+    (skills_dir / "ignored.txt").write_text("not a skill", encoding="utf-8")
+    monkeypatch.setattr(
+        setup_status, "_claude_standalone_skills_dir", lambda: skills_dir
+    )
+
+    assert setup_status.discover_claude_system_skills() == [
+        "ego-browser",
+        "note-taking",
+        "skill-creator",
+    ]
+
+
+def test_discover_claude_system_skills_falls_back_to_installed_plugins(
+    monkeypatch, tmp_path
+) -> None:
+    """With no CLI and no standalone skills, installed plugins still surface."""
+    from ciao import setup_status
+
+    setup_status.clear_claude_discovery_cache()
+    monkeypatch.setattr(setup_status.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(
+        setup_status, "_claude_standalone_skills_dir", lambda: tmp_path / "absent"
+    )
+
+    plugins_dir = tmp_path / ".claude" / "plugins"
+    plugins_dir.mkdir(parents=True)
+    (plugins_dir / "installed_plugins.json").write_text(
+        json.dumps({"plugins": {"legacy-plugin@source": {}}}), encoding="utf-8"
+    )
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    assert setup_status.discover_claude_system_skills() == ["legacy-plugin"]
 
 
 # ── Claude MCP discovery cache ──────────────────────────────────────────
@@ -1088,3 +1150,94 @@ def test_a_fresh_mcp_cache_does_not_refresh(monkeypatch):
     ss.discover_claude_mcps(None)
     ss.discover_claude_mcps(None)
     assert len(calls) == 1, "a fresh entry must not spawn a discovery"
+
+
+# An empty discovery usually means the health pass timed out, not that nothing
+# is connected, so it must expire fast instead of poisoning the tab for the
+# full five-minute success TTL.
+
+
+def test_a_fresh_empty_mcp_cache_serves_without_refresh(monkeypatch):
+    from ciao import setup_status as ss
+
+    calls = []
+    monkeypatch.setattr(
+        ss, "_discover_claude_mcps_uncached", lambda **kw: calls.append(1) or []
+    )
+    monkeypatch.setattr(ss, "_claude_mcps_cache", None)
+    monkeypatch.setattr(ss, "_claude_mcps_refreshing", False)
+
+    assert ss.discover_claude_mcps(None) == []
+    assert ss.discover_claude_mcps(None) == []
+    assert len(calls) == 1, "a fresh (empty) entry must not spawn a discovery"
+
+
+def test_an_empty_mcp_cache_expires_fast_and_recovers(monkeypatch):
+    import threading
+    import time as _time
+
+    from ciao import setup_status as ss
+
+    calls = []
+    done = threading.Event()
+
+    def discovery(**kwargs):
+        calls.append(1)
+        if len(calls) > 1:
+            done.set()
+        return [] if len(calls) == 1 else ["recovered"]
+
+    monkeypatch.setattr(ss, "_discover_claude_mcps_uncached", discovery)
+    monkeypatch.setattr(ss, "_claude_mcps_cache", None)
+    monkeypatch.setattr(ss, "_claude_mcps_refreshing", False)
+
+    assert ss.discover_claude_mcps(None) == []
+    assert calls == [1]
+
+    # Age the entry past the empty TTL but well short of the success TTL: the
+    # stale empty list still serves instantly, but a refresh must kick off.
+    stamp, ws_key, value = ss._claude_mcps_cache
+    assert value == ()
+    aged = stamp - (ss._CLAUDE_DISCOVERY_EMPTY_TTL_SECONDS + 1)
+    monkeypatch.setattr(ss, "_claude_mcps_cache", (aged, ws_key, value))
+
+    assert ss.discover_claude_mcps(None) == []
+    assert done.wait(timeout=5), "empty cache must re-discover in the background"
+    deadline = _time.monotonic() + 5
+    while ss._claude_mcps_cache[2] != ("recovered",) and _time.monotonic() < deadline:
+        _time.sleep(0.01)
+    assert ss._claude_mcps_cache[2] == ("recovered",)
+
+
+def test_warm_claude_discovery_cache_populates_both_caches(monkeypatch, tmp_path):
+    import time
+
+    from ciao import setup_status as ss
+
+    monkeypatch.setattr(ss, "_claude_mcps_cache", None)
+    monkeypatch.setattr(ss, "_claude_mcps_refreshing", False)
+    monkeypatch.setattr(ss, "_claude_skills_cache", None)
+    seen = []
+
+    def fake_mcps(workspace_root=None, **kwargs):
+        seen.append(("mcps", workspace_root))
+        return ["Airtable"]
+
+    def fake_skills():
+        seen.append(("skills", None))
+        return ["skill-creator"]
+
+    monkeypatch.setattr(ss, "_discover_claude_mcps_uncached", fake_mcps)
+    monkeypatch.setattr(ss, "_discover_claude_system_skills_uncached", fake_skills)
+
+    ss.warm_claude_discovery_cache(tmp_path)
+
+    deadline = time.monotonic() + 5
+    while len(seen) < 2 and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert ("mcps", tmp_path) in seen
+    assert ("skills", None) in seen
+    assert ss._claude_mcps_cache is not None
+    assert ss._claude_mcps_cache[2] == ("Airtable",)
+    assert ss._claude_skills_cache is not None
+    assert ss._claude_skills_cache[1] == ("skill-creator",)

--- a/tests/test_setup_status.py
+++ b/tests/test_setup_status.py
@@ -909,6 +909,7 @@ def test_discover_claude_mcps_filters_connected_and_caches(monkeypatch, tmp_path
     from ciao import setup_status
 
     setup_status.clear_claude_discovery_cache()
+    monkeypatch.setattr(setup_status, "_claude_mcps_inflight", None)
     calls = {"n": 0}
     config = tmp_path / ".claude.json"
     config.write_text(
@@ -1338,6 +1339,59 @@ def test_requests_wait_for_an_in_flight_warmup(monkeypatch, tmp_path):
     waiter.join(timeout=5)
     assert results == [["Airtable"]]
     assert len(calls) == 1, "request must reuse the warm-up probe"
+
+
+def test_clear_preserves_an_in_flight_probe(monkeypatch, tmp_path):
+    """Verify's cache bust must not unregister a still-running warm-up probe.
+
+    Clearing only the cached values keeps the single-flight registration: the
+    next payload waits for the in-flight probe instead of claiming ownership
+    and stacking a second blocking `claude mcp list`.
+    """
+    import threading
+    import time as _time
+
+    from ciao import setup_status as ss
+
+    calls = []
+    release = threading.Event()
+    request_done = threading.Event()
+
+    def slow_probe(**kwargs):
+        calls.append(1)
+        release.wait(timeout=5)
+        return ["Airtable"]
+
+    monkeypatch.setattr(ss, "_discover_claude_mcps_uncached", slow_probe)
+    monkeypatch.setattr(ss, "_claude_mcps_cache", None)
+    monkeypatch.setattr(ss, "_claude_mcps_refreshing", False)
+    monkeypatch.setattr(ss, "_claude_mcps_inflight", None)
+
+    ss.warm_claude_discovery_cache(tmp_path)
+    deadline = _time.monotonic() + 5
+    while not calls and _time.monotonic() < deadline:
+        _time.sleep(0.01)
+    assert calls == [1], "warm-up probe never started"
+
+    ss.clear_claude_discovery_cache()
+    assert ss._claude_mcps_inflight is not None, "clear dropped an active probe"
+
+    results: list[list[str]] = []
+
+    def request() -> None:
+        results.append(ss.discover_claude_mcps(tmp_path))
+        request_done.set()
+
+    waiter = threading.Thread(target=request)
+    waiter.start()
+    _time.sleep(0.05)
+    assert len(calls) == 1, "clear must not let a second probe start"
+
+    release.set()
+    assert request_done.wait(timeout=5), "request never served"
+    waiter.join(timeout=5)
+    assert results == [["Airtable"]]
+    assert len(calls) == 1, "request must reuse the probe that survived clear"
 
 
 def test_waiter_reacquires_ownership_when_warmup_targets_another_root(

--- a/tests/test_setup_status.py
+++ b/tests/test_setup_status.py
@@ -1165,9 +1165,11 @@ def test_expired_mcp_cache_serves_stale_and_refreshes_in_background(monkeypatch)
 
     # Expire the entry; the next call must return the stale value immediately
     # rather than paying the discovery again.
-    stamp, ws_key, value = ss._claude_mcps_cache
+    stamp, ws_key, value, gen = ss._claude_mcps_cache
     monkeypatch.setattr(
-        ss, "_claude_mcps_cache", (stamp - ss._CLAUDE_DISCOVERY_TTL_SECONDS - 1, ws_key, value)
+        ss,
+        "_claude_mcps_cache",
+        (stamp - ss._CLAUDE_DISCOVERY_TTL_SECONDS - 1, ws_key, value, gen),
     )
     assert ss.discover_claude_mcps(None) == ["mcp-1"]
 
@@ -1241,10 +1243,10 @@ def test_an_empty_mcp_cache_expires_fast_and_recovers(monkeypatch):
 
     # Age the entry past the empty TTL but well short of the success TTL: the
     # stale empty list still serves instantly, but a refresh must kick off.
-    stamp, ws_key, value = ss._claude_mcps_cache
+    stamp, ws_key, value, gen = ss._claude_mcps_cache
     assert value == ()
     aged = stamp - (ss._CLAUDE_DISCOVERY_EMPTY_TTL_SECONDS + 1)
-    monkeypatch.setattr(ss, "_claude_mcps_cache", (aged, ws_key, value))
+    monkeypatch.setattr(ss, "_claude_mcps_cache", (aged, ws_key, value, gen))
 
     assert ss.discover_claude_mcps(None) == []
     assert done.wait(timeout=5), "empty cache must re-discover in the background"
@@ -1390,8 +1392,139 @@ def test_clear_preserves_an_in_flight_probe(monkeypatch, tmp_path):
     release.set()
     assert request_done.wait(timeout=5), "request never served"
     waiter.join(timeout=5)
+    # The surviving probe started pre-clear, so its result is generation-stamped
+    # stale: the waiter re-probes rather than serving it — but only after the
+    # first probe fully finished (never two probes at once).
     assert results == [["Airtable"]]
-    assert len(calls) == 1, "request must reuse the probe that survived clear"
+    assert len(calls) == 2
+
+
+def test_verify_reprobes_after_waiting_out_a_preclear_probe(monkeypatch, tmp_path):
+    """A probe that started before Verify's bust must not be served or kept.
+
+    The startup warm-up may still be running when the user changes a connector
+    and clicks Verify. The cache clear preserves the in-flight probe, but its
+    result reflects pre-change configuration: the waiter must discard it,
+    re-probe with current configuration (without overlapping the old run),
+    and cache only the fresh result.
+    """
+    import threading
+    import time as _time
+
+    from ciao import setup_status as ss
+
+    calls = []
+    release = threading.Event()
+    request_done = threading.Event()
+
+    def probe(**kwargs):
+        calls.append(1)
+        if len(calls) == 1:
+            release.wait(timeout=5)
+            return ["Stale"]
+        return ["Fresh"]
+
+    monkeypatch.setattr(ss, "_discover_claude_mcps_uncached", probe)
+    monkeypatch.setattr(ss, "_claude_mcps_cache", None)
+    monkeypatch.setattr(ss, "_claude_mcps_refreshing", False)
+    monkeypatch.setattr(ss, "_claude_mcps_inflight", None)
+
+    ss.warm_claude_discovery_cache(tmp_path)
+    deadline = _time.monotonic() + 5
+    while not calls and _time.monotonic() < deadline:
+        _time.sleep(0.01)
+    assert calls == [1], "warm-up probe never started"
+
+    ss.clear_claude_discovery_cache()
+
+    results: list[list[str]] = []
+
+    def request() -> None:
+        results.append(ss.discover_claude_mcps(tmp_path))
+        request_done.set()
+
+    waiter = threading.Thread(target=request)
+    waiter.start()
+    _time.sleep(0.05)
+    assert len(calls) == 1, "no probe may overlap the in-flight one"
+
+    release.set()
+    assert request_done.wait(timeout=5), "waiter never re-probed"
+    waiter.join(timeout=5)
+    assert results == [["Fresh"]], "pre-clear result must not be served"
+    assert len(calls) == 2, "waiter must re-probe after the invalidated result"
+
+    # Only the fresh result may be cached, and it must serve without a re-probe.
+    assert ss.discover_claude_mcps(tmp_path) == ["Fresh"]
+    assert len(calls) == 2
+
+
+def test_stale_refresh_joins_the_single_flight(monkeypatch, tmp_path):
+    """The empty-TTL background refresh must register as the active probe.
+
+    Otherwise a Verify bust during the refresh claims ownership and stacks a
+    second concurrent `claude mcp list` racing the background cache write.
+    """
+    import threading
+    import time as _time
+
+    from ciao import setup_status as ss
+
+    calls = []
+    release = threading.Event()
+
+    def slow_probe(**kwargs):
+        calls.append(1)
+        release.wait(timeout=5)
+        return ["Refreshed"]
+
+    monkeypatch.setattr(ss, "_discover_claude_mcps_uncached", slow_probe)
+    monkeypatch.setattr(ss, "_claude_mcps_refreshing", False)
+    monkeypatch.setattr(ss, "_claude_mcps_inflight", None)
+
+    # Seed a cache entry the refresh path will treat as expired-empty.
+    stamp = _time.monotonic() - (ss._CLAUDE_DISCOVERY_EMPTY_TTL_SECONDS + 1)
+    monkeypatch.setattr(
+        ss,
+        "_claude_mcps_cache",
+        (stamp, str(tmp_path), (), ss._claude_mcps_generation),
+    )
+
+    assert ss.discover_claude_mcps(tmp_path) == []
+
+    deadline = _time.monotonic() + 5
+    while len(calls) < 1 and _time.monotonic() < deadline:
+        _time.sleep(0.01)
+    assert calls == [1], "expired-empty entry must start the background refresh"
+
+    deadline = _time.monotonic() + 5
+    while ss._claude_mcps_inflight is None and _time.monotonic() < deadline:
+        _time.sleep(0.01)
+    assert ss._claude_mcps_inflight is not None, "refresh never joined single-flight"
+
+    # A Verify-style bust + payload during the refresh must wait, not re-probe.
+    ss.clear_claude_discovery_cache()
+    assert ss._claude_mcps_inflight is not None
+
+    results: list[list[str]] = []
+    request_done = threading.Event()
+
+    def request() -> None:
+        results.append(ss.discover_claude_mcps(tmp_path))
+        request_done.set()
+
+    waiter = threading.Thread(target=request)
+    waiter.start()
+    _time.sleep(0.05)
+    assert len(calls) == 1, "payload must not stack a probe on the refresh"
+
+    release.set()
+    assert request_done.wait(timeout=5), "payload never served"
+    waiter.join(timeout=5)
+    # The refresh's result was stamped pre-clear (old generation), so the
+    # payload discards it and re-probes with the current generation.
+    assert results == [["Refreshed"]]
+    assert len(calls) == 2
 
 
 def test_waiter_reacquires_ownership_when_warmup_targets_another_root(

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -809,51 +809,6 @@
               >opencode permissions docs ↗</a>.
             </p>
 
-            <div v-for="(meta, key) in providerKeys.service_keys" :key="key" class="credential-row">
-              <div class="setting-row-main setting-row-main--inline">
-                <div class="routine-info">
-                  <span class="routine-name">{{ meta.label }}</span>
-                  <p class="hint hint--compact">{{ meta.description }}</p>
-                </div>
-                <span class="badge" :class="meta.configured ? 'badge--success' : 'badge--error'">
-                  {{ meta.configured ? 'Configured' : 'Unconfigured' }}
-                </span>
-              </div>
-              <input
-                type="password"
-                class="routine-input"
-                v-model="providerKeyInputs[key]"
-                :placeholder="meta.configured ? '•••••••••••• (Leave blank to keep existing, or type empty space to clear)' : 'Enter API Key'"
-                :disabled="providerKeysSaving"
-              />
-            </div>
-
-            <div v-for="(meta, key) in providerKeys.keys" :key="key" class="credential-row">
-              <div class="setting-row-main setting-row-main--inline">
-                <div class="routine-info">
-                  <span class="routine-name">{{ meta.label }}</span>
-                  <p class="hint hint--compact">{{ meta.description }}</p>
-                </div>
-                <span class="badge" :class="meta.configured ? 'badge--success' : 'badge--error'">
-                  {{ meta.configured ? (meta.auth_method === 'oauth' ? 'OAuth' : 'Configured') : 'Unconfigured' }}
-                </span>
-              </div>
-              <input
-                type="password"
-                class="routine-input"
-                v-model="providerKeyInputs[key]"
-                :placeholder="meta.configured ? '•••••••••••• (Leave blank to keep existing, or type empty space to clear)' : 'Enter API Key'"
-                :disabled="providerKeysSaving"
-              />
-            </div>
-
-
-            <div class="action-row settings-actions">
-              <button class="btn-primary" @click="saveProviderKeys" :disabled="providerKeysSaving">
-                {{ providerKeysSaving ? 'Saving...' : 'Save Keys' }}
-              </button>
-            </div>
-            <div v-if="providerKeysResult" class="action-result">{{ providerKeysResult }}</div>
            </div>
          </template>
       </template>
@@ -2968,13 +2923,10 @@ function routineModelSummary(key: RoutineModelKey): string {
 const providerKeys = ref<ProviderConfigSettings | null>(null)
 const providerKeysLoaded = ref(false)
 const providerKeysError = ref('')
-const providerKeysSaving = ref(false)
-const providerKeysResult = ref('')
 const mcpStatus = ref<McpStatus | null>(null)
 const mcpUsage = ref<McpUsage | null>(null)
 const mcpUsageLoaded = ref(false)
 const mcpUsageError = ref('')
-const providerKeyInputs = ref<Record<string, string>>({})
 const providerConnectionPending = ref('')
 const providerConnectionResult = ref('')
 const autoUpdateGithubSkills = ref(false)
@@ -3379,12 +3331,6 @@ async function fetchProviderKeys() {
   try {
     const res = await api.get<ProviderConfigSettings>('/api/settings/providers')
     providerKeys.value = res
-    for (const key in res.keys) {
-      providerKeyInputs.value[key] = ''
-    }
-    for (const key in res.service_keys || {}) {
-      providerKeyInputs.value[key] = ''
-    }
     if (res.auto_update_github_skills !== undefined) {
       autoUpdateGithubSkills.value = res.auto_update_github_skills
     }
@@ -3450,60 +3396,6 @@ async function providerConnectionAction(provider: string, action: 'connect' | 'v
     providerConnectionPending.value = ''
   }
 }
-
-async function saveProviderKeys() {
-  if (!providerKeys.value) return
-  providerKeysSaving.value = true
-  providerKeysResult.value = ''
-  
-  const patchKeys: Record<string, string> = {}
-  for (const key in providerKeys.value.keys) {
-    const val = providerKeyInputs.value[key]
-    if (val !== '') {
-      patchKeys[key] = val
-    }
-  }
-  for (const key in providerKeys.value.service_keys || {}) {
-    const val = providerKeyInputs.value[key]
-    if (val !== '') {
-      patchKeys[key] = val
-    }
-  }
-  
-  if (!Object.keys(patchKeys).length) {
-    providerKeysResult.value = 'No changes to save.'
-    providerKeysSaving.value = false
-    setTimeout(() => { providerKeysResult.value = '' }, 2000)
-    return
-  }
-  
-  try {
-    const res = await api.patch<ProviderConfigSettings>(
-      '/api/settings/providers',
-      { keys: patchKeys },
-    )
-    providerKeys.value = res
-    for (const key in res.keys) {
-      providerKeyInputs.value[key] = ''
-    }
-    for (const key in res.service_keys || {}) {
-      providerKeyInputs.value[key] = ''
-    }
-    if (res.auto_update_github_skills !== undefined) {
-      autoUpdateGithubSkills.value = res.auto_update_github_skills
-    }
-    providerKeysResult.value = ''
-    // A service key only reaches the process env on startup, so a change here
-    // always needs a restart. There is nothing else this save can change.
-    await restartAndReload('Configuration saved. Restarting Ciaobot to apply…')
-  } catch (e) {
-    providerKeysResult.value = `Error: ${errorMessage(e)}`
-  } finally {
-    providerKeysSaving.value = false
-  }
-}
-
-
 
 async function fetchSkills() {
   try {

--- a/web/src/components/__tests__/mountSmoke.test.ts
+++ b/web/src/components/__tests__/mountSmoke.test.ts
@@ -756,7 +756,7 @@ describe('component mount smoke', () => {
     wrapper.unmount()
   })
 
-  it('SettingsView shows the OpenAI voice key without provider protocol labels', async () => {
+  it('SettingsView renders no API-key entry UI even when the payload advertises keys', async () => {
     const router = makeRouter()
     await router.push('/settings/providers')
     await router.isReady()
@@ -767,11 +767,12 @@ describe('component mount smoke', () => {
     await flushPromises()
     await nextTick()
 
-    const voiceKeyRow = wrapper.findAll('.credential-row')
-      .find((row) => row.text().includes('OpenAI voice API key'))
-    expect(voiceKeyRow).toBeTruthy()
-    expect(voiceKeyRow!.text()).toContain('cloud transcription and speech')
-    expect(voiceKeyRow!.find('input[type="password"]').exists()).toBe(true)
+    // Provider auth goes through each CLI (`ciao auth <provider>`), so the old
+    // key-entry rows and Save Keys button are gone — even if a stale payload
+    // still advertises key metadata.
+    expect(wrapper.text()).not.toContain('OpenAI voice API key')
+    expect(wrapper.findAll('input[type="password"]').length).toBe(0)
+    expect(wrapper.text()).not.toContain('Save Keys')
     expect(wrapper.text()).not.toContain('Agent SDK ready')
     expect(wrapper.text()).not.toContain('app-server protocol compatible')
     expect(wrapper.text()).not.toContain('connection and protocol')


### PR DESCRIPTION
## Summary

Three fixes for the Settings → Providers tab, from dogfooding on an install with ~28 claude.ai connectors:

1. **Remove the Save Keys button and key-entry rows.** Both key-metadata catalogs (`_PROVIDER_KEY_META` / `_SERVICE_KEY_META`) are empty — provider auth goes through each CLI — so the button could only ever say "No changes to save." The model/thinking dropdowns already auto-save via `/api/settings/routines`.

2. **Fix MCP servers always showing (0).** `claude mcp list` health-checks every configured connector before printing; a healthy run measures ~11–12s with ~30 connectors, and the 12s subprocess timeout swallowed the failure and cached the empty list for the full 5-minute TTL. Changes:
   - timeout 12s → 30s
   - empty results expire in 15s (successes keep the 300s TTL) so the stale-while-revalidate retry recovers quickly
   - app startup warms the discovery cache in a background thread so the first Providers visit serves a populated list instead of blocking on the probe

3. **Surface standalone skills.** `claude plugin list` only reports plugins, and the `~/.claude/skills` directory scan only ran as a fallback when the CLI reported nothing — so hand-installed skills (e.g. `ego-browser`) were invisible whenever any plugin was enabled. The directory now merges into the result unconditionally; disabled plugins stay filtered.

## Test plan

- [x] `pytest tests/` — 2837 passed
- [x] `cd web && npm run build` (includes `vue-tsc --noEmit`)
- [x] `cd web && npm test` — 826 passed (updated the mount-smoke test that asserted the removed key-row UI; it now guards the removal)
- [x] Manual: bundled-CLI `claude mcp list` from the workspace root returns 11 connected connectors in ~11.4s (previously timed out at 12s → cached empty)