### PR TITLE
feat(memory, viewer): workspace guide card + discuss-in-chat + viewer simplification + memory map fixes

### DIFF
--- a/docs/plans/GWS_CLI_WRAPPER_PLAN.md
+++ b/docs/plans/GWS_CLI_WRAPPER_PLAN.md
@@ -1,0 +1,231 @@
+# Route Google Workspace auth through the installed `ciao` CLI
+
+## Resume block
+
+- Status: proposed
+- Current checkpoint: C2 (direction set, awaiting approval)
+- Next action: get approval, then implement C6
+- Blocker: none
+- Implementation repository: `/Users/raffaelefarinaro/repos/ciaobot`
+- Generated plan output: `docs/plans/GWS_CLI_WRAPPER_PLAN.md`
+- Visual companions: none (no spatial/UI-state question to answer)
+- Verified on: 2026-08-26 against `scripts/gws-profile.sh`, `scripts/gws-auth-helper.py`, `ciao/gws_auth.py`, `ciao/gws_skills.py`, `ciao/cli.py`, `ciao/config.py`, `ciao/web/routes_api.py`, `web/src/components/SettingsView.vue`, `ciao/system_prompt.md`, `ciao/stock/agents/secretary.md`, `INTEGRATIONS.md`, `docs/ARCHITECTURE.md`, `desktop/src-tauri/src/service.rs`, `scripts/build-bundled-runtime.sh`, `scripts/install.sh`, `tests/test_gws_auth.py`, `tests/test_gws_skills.py`, `tests/test_core_prompt.py`, `tests/test_workspace_settings_routes.py`
+
+## Outcome and user value
+
+Today the Google Workspace integration depends on two files that only exist in a git checkout of the repo: `scripts/gws-profile.sh` (the profile wrapper) and `scripts/gws-auth-helper.py` (headless re-auth). Someone who installed Ciaobot.app has neither, so:
+
+- the Settings → Workspaces card shows terminal commands (`scripts/gws-profile.sh <profile> auth setup --login`, `python3 scripts/gws-auth-helper.py <profile>`) that cannot run;
+- the `gws-*` skills tell the agent to run `scripts/gws-profile.sh "$GWS_PROFILE" ...`, which fails in an installed workspace;
+- the token-health monitor silently degrades to `available: false, reason: "wrapper script not found"`.
+
+The fix routes every one of these through the `ciao` CLI that ships inside the installed app (`.../ciao-runtime/bin/ciao`), so the same command works on a dev checkout and on an installed app. The repo scripts become thin shims so nothing external breaks.
+
+## Scope and non-goals
+
+In scope:
+
+- New `ciao gws` subcommand: profile-aware passthrough to the `gws` CLI (replaces the bash wrapper's logic).
+- New `ciao gws-auth-helper` subcommand: headless OAuth re-auth moved into the package (replaces `scripts/gws-auth-helper.py`).
+- `ciao.gws_auth.auth_status` runs `gws auth status` directly with the computed env (no bash wrapper dependency).
+- Update Settings hints (`routes_api.py` payload + `SettingsView.vue` hardcoded hint) to the new commands.
+- Update `gws_skills.py` curation/rewrite rules and regenerate the stock `gws-*` skills; update `system_prompt.md` and `ciao/stock/agents/secretary.md`.
+- Keep `scripts/gws-profile.sh` and `scripts/gws-auth-helper.py` as thin shims forwarding to the new subcommands.
+- Update docs (`INTEGRATIONS.md`, `docs/ARCHITECTURE.md`) and tests.
+
+Out of scope for this release:
+
+- Adding `ciao` to the user's shell PATH automatically (installer symlink). The UI will show `ciao gws ...`; setup already prints an `export PATH=...` hint. Revisit only if users report friction.
+- Changing the PWA-native OAuth flow (upload `client_secret.json` → browser exchange). It already works on installed apps and is untouched.
+- Renaming the `gws` CLI or its service names.
+
+## Current-state evidence
+
+Observed (read the files):
+
+- `scripts/gws-profile.sh` (60 lines): resolves profile (positional first-arg disambiguation against `GWS_SERVICE_NAMES`, else `GWS_PROFILE`), sets `GOOGLE_WORKSPACE_CLI_CONFIG_DIR=<root>/secrets/gws[-<slug>]` (legacy `personal`→`gws-personal`, `work`→`gws`), unsets `GOOGLE_APPLICATION_CREDENTIALS`, `exec gws "$@"`. Lives only in the repo.
+- `scripts/gws-auth-helper.py` (316 lines): interactive headless OAuth re-auth. Duplicates logic already in `ciao/gws_auth.py` (`FULL_SCOPES`/`_PERSONAL_SCOPES`, `exchange_code`, `save_credentials`, `extract_email_from_id_token`, `profile_config_dir`). `ciao/gws_auth.py:52-53` already flags the duplication.
+- `ciao/gws_auth.py:103-118` `profile_config_dir(config, profile)` is the single source of truth for the credential dir mapping; `:140-142` `slugify_profile`; `:76-89` `GWS_SERVICE_NAMES`.
+- `ciao/gws_auth.py:538-592` `wrapper_path()` + `auth_status()`: runs `bash <workspace>/scripts/gws-profile.sh <profile> auth status`; returns `available: False, reason: "wrapper script not found"` when the file is absent.
+- `ciao/web/routes_api.py:1404-1409,1476-1477`: builds `setup_command = "scripts/gws-profile.sh {profile} auth login --full"` and `headless_auth_command = "python3 scripts/gws-auth-helper.py {profile}"`; exposes `wrapper_available`/`helper_available`/`wrapper_path`/`headless_helper_path`.
+- `web/src/components/SettingsView.vue:1207-1213` renders `setup_command`/`headless_auth_command`; `:1223` hardcodes `scripts/gws-profile.sh {{ profile.name }} auth setup`.
+- `ciao/gws_skills.py:47-63` `_CIAOBOT_SHARED_HEAD` and `:143-169` `rewrite_gws_commands` emit `scripts/gws-profile.sh "$GWS_PROFILE" ...`; `curate_gws_skill` applies them. Stock skills under `ciao/stock/skills/gws-*/SKILL.md` are generated + curated.
+- `ciao/system_prompt.md:25` and `ciao/stock/agents/secretary.md` reference `scripts/gws-profile.sh`.
+- `INTEGRATIONS.md:88-98,331` and `docs/ARCHITECTURE.md:149-150` document the repo scripts.
+- `ciao/cli.py:2876` `build_parser()` adds subcommands; `:3862` `main()` dispatches via `args.func`. `ciao/config.py:1259` `CiaoConfig.from_env()` loads config from env/`.env`.
+- Bundled engine: `~/Applications/Ciaobot.app/Contents/Resources/ciao-runtime/bin/ciao`; the launcher (`scripts/build-bundled-runtime.sh:157`) exports `PATH="$root/bin:$PATH"`, so agent-spawned shells resolve `ciao`. `desktop/src-tauri/src/service.rs:37-54` `resolve_ciao` resolves the bundled engine.
+- `gws` CLI 0.22.5 installed at `/opt/homebrew/bin/gws` (needed to regenerate stock skills).
+- Tests referencing the wrapper: `tests/test_gws_auth.py:219-267`, `tests/test_gws_skills.py:160`, `tests/test_core_prompt.py:28`, `tests/test_workspace_settings_routes.py:535,573`.
+
+Assumed (not yet verified):
+
+- Installed users do not have `ciao` on PATH in their own terminal by default; setup prints an `export PATH=...` hint (`ciao/cli.py:256-276,293-296`). Agent-spawned shells do get it via the launcher PATH export.
+- The signed updater replaces the bundle in place, so the engine path is stable across updates.
+
+## Recommended direction
+
+Add two `ciao` subcommands and route every GWS terminal path through them.
+
+1. **`ciao gws`** — passthrough that replicates the bash wrapper in Python, reusing `ciao.gws_auth`:
+   - Resolve profile: first positional arg that is not a service name and does not start with `-` (mirror `GWS_SERVICE_NAMES` disambiguation), else `GWS_PROFILE` env, else the workspace's default profile.
+   - Compute `GOOGLE_WORKSPACE_CLI_CONFIG_DIR` via `gws_auth.profile_config_dir(config, profile)`; unset `GOOGLE_APPLICATION_CREDENTIALS`.
+   - `os.execvp("gws", ...)` with the remaining args; friendly error when `gws` is not on PATH (point to Settings → Workspaces install button).
+   - New module `ciao/gws_wrapper.py` with a `main(argv)`; registered in `build_parser()`.
+
+2. **`ciao gws-auth-helper`** — move `scripts/gws-auth-helper.py` into the package as `ciao/gws_auth_helper.py`, reusing `ciao.gws_auth` (drop the duplicated `FULL_SCOPES`/exchange/save code). Registered in `build_parser()`.
+
+3. **`gws_auth.auth_status`** — stop shelling out to the bash wrapper. Compute the env in-process and run `[gws_bin, "auth", "status"]` directly (it already resolves `gws` via `tool_path.resolve_tool`). Remove `wrapper_path()` and its uses.
+
+4. **Settings hints** — `routes_api.py`:
+   - `setup_command` → `ciao gws {profile} auth login --full`
+   - `headless_auth_command` → `ciao gws-auth-helper {profile}`
+   - Replace `wrapper_available`/`helper_available`/`wrapper_path`/`headless_helper_path` with a single `cli_available` (whether `gws` is on PATH) or drop them if the UI does not use them (verify; `SettingsView.vue` only reads `setup_command`/`headless_auth_command`).
+   - `SettingsView.vue:1223` hardcoded hint → `ciao gws {{ profile.name }} auth setup`.
+
+5. **Skills** — update `gws_skills.py`:
+   - `_CIAOBOT_SHARED_HEAD` prose → `ciao gws "$GWS_PROFILE" <service> <subcommand> [flags]`.
+   - `rewrite_gws_commands` → prefix `ciao gws "$GWS_PROFILE" ` instead of `scripts/gws-profile.sh "$GWS_PROFILE" `.
+   - Regenerate the stock `gws-*` skills with the installed `gws` 0.22.5 (release flow `ciao release` does this; run the same regeneration here).
+   - Update `ciao/system_prompt.md:25` and `ciao/stock/agents/secretary.md`.
+
+6. **Shims** — rewrite `scripts/gws-profile.sh` to `exec ciao gws "$@"` and `scripts/gws-auth-helper.py` to `exec ciao gws-auth-helper "$@"` (or `python -m ciao.cli ...`), so dev checkouts and any external references keep working.
+
+7. **Docs + tests** — update `INTEGRATIONS.md`, `docs/ARCHITECTURE.md:149-150`, and the affected tests; add tests for the new subcommands (profile resolution, env computation, exec) and for `auth_status` via direct `gws` invocation.
+
+## Alternatives and rejected options
+
+### Seed `scripts/gws-profile.sh` into the workspace during setup
+
+Copy the wrapper + helper into `<workspace>/scripts/` at setup time, keeping the existing relative-path hints and skills unchanged.
+
+Rejected: it leaves two sources of truth (repo scripts + seeded copies) that drift, does not fix the agent-side skills on already-configured workspaces without a re-seed, and the user explicitly asked for the CLI-based approach ("with the ciao cli that gets installed automatically"). The CLI is the single canonical entry point.
+
+### Keep the bash wrapper and only change the hints
+
+Rejected: the wrapper still only exists in the repo; installed users would still be shown a command that cannot run.
+
+### Add a `ciao` PATH symlink in the installer
+
+Rejected for this release: writing to `/usr/local/bin` may need sudo and `~/.local/bin` may not be on PATH; setup already prints an `export PATH=...` hint. Deferred as a follow-up if users report friction.
+
+## Visual review
+
+Not applicable. This is a CLI/plumbing change with no spatial or UI-state question to answer; the Settings card text change is a one-line string swap.
+
+## Decisions and hard-to-reverse bets
+
+| ID | Decision | Rationale | Status |
+| --- | --- | --- | --- |
+| D-01 | Add `ciao gws` and `ciao gws-auth-helper` subcommands as the canonical GWS terminal entry points | The bundled engine ships with every install; one entry point works on dev and installed apps | Proposed |
+| D-02 | `auth_status` runs `gws auth status` directly with in-process env, dropping the bash wrapper | Removes the filesystem dependency; `gws` is already resolved via `tool_path` | Proposed |
+| D-03 | Keep `scripts/gws-profile.sh` and `scripts/gws-auth-helper.py` as thin shims | Back-compat for dev checkouts and any external references; cheap | Proposed |
+| D-04 | Regenerate stock `gws-*` skills from the installed `gws` 0.22.5 | Keeps the generated files consistent with the new rewrite rules | Proposed |
+| D-05 | UI shows `ciao gws ...`; no installer PATH symlink this release | Consistent with existing CLI docs; setup already prints a PATH hint | Proposed |
+
+## Open questions with recommended defaults
+
+| ID | Question | Recommended default | Status |
+| --- | --- | --- | --- |
+| Q-01 | Should `ciao gws` also accept `--profile <name>` in addition to the positional form? | Yes — add `--profile` for clarity; keep positional for skill compatibility | Open |
+| Q-02 | Does the Settings UI use `wrapper_available`/`helper_available`/`wrapper_path`/`headless_helper_path` anywhere? | Verify; if unused, replace with a single `cli_available` flag | Open |
+| Q-03 | Should the repo shims forward via `ciao` (PATH) or via the absolute engine path? | `ciao` on PATH for dev checkouts; document the absolute path for installed users | Open |
+
+## Not yet specified (fog of war)
+
+- Whether the PWA Settings card should offer a "copy command" button with the absolute engine path for installed users who lack `ciao` on PATH. Not phraseable until Q-03 is resolved and the UI text is finalized.
+- Whether the `gws-shared` skill's "Install gws from Settings → Workspaces" note needs a companion note about `ciao` being on PATH. Likely, but depends on the final hint wording.
+
+## Feedback and decision log
+
+| ID | Location | Feedback | Decision | Status | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| F-01 | chat | "for someone that installed ciaobot, where is this?" (the wrapper) | Root cause: wrapper only exists in a git checkout; route through the installed `ciao` CLI | accepted | this plan |
+| F-02 | chat | "ideally we can do this with the ciao cli that gets installed automatically otherwise it makes no sense" | Adopt the `ciao gws` / `ciao gws-auth-helper` subcommand approach | accepted | D-01 |
+
+## Implementation checkpoints
+
+Each checkpoint has an exit condition so another model can tell whether the work is actually ready to move on.
+
+### C0. Start or resume
+
+- Read the Resume block and current checkpoint.
+- Read the project canonical document (`docs/ARCHITECTURE.md`, `docs/DEVELOPMENT.md`) and the live files named by the plan.
+- Confirm the plan's status still matches the repository.
+
+Exit evidence: the plan records the next concrete action and any blocker.
+
+### C1. Ground the plan
+
+- Name the actual files, symbols, routes, components, and data shapes involved (done above).
+- Separate observed facts from assumptions (done above).
+
+Exit evidence: a reader can verify the current-state claims without relying on chat history.
+
+### C2. Set direction
+
+- Choose one recommended approach (done above).
+- Record alternatives and rejected options (done above).
+- Mark unresolved items as open questions with defaults (done above).
+
+Exit evidence: the plan is executable in one direction.
+
+### C3. Build the review artifact
+
+- Write the Markdown plan (this file).
+- No visual companions needed.
+
+Exit evidence: the plan is surfaced and self-contained.
+
+### C4. Review the artifact
+
+- Inspect the plan for filler, invented paths, and claims not grounded in the files read.
+
+Exit evidence: the first screen makes the proposed outcome understandable without the chat transcript.
+
+### C5. Get approval
+
+- Surface the plan and name the files/areas implementation will touch.
+- Capture user comments in the feedback log.
+- Mark the plan `approved` only after the user accepts the direction.
+
+Exit evidence: the plan states what is approved and what remains deferred.
+
+### C6. Implement
+
+- Re-read the approved plan before editing.
+- Work through the tasks in order:
+  1. `ciao/gws_wrapper.py` + `ciao gws` subcommand.
+  2. `ciao/gws_auth_helper.py` + `ciao gws-auth-helper` subcommand (reuse `ciao.gws_auth`).
+  3. `gws_auth.auth_status` direct invocation; remove `wrapper_path()`.
+  4. `routes_api.py` hints + `SettingsView.vue:1223`.
+  5. `gws_skills.py` rewrite/curation + regenerate stock skills; `system_prompt.md`; `secretary.md`.
+  6. Repo shims (`scripts/gws-profile.sh`, `scripts/gws-auth-helper.py`).
+  7. Docs (`INTEGRATIONS.md`, `docs/ARCHITECTURE.md`) and tests.
+- Update the plan when scope changes instead of silently changing course in chat.
+
+Exit evidence: every planned source change has a corresponding implementation or an explicit deferral.
+
+### C7. Verify
+
+- Run focused tests first (`tests/test_gws_auth.py`, `tests/test_gws_skills.py`, `tests/test_core_prompt.py`, `tests/test_workspace_settings_routes.py`), then `pytest tests/`.
+- Run `cd web && npm run build` after the frontend change.
+- Verify the new subcommands manually: `ciao gws --help`, `ciao gws-auth-helper --help`, and a `ciao gws <profile> auth status` against a real profile.
+- Record failures, skipped checks, and live verification limits.
+
+Exit evidence: the plan distinguishes verified behavior from work that is only merged or assumed to be deployed.
+
+### C8. Close or hand off
+
+- Set the final status to `complete`, `deferred`, or `blocked`.
+- Record the last verified commit or deployment state.
+- Leave a next action only when work remains.
+
+Exit evidence: another model can tell whether it should continue, verify, or stop.
+
+## Verification and rollout
+
+- Backend: `pytest tests/` (focused first, then full).
+- Frontend: `cd web && npm run build`.
+- Manual: run `ciao gws --help`, `ciao gws-auth-helper --help`, and `ciao gws <profile> auth status` against a real profile; confirm the Settings card shows the new commands.
+- Rollout: this ships in the next release via the normal `ciao release` flow (which regenerates the stock `gws-*` skills from the installed `gws` CLI). The repo shims keep dev checkouts working immediately.
+- Note: the agent-side `gws-*` skills only take effect in a workspace after `ciao sync-skills` refreshes the `.claude/skills/` catalog (runs on startup).

--- a/web/src/components/FileViewerModal.vue
+++ b/web/src/components/FileViewerModal.vue
@@ -71,17 +71,24 @@
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 1 1 3 3L12 15l-4 1 1-4z"/></svg>
           </button>
+          <button
+            v-if="store.path"
+            class="btn-icon"
+            title="Discuss in chat"
+            aria-label="Discuss in chat"
+            @click="discussInChat"
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>
+          </button>
           <button class="btn-icon" @click="store.close()" title="Close (Esc)" aria-label="Close">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
           </button>
         </div>
       </header>
 
-      <!-- Tabs strip. Hidden in image mode (no diff/history makes sense for
-           binary image files). History and Diff are also disabled when the
-           viewer was opened without a chat context (e.g. clicking a path in
-           the chat trace text — those flows have no chat_id to key by). -->
-      <nav v-if="store.kind !== 'image' && store.kind !== 'pdf'" class="fv-tabs" aria-label="View mode">
+      <!-- Tabs strip. History and Diff were removed as overkill for the viewer;
+           Preview is the only reading/editing surface, Backlinks stays for markdown notes. -->
+      <nav v-if="store.kind !== 'image' && store.kind !== 'pdf' && isMarkdown" class="fv-tabs" aria-label="View mode">
         <button
           class="fv-tab"
           :class="{ active: store.tab === 'preview' }"
@@ -89,23 +96,6 @@
           type="button"
         >Preview</button>
         <button
-          class="fv-tab"
-          :class="{ active: store.tab === 'history', disabled: !store.chatId }"
-          :disabled="!store.chatId"
-          :title="store.chatId ? '' : 'Open from an inline file card to see history'"
-          @click="store.setTab('history')"
-          type="button"
-        >History<span v-if="store.snapshots.length" class="fv-tab-badge">{{ store.snapshots.length }}</span></button>
-        <button
-          class="fv-tab"
-          :class="{ active: store.tab === 'diff', disabled: !store.chatId }"
-          :disabled="!store.chatId"
-          :title="store.chatId ? '' : 'Open from an inline file card to see diff'"
-          @click="store.setTab('diff')"
-          type="button"
-        >Diff</button>
-        <button
-          v-if="isMarkdown"
           class="fv-tab"
           :class="{ active: store.tab === 'backlinks' }"
           @click="loadBacklinks"
@@ -148,60 +138,6 @@
                   {{ store.editSaving ? 'Saving…' : 'Save' }}
                 </button>
               </div>
-            </div>
-          </template>
-
-          <!-- History tab: snapshot list with action labels and Restore. -->
-          <template v-else-if="store.tab === 'history'">
-            <div v-if="store.snapshotsLoading" class="fv-loading">Loading history…</div>
-            <div v-else-if="store.snapshotsError" class="fv-error">{{ store.snapshotsError }}</div>
-            <div v-else-if="!store.snapshots.length" class="fv-empty">No snapshots yet for this file in this chat.</div>
-            <ul v-else class="fv-history-list">
-              <li
-                v-for="s in [...store.snapshots].reverse()"
-                :key="s.seq"
-                class="fv-history-item"
-              >
-                <div class="fv-history-line">
-                  <span class="fv-history-seq">#{{ s.seq }}</span>
-                  <span class="fv-history-action">{{ s.action }}</span>
-                  <span class="fv-history-tool">{{ s.tool }}</span>
-                  <span class="fv-history-ts">{{ formatHistoryTs(s.ts) }}</span>
-                </div>
-                <div class="fv-history-actions">
-                  <button class="fv-btn-sm" @click="diffAgainstSeq(s.seq)" title="Compare this snapshot with the previous one">Diff</button>
-                  <button class="fv-btn-sm" @click="restoreSeq(s.seq)" title="Write this snapshot back to disk">Restore</button>
-                </div>
-              </li>
-            </ul>
-          </template>
-
-          <!-- Diff tab: terminal-style changed lines only. -->
-          <template v-else-if="store.tab === 'diff'">
-            <div v-if="store.diffLoading" class="fv-loading">Loading diff…</div>
-            <div v-else-if="store.diffError" class="fv-error">{{ store.diffError }}</div>
-            <div v-else-if="!store.snapshots.length" class="fv-empty">No snapshots yet for this file in this chat.</div>
-            <div v-else class="fv-diff-shell">
-              <div class="fv-diff-picker">
-                <label class="fv-diff-label">From
-                  <select v-model.number="store.diffSeqA" @change="store.setDiffSeqs(Number(store.diffSeqA), Number(store.diffSeqB))">
-                    <option v-for="s in store.snapshots" :key="`a-${s.seq}`" :value="s.seq">#{{ s.seq }} {{ s.action }} {{ formatHistoryTs(s.ts) }}</option>
-                  </select>
-                </label>
-                <span class="fv-diff-arrow">→</span>
-                <label class="fv-diff-label">To
-                  <select v-model.number="store.diffSeqB" @change="store.setDiffSeqs(Number(store.diffSeqA), Number(store.diffSeqB))">
-                    <option :value="0">current on disk</option>
-                    <option v-for="s in store.snapshots" :key="`b-${s.seq}`" :value="s.seq">#{{ s.seq }} {{ s.action }} {{ formatHistoryTs(s.ts) }}</option>
-                  </select>
-                </label>
-              </div>
-              <pre class="fv-diff-pre"><code><span
-                v-for="(line, i) in diffLines"
-                :key="i"
-                :class="['fv-diff-line', `fv-diff-${line.kind}`]"
-              >{{ diffPrefix(line.kind) }}{{ line.text }}
-</span></code></pre>
             </div>
           </template>
 
@@ -394,9 +330,7 @@ import { parseFrontmatter } from '../lib/markdownFrontmatter'
 import { renderFileMarkdown } from '../lib/safeMarkdown'
 import { buildMarkdownIndex, resolveVaultLinkTarget } from '../lib/vaultLinks'
 import { openWorkspaceFileExternally } from '../lib/openWorkspaceFile'
-import { createTerminalDiffLines, terminalDiffPrefix, type TerminalDiffKind } from '../lib/terminalDiff'
 import { isCsvPath } from '../lib/csv'
-import { askConfirm } from '../lib/confirm'
 import { useFileComments } from '../composables/useFileComments'
 import { writeClipboard } from '../lib/codeCopy'
 import CommentComposePopover from './CommentComposePopover.vue'
@@ -444,20 +378,6 @@ const canEdit = computed(() => {
   return store.kind === 'text'
 })
 
-// History tab timestamp formatting. Snapshots store ISO 8601; we want a
-// short local form: "May 18, 14:32".
-function formatHistoryTs(iso: string): string {
-  if (!iso) return ''
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return iso
-  return d.toLocaleString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
-}
-
 interface BacklinkItem {
   path: string
   title: string
@@ -503,41 +423,6 @@ watch(
     loadingBacklinks.value = false
   },
 )
-
-// Click Diff next to a snapshot row in History: compares it with the
-// snapshot immediately before it (or the only snapshot vs current on disk
-// when there's just one).
-async function diffAgainstSeq(seq: number): Promise<void> {
-  const snaps = store.snapshots
-  const idx = snaps.findIndex((s: { seq: number }) => s.seq === seq)
-  let a = 0, b = seq
-  if (idx > 0) {
-    a = snaps[idx - 1].seq
-  } else {
-    // First snapshot: diff against current on-disk content. 0 is the
-    // sentinel for "current" in the store's _fetchSeq path.
-    a = seq
-    b = 0
-  }
-  await store.setTab('diff')
-  await store.setDiffSeqs(a, b)
-}
-
-async function restoreSeq(seq: number): Promise<void> {
-  if (!await askConfirm(`Restore snapshot #${seq} to disk? This writes a new snapshot so it can be undone.`, {
-    title: 'Restore snapshot',
-    confirmLabel: 'Restore',
-    destructive: true,
-  })) return
-  const ok = await store.restoreSnapshot(seq)
-  if (!ok) projectsStore.pushErrorToast('Restore failed', `Could not restore snapshot #${seq}. See network console for details.`)
-}
-
-const diffLines = computed(() => createTerminalDiffLines(store.diffContentA, store.diffContentB))
-
-function diffPrefix(kind: TerminalDiffKind): string {
-  return terminalDiffPrefix(kind)
-}
 
 // Split frontmatter off so the body renders cleanly and the metadata card
 // at the top can show key fields as pills/chips. Mirrors PinnedFilePanel.
@@ -1262,6 +1147,21 @@ async function openExternally(): Promise<void> {
   }
   openExternalState.value = ''
   projectsStore.pushErrorToast('Could not open file', result.error)
+}
+
+async function discussInChat(): Promise<void> {
+  const path = store.path
+  if (!path) return
+  const ws = projectsStore.activeWorkspace
+  const general = projectsStore.projects.find(p => p.workspace === ws && p.is_auto && p.name === 'General')
+  if (!general) { projectsStore.pushErrorToast('Cannot start chat', 'No General project found in this workspace.'); return }
+  const title = `Discuss ${path.split('/').pop() || path}`
+  const seed = `Let's discuss the file \`${path}\`. Help me understand, review, or improve it.`
+  try {
+    const chat = await projectsStore.createChat(general.project_id, title, seed)
+    projectsStore.pinFile(chat.chat_id, path)
+    await store.close(true)
+  } catch (e) { projectsStore.pushErrorToast('Could not start discussion', e instanceof Error ? e.message : String(e)) }
 }
 
 // Download the currently-open file. For images we hand the browser the

--- a/web/src/components/MemoryMapView.vue
+++ b/web/src/components/MemoryMapView.vue
@@ -288,8 +288,15 @@ function safeSetDetailWidth(v: number) {
 }
 const detailWidth = ref(safeGetDetailWidth())
 const isDraggingDetail = ref(false)
+// The inline grid-template-columns would otherwise outrank the
+// `@media (max-width: 900px)` rule that restores a single full-width column
+// (and hides the panel). Only apply the persisted width above the desktop
+// breakpoint so a phone never reserves a 220-560px column for a hidden panel.
+const isNarrow = ref(window.innerWidth <= 900)
+function onResizeNarrow() { isNarrow.value = window.innerWidth <= 900 }
+if (typeof window !== 'undefined') window.addEventListener('resize', onResizeNarrow)
 const detailBodyStyle = computed(() => {
-  if (!mm.selectedNode) return undefined
+  if (!mm.selectedNode || isNarrow.value) return undefined
   return { gridTemplateColumns: `1fr ${detailWidth.value}px` } as Record<string, string>
 })
 let detailDragStartX = 0
@@ -1402,6 +1409,7 @@ onBeforeUnmount(() => {
   window.removeEventListener('mouseup', onMouseUp)
   window.removeEventListener('mousemove', handleDetailDrag)
   window.removeEventListener('mouseup', stopDetailDrag)
+  window.removeEventListener('resize', onResizeNarrow)
   document.body.classList.remove('is-dragging-layout')
 })
 </script>

--- a/web/src/components/MemoryMapView.vue
+++ b/web/src/components/MemoryMapView.vue
@@ -4,7 +4,7 @@
 
     <ProposalReviewPanel v-if="mm.view === 'review'" />
 
-    <div v-else class="mm-body" :class="{ 'mm-body--detail-open': !!mm.selectedNode }">
+    <div v-else class="mm-body" :class="{ 'mm-body--detail-open': !!mm.selectedNode, 'mm-body--dragging-detail': isDraggingDetail }" :style="detailBodyStyle">
       <div v-if="mm.loading" class="mm-skeleton" role="status" aria-live="polite" aria-label="Loading vault graph">
         <div class="mm-brain-skeleton" aria-hidden="true">
           <svg viewBox="0 0 200 140" class="mm-brain-svg">
@@ -162,6 +162,12 @@
       </div>
 
       <aside v-if="mm.selectedNode" class="mm-detail">
+        <div
+          class="mm-detail-resizer"
+          @mousedown="startDetailDrag"
+          title="Drag to resize"
+          aria-hidden="true"
+        ></div>
         <button
           type="button"
           class="mm-detail-close"
@@ -175,7 +181,6 @@
           <span v-if="mm.selectedNode.stale" class="stale-badge" title="Unverified past this note type's staleness horizon">needs review</span>
         </div>
         <div v-if="ageLabelOfSelected" class="mm-detail-verified">Last verified {{ ageLabelOfSelected }} ago</div>
-        <div v-if="mm.selectedNode.description" class="mm-detail-desc">{{ mm.selectedNode.description }}</div>
         <button type="button" class="mm-detail-path" @click="openNoteFile(mm.selectedNode.id)">{{ mm.selectedNode.id }}</button>
 
         <div class="mm-detail-section mm-detail-preview">
@@ -260,6 +265,69 @@ const emit = defineEmits<{ 'open-sidebar': [] }>()
 const store = useProjectStore()
 const mm = useMemoryMapStore()
 const fileViewer = useFileViewerStore()
+
+// ---------- detail panel resizer ----------
+// Mirrors ChatLayout's sidebar resizer: draggable, persisted, snaps to default.
+const DETAIL_DEFAULT_WIDTH = 320
+const DETAIL_MIN_WIDTH = 220
+const DETAIL_MAX_WIDTH = 560
+const DETAIL_SNAP_THRESHOLD = 12
+function safeGetDetailWidth(): number {
+  try {
+    const raw = typeof localStorage !== 'undefined' ? localStorage.getItem('ciao:mm-detail-width') : null
+    const n = raw ? Number(raw) : NaN
+    return Number.isFinite(n) ? n : DETAIL_DEFAULT_WIDTH
+  } catch {
+    return DETAIL_DEFAULT_WIDTH
+  }
+}
+function safeSetDetailWidth(v: number) {
+  try {
+    if (typeof localStorage !== 'undefined') localStorage.setItem('ciao:mm-detail-width', String(v))
+  } catch {}
+}
+const detailWidth = ref(safeGetDetailWidth())
+const isDraggingDetail = ref(false)
+const detailBodyStyle = computed(() => {
+  if (!mm.selectedNode) return undefined
+  return { gridTemplateColumns: `1fr ${detailWidth.value}px` } as Record<string, string>
+})
+let detailDragStartX = 0
+let detailDragStartWidth = 0
+function startDetailDrag(e: MouseEvent) {
+  e.preventDefault()
+  isDraggingDetail.value = true
+  detailDragStartX = e.clientX
+  detailDragStartWidth = detailWidth.value
+  window.addEventListener('mousemove', handleDetailDrag)
+  window.addEventListener('mouseup', stopDetailDrag)
+  document.body.classList.add('is-dragging-layout')
+}
+function handleDetailDrag(e: MouseEvent) {
+  if (!isDraggingDetail.value) return
+  // Dragging the left edge: moving left (negative delta) grows the panel.
+  const delta = detailDragStartX - e.clientX
+  let next = detailDragStartWidth + delta
+  if (Math.abs(next - DETAIL_DEFAULT_WIDTH) < DETAIL_SNAP_THRESHOLD) next = DETAIL_DEFAULT_WIDTH
+  next = Math.max(DETAIL_MIN_WIDTH, Math.min(DETAIL_MAX_WIDTH, next))
+  detailWidth.value = next
+  // Keep the canvas backing store in sync while dragging, not only on release —
+  // otherwise the canvas stays stretched at the old W/H until mouseup.
+  resizeCanvas()
+  requestRedraw()
+}
+function stopDetailDrag() {
+  if (!isDraggingDetail.value) return
+  isDraggingDetail.value = false
+  safeSetDetailWidth(detailWidth.value)
+  window.removeEventListener('mousemove', handleDetailDrag)
+  window.removeEventListener('mouseup', stopDetailDrag)
+  document.body.classList.remove('is-dragging-layout')
+  // Resizing the panel changes the canvasWrap width; re-measure the canvas and
+  // re-draw at the new size so it doesn't stay stretched or clipped.
+  resizeCanvas()
+  requestRedraw()
+}
 
 // The canvas paints with literal colours while the rest of the app switches
 // theme through CSS custom properties, so it has to read the resolved values
@@ -1237,8 +1305,19 @@ function onMouseUp() {
 }
 function onWheel(e: WheelEvent) {
   cancelCameraTween()
+  if (!canvasEl.value || !W || !H) return
+  const rect = canvasEl.value.getBoundingClientRect()
+  // Cursor in device pixels, same coordinate space as W/H and worldToScreen.
+  const sx = (e.clientX - rect.left) * dpr
+  const sy = (e.clientY - rect.top) * dpr
+  const [wx, wy] = screenToWorld(sx, sy)
   const delta = -e.deltaY * 0.0012
-  camera.scale = Math.max(0.15, Math.min(3, camera.scale * (1 + delta)))
+  const newScale = Math.max(0.15, Math.min(3, camera.scale * (1 + delta)))
+  if (newScale === camera.scale) return
+  // Keep the world point under the cursor fixed while the scale changes.
+  camera.scale = newScale
+  camera.x = sx - W / 2 - wx * newScale
+  camera.y = sy - H / 2 - wy * newScale
   requestRedraw()
 }
 
@@ -1321,6 +1400,9 @@ onBeforeUnmount(() => {
   ro?.disconnect()
   window.removeEventListener('mousemove', onMouseMove)
   window.removeEventListener('mouseup', onMouseUp)
+  window.removeEventListener('mousemove', handleDetailDrag)
+  window.removeEventListener('mouseup', stopDetailDrag)
+  document.body.classList.remove('is-dragging-layout')
 })
 </script>
 
@@ -1340,11 +1422,18 @@ onBeforeUnmount(() => {
   grid-template-columns: 1fr;
 }
 .mm-body.mm-body--detail-open {
-  grid-template-columns: 1fr 280px;
+  grid-template-columns: 1fr 320px;
+}
+.mm-body--dragging-detail {
+  user-select: none;
+}
+.mm-body--dragging-detail .mm-detail {
+  transition: none;
 }
 @media (max-width: 900px) {
   .mm-body.mm-body--detail-open { grid-template-columns: 1fr; }
   .mm-detail { display: none; }
+  .mm-detail-resizer { display: none; }
 }
 
 .mm-detail {
@@ -1364,6 +1453,31 @@ onBeforeUnmount(() => {
 }
 @media (prefers-reduced-motion: reduce) {
   .mm-detail { animation: none; }
+}
+.mm-detail-resizer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 6px;
+  margin-left: -3px;
+  cursor: col-resize;
+  z-index: 2;
+  touch-action: none;
+}
+.mm-detail-resizer::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 3px;
+  width: 1px;
+  background: transparent;
+  transition: background 120ms;
+}
+.mm-detail-resizer:hover::after,
+.mm-body--dragging-detail .mm-detail-resizer::after {
+  background: var(--accent);
 }
 .mm-detail-close {
   position: absolute;
@@ -1560,7 +1674,6 @@ onBeforeUnmount(() => {
 
 .mm-detail-type { font-size: var(--text-xs); text-transform: uppercase; letter-spacing: 0.06em; color: var(--fg3); }
 .mm-detail-title { font-size: var(--text-lg); font-weight: 600; margin: 4px 0 var(--space-2); }
-.mm-detail-desc { color: var(--fg2); font-size: var(--text-sm); margin-bottom: var(--space-3); }
 /* Age is a warning state, not a category, so it uses the app's warning token
    rather than any type hue. */
 .stale-badge {

--- a/web/src/components/PinnedFilePanel.vue
+++ b/web/src/components/PinnedFilePanel.vue
@@ -54,6 +54,15 @@
         >
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
         </button>
+        <button
+          class="btn-icon"
+          title="Discuss in chat"
+          aria-label="Discuss in chat"
+          :disabled="loading || !!error"
+          @click="discussInChat"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>
+        </button>
       </template>
     </PaneHeader>
     <div class="pfp-main" ref="mainEl">
@@ -731,6 +740,20 @@ async function openExternally(): Promise<void> {
   }
   openExternalState.value = ''
   projectsStore.pushErrorToast('Could not open file', result.error)
+}
+
+async function discussInChat(): Promise<void> {
+  const path = cleanPath.value
+  if (!path || loading.value || error.value) return
+  const ws = projectsStore.activeWorkspace
+  const general = projectsStore.projects.find(p => p.workspace === ws && p.is_auto && p.name === 'General')
+  if (!general) { projectsStore.pushErrorToast('Cannot start chat', 'No General project found in this workspace.'); return }
+  const title = `Discuss ${path.split('/').pop() || path}`
+  const seed = `Let's discuss the file \`${path}\`. Help me understand, review, or improve it.`
+  try {
+    const chat = await projectsStore.createChat(general.project_id, title, seed)
+    projectsStore.pinFile(chat.chat_id, path)
+  } catch (e) { projectsStore.pushErrorToast('Could not start discussion', e instanceof Error ? e.message : String(e)) }
 }
 
 // Set when an auto-reload was skipped because the user had unsaved work open;

--- a/web/src/components/ProjectSidebar.vue
+++ b/web/src/components/ProjectSidebar.vue
@@ -1250,8 +1250,14 @@ function expirationInfo(entry: string): { expired: boolean; malformed: boolean }
   if (!m) return { expired: false, malformed: hasPrefix }
   const raw = m[1].trim()
   if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) return { expired: false, malformed: true }
-  const d = new Date(raw + 'T00:00:00')
-  if (Number.isNaN(d.getTime())) return { expired: false, malformed: true }
+  // Reject impossible dates (e.g. 2026-02-30): JS normalizes them to a later
+  // day, so Number.isNaN alone would report them as valid. Round-trip the
+  // parsed year/month/day back to the original string to agree with the
+  // backend validator, which rejects these as malformed.
+  const [y, mo, da] = raw.split('-').map(Number)
+  const d = new Date(y, mo - 1, da)
+  const roundTrips = d.getFullYear() === y && d.getMonth() === mo - 1 && d.getDate() === da
+  if (!roundTrips) return { expired: false, malformed: true }
   const today = new Date(); today.setHours(0,0,0,0)
   return { expired: d < today, malformed: false }
 }
@@ -1294,9 +1300,18 @@ async function fetchGuide(): Promise<void> {
   const seq = ++guideFetchSeq
   guideLoading.value = true
   guideError.value = ''
-  // Workspace-relative fetch: the server anchors to the active workspace root.
-  // Try CLAUDE.md first, then AGENTS.md (which is often a symlink to it).
-  for (const candidate of ['CLAUDE.md', 'AGENTS.md']) {
+  // After the workspace re-root migration each guide lives under
+  // `<workspace>/CLAUDE.md`, so a bare basename would let /api/workspace-file's
+  // fuzzy lookup silently resolve to the lexicographically-first workspace's
+  // guide. Try the workspace-qualified path first (retained for Open/Discuss/
+  // pin), then fall back to the bare basename for installs that have not
+  // re-rooted (guide still at the install root).
+  const ws = store.activeWorkspace
+  const candidates = [
+    `${ws}/CLAUDE.md`, `${ws}/AGENTS.md`,
+    'CLAUDE.md', 'AGENTS.md',
+  ]
+  for (const candidate of candidates) {
     try {
       const resp = await fetch(`/api/workspace-file?path=${encodeURIComponent(candidate)}`, { credentials: 'same-origin' })
       if (seq !== guideFetchSeq) return
@@ -3352,6 +3367,13 @@ async function confirmDeleteChat(chatId: string) {
   color: var(--fg2);
   cursor: pointer;
   font-family: var(--font);
+  /* Touch-safe hit area: the visible 3px/8px padding is too small to tap
+     reliably on the mobile sidebar, so guarantee a 44px minimum target. */
+  min-width: 44px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 .guide-card-btn:disabled { opacity: 0.5; cursor: default; }
 .guide-card-btn:hover:not(:disabled) { background: var(--bg3); color: var(--fg); }

--- a/web/src/components/ProjectSidebar.vue
+++ b/web/src/components/ProjectSidebar.vue
@@ -555,6 +555,53 @@
             <div class="mm-stat"><div class="n">{{ mm.clusters.length }}</div><div class="l">clusters</div></div>
           </div>
 
+          <!-- Workspace guide (CLAUDE.md / AGENTS.md) — the only file every chat loads.
+               Surfaced here because the vault graph hides it (it is not a vault note)
+               yet its bounded regions budget every session. -->
+          <div class="guide-card" :class="{ 'guide-card--over': guideOverCap }">
+            <div class="guide-card-head">
+              <div class="guide-card-title">
+                <span class="guide-card-icon" aria-hidden="true">◆</span>
+                {{ guidePathLabel }}
+                <span v-if="guideOverCap" class="guide-card-badge guide-card-badge--warn" title="A bounded region is over its advisory cap">over cap</span>
+                <span v-else-if="guideLoading" class="guide-card-badge">loading…</span>
+              </div>
+              <div class="guide-card-actions">
+                <button type="button" class="guide-card-btn" :disabled="guideLoading || !!guideError" @click="openGuideFile" title="Open CLAUDE.md">Open</button>
+                <button type="button" class="guide-card-btn guide-card-btn--primary" :disabled="!canDiscussGuide" @click="discussGuide" title="Start a chat about this guide">Discuss</button>
+              </div>
+            </div>
+            <div v-if="guideError" class="guide-card-error">{{ guideError }}</div>
+            <template v-else-if="guideStats">
+              <div class="guide-card-regions">
+                <div v-for="r in guideStats.regions" :key="r.key" class="guide-region">
+                  <div class="guide-region-head">
+                    <span class="guide-region-name">{{ r.label }}</span>
+                    <span class="guide-region-count" :class="{ 'guide-region-count--warn': r.overCap }">{{ r.usedChars }} / {{ r.charLimit }} chars</span>
+                    <span class="guide-region-tokens" :title="`${r.usedChars} chars ≈ ${r.tokens} tokens`">≈ {{ r.tokens }} tokens</span>
+                  </div>
+                  <div class="guide-region-bar" :class="{ 'guide-region-bar--warn': r.overCap, 'guide-region-bar--high': !r.overCap && r.pct >= 80 }" :title="`${r.pct}% of cap`">
+                    <span :style="{ width: Math.min(100, r.pct) + '%' }"></span>
+                  </div>
+                  <div class="guide-region-meta">
+                    {{ r.entryCount }} {{ r.entryCount === 1 ? 'entry' : 'entries' }} · {{ r.pct }}%
+                    <span v-if="r.expiredCount"> · {{ r.expiredCount }} expired</span>
+                    <span v-if="r.malformedCount" class="guide-region-meta--warn"> · {{ r.malformedCount }} malformed tag</span>
+                  </div>
+                </div>
+              </div>
+              <div class="guide-card-foot">
+                <span class="guide-card-foot-info" :title="guideContent ? `${guideContent.length} chars on disk` : ''">
+                  {{ guideContent ? `${guideContent.length.toLocaleString()} chars` : '' }} · {{ guideStats.totalTokens }} tokens total
+                </span>
+                <button type="button" class="mm-link" @click="openGuideFile">Edit in viewer →</button>
+              </div>
+            </template>
+            <template v-else-if="!guideLoading">
+              <div class="guide-card-hint">No guide file found for this workspace.</div>
+            </template>
+          </div>
+
           <div class="mm-search">
             <input v-model="mm.search" type="text" placeholder="Search notes, tags…" autocomplete="off" />
           </div>
@@ -1172,6 +1219,130 @@ function reviewKindLabel(kind: string): string {
 // the bottom of the sidebar.
 const orphanLimit = ref(8)
 const staleLimit = ref(8)
+
+// ---------- workspace guide card (CLAUDE.md / AGENTS.md) ----------
+const GUIDE_DEFAULTS: Record<string, { label: string; limit: number }> = {
+  memory: { label: 'Agent memory', limit: 3000 },
+  profile: { label: 'User profile', limit: 1375 },
+}
+const guideContent = ref('')
+const guideLoading = ref(false)
+const guideError = ref('')
+const guideResolvedPath = ref('') // actual file that existed: CLAUDE.md or AGENTS.md
+const guidePathLabel = computed(() => guideResolvedPath.value || 'CLAUDE.md')
+const GUIDE_REGION_RE: Record<string, RegExp> = {
+  memory: /<!--\s*ciao:memory:start(?:\s+cap=(\d+))?\s*-->([\s\S]*?)<!--\s*ciao:memory:end\s*-->/i,
+  profile: /<!--\s*ciao:profile:start(?:\s+cap=(\d+))?\s*-->([\s\S]*?)<!--\s*ciao:profile:end\s*-->/i,
+}
+function parseEntriesForRegion(raw: string): string[] {
+  const headingStripped = raw.replace(/^\s*##\s*(Agent memory|User profile)\s*\n?/, '')
+  const parts = headingStripped.split(/\n?§\n?/)
+  return parts.map(p => p.trim()).filter(Boolean)
+}
+function serializeLen(entries: string[]): number {
+  if (!entries.length) return 0
+  return entries.join('\n§\n').length + 1 // +1 trailing \n mirrors python serialize_entries
+}
+function tokensFor(chars: number): number { return Math.ceil(chars / 4) || 0 }
+function expirationInfo(entry: string): { expired: boolean; malformed: boolean } {
+  const hasPrefix = /\[expires\s*:/i.test(entry)
+  const m = entry.match(/\[expires:\s*([^\]]*)\]/i)
+  if (!m) return { expired: false, malformed: hasPrefix }
+  const raw = m[1].trim()
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) return { expired: false, malformed: true }
+  const d = new Date(raw + 'T00:00:00')
+  if (Number.isNaN(d.getTime())) return { expired: false, malformed: true }
+  const today = new Date(); today.setHours(0,0,0,0)
+  return { expired: d < today, malformed: false }
+}
+const guideStats = computed(() => {
+  const content = guideContent.value
+  if (!content) return null
+  const regions: Array<{
+    key: string; label: string; usedChars: number; charLimit: number; pct: number;
+    tokens: number; entryCount: number; expiredCount: number; malformedCount: number; overCap: boolean
+  }> = []
+  let totalChars = 0
+  for (const key of ['memory', 'profile'] as const) {
+    const re = GUIDE_REGION_RE[key]
+    const match = content.match(re)
+    let cap = GUIDE_DEFAULTS[key].limit
+    let body = ''
+    if (match) {
+      if (match[1]) { const n = Number(match[1]); if (Number.isFinite(n)) cap = n }
+      body = match[2] || ''
+    }
+    const entries = body ? parseEntriesForRegion(body) : []
+    const used = serializeLen(entries)
+    totalChars += used
+    let expired = 0, malformed = 0
+    for (const e of entries) { const info = expirationInfo(e); if (info.expired) expired++; if (info.malformed) malformed++ }
+    const pct = cap ? Math.round((used / cap) * 100 * 10) / 10 : 0
+    regions.push({
+      key, label: GUIDE_DEFAULTS[key].label,
+      usedChars: used, charLimit: cap, pct, tokens: tokensFor(used),
+      entryCount: entries.length, expiredCount: expired, malformedCount: malformed,
+      overCap: used > cap,
+    })
+  }
+  return { regions, totalTokens: tokensFor(content.length), totalChars: content.length }
+})
+const guideOverCap = computed(() => !!guideStats.value?.regions.some(r => r.overCap))
+const canDiscussGuide = computed(() => !!guideResolvedPath.value && !guideLoading.value && !guideError.value)
+let guideFetchSeq = 0
+async function fetchGuide(): Promise<void> {
+  const seq = ++guideFetchSeq
+  guideLoading.value = true
+  guideError.value = ''
+  // Workspace-relative fetch: the server anchors to the active workspace root.
+  // Try CLAUDE.md first, then AGENTS.md (which is often a symlink to it).
+  for (const candidate of ['CLAUDE.md', 'AGENTS.md']) {
+    try {
+      const resp = await fetch(`/api/workspace-file?path=${encodeURIComponent(candidate)}`, { credentials: 'same-origin' })
+      if (seq !== guideFetchSeq) return
+      if (resp.status === 404) continue
+      if (!resp.ok) { guideError.value = `Failed to load ${candidate} (HTTP ${resp.status})`; guideContent.value = ''; guideResolvedPath.value=''; break }
+      const text = await resp.text()
+      if (seq !== guideFetchSeq) return
+      guideContent.value = text
+      guideResolvedPath.value = candidate
+      guideError.value = ''
+      guideLoading.value = false
+      return
+    } catch (e) { if (seq === guideFetchSeq) { guideError.value = e instanceof Error ? e.message : String(e) } }
+  }
+  if (seq !== guideFetchSeq) return
+  guideContent.value = ''
+  if (!guideError.value) guideError.value = ''
+  guideResolvedPath.value = ''
+  guideLoading.value = false
+}
+watch(() => store.activeWorkspace, () => { void fetchGuide() }, { immediate: true })
+onMounted(() => { void fetchGuide() })
+function openGuideFile(): void {
+  if (!guideResolvedPath.value) return
+  void fileViewer.open(guideResolvedPath.value)
+}
+async function discussGuide(): Promise<void> {
+  if (!guideResolvedPath.value) return
+  const path = guideResolvedPath.value
+  // Reuse the generic file-discuss flow (creates a chat and pins the guide).
+  await discussFileInChat(path, `Let's review the workspace guide \`${path}\`. Help me audit it — what should we trim, clarify, or promote from the bounded regions?`)
+}
+async function discussFileInChat(path: string, prompt?: string): Promise<void> {
+  const ws = store.activeWorkspace
+  const general = store.projects.find(p => p.workspace === ws && p.is_auto && p.name === 'General')
+  if (!general) { store.pushErrorToast('Cannot start chat', 'No General project found in this workspace.'); return }
+  const title = `Discuss ${path.split('/').pop() || path}`
+  const seed = prompt || `Let's discuss the file \`${path}\`.`
+  try {
+    const chat = await store.createChat(general.project_id, title, seed)
+    // Pin the file so the new chat opens split-view with it visible.
+    store.pinFile(chat.chat_id, path)
+  } catch (e) { store.pushErrorToast('Could not start discussion', e instanceof Error ? e.message : String(e)) }
+}
+// Expose for template's generic file discuss (also used by FileViewerModal/PinnedFilePanel via a shared helper fallback)
+// and for the guide card's "Discuss" button.
 const route = useRoute()
 const router = useRouter()
 
@@ -3129,6 +3300,106 @@ async function confirmDeleteChat(chatId: string) {
 
 .mm-search { margin-top: var(--space-3); }
 .mm-search input { width: 100%; font-size: var(--text-sm); }
+
+/* Workspace guide card (CLAUDE.md / AGENTS.md) — bounded memory health, always visible */
+.guide-card {
+  margin-top: var(--space-3);
+  padding: 10px 10px 8px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.guide-card--over { border-color: color-mix(in srgb, var(--warning) 45%, var(--border)); }
+.guide-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.guide-card-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--fg2);
+  font-family: var(--font-mono);
+}
+.guide-card-icon { color: var(--accent); font-size: 10px; }
+.guide-card-badge {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--fg3);
+  background: var(--bg3);
+  padding: 1px 6px;
+  border-radius: var(--radius-pill);
+}
+.guide-card-badge--warn { background: color-mix(in srgb, var(--warning) 18%, transparent); color: var(--warning); }
+.guide-card-actions { display: inline-flex; gap: 6px; flex-shrink: 0; }
+.guide-card-btn {
+  font-size: var(--text-xs);
+  padding: 3px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg2);
+  color: var(--fg2);
+  cursor: pointer;
+  font-family: var(--font);
+}
+.guide-card-btn:disabled { opacity: 0.5; cursor: default; }
+.guide-card-btn:hover:not(:disabled) { background: var(--bg3); color: var(--fg); }
+.guide-card-btn--primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+.guide-card-btn--primary:hover:not(:disabled) { filter: brightness(1.08); color: #fff; }
+.guide-card-error { color: var(--warning); font-size: var(--text-xs); }
+.guide-card-hint { color: var(--fg3); font-size: var(--text-xs); }
+.guide-card-regions { display: flex; flex-direction: column; gap: 10px; }
+.guide-region-head {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: var(--text-xs);
+}
+.guide-region-name { font-weight: 600; color: var(--fg2); flex: 1; }
+.guide-region-count { color: var(--fg3); font-variant-numeric: tabular-nums; }
+.guide-region-count--warn { color: var(--warning); font-weight: 600; }
+.guide-region-tokens { color: var(--fg3); font-family: var(--font-mono); font-size: 11px; }
+.guide-region-bar {
+  height: 6px;
+  border-radius: 3px;
+  background: var(--bg3);
+  overflow: hidden;
+  margin-top: 4px;
+}
+.guide-region-bar > span {
+  display: block;
+  height: 100%;
+  border-radius: 3px;
+  background: var(--accent);
+  transition: width 200ms;
+}
+.guide-region-bar--high > span { background: #d6a600; }
+.guide-region-bar--warn > span { background: var(--warning); }
+.guide-region-meta { font-size: 11px; color: var(--fg3); margin-top: 3px; }
+.guide-region-meta--warn { color: var(--warning); }
+.guide-card-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding-top: 6px;
+  border-top: 1px solid var(--border);
+  font-size: var(--text-xs);
+  color: var(--fg3);
+}
+.guide-card-foot-info { font-variant-numeric: tabular-nums; }
 
 .mm-chip-row { display: flex; flex-direction: column; gap: 2px; }
 .mm-chip {

--- a/web/src/stores/fileViewer.ts
+++ b/web/src/stores/fileViewer.ts
@@ -7,28 +7,16 @@ import { askConfirm } from '../lib/confirm'
 // in a chat or by tapping an inline file-card. Backed by /api/workspace-file
 // (no workspace sandbox; relative paths anchor to config.workspace_root).
 //
-// Three "tabs" the modal exposes:
-//   - preview: current on-disk content (current contract; default)
-//   - history: snapshot list from /api/file-history, drives the diff selector
-//   - diff:    side-by-side comparison of two snapshots (or current vs prior)
-//
-// Plus an editing mode that POSTs to /api/workspace-file to save user edits
-// and snapshot them via the active chat's history.
+// The only reading tabs are:
+//   - preview: current on-disk content (default, also the editing surface)
+//   - backlinks: markdown incoming links, when the file is markdown
+// History/Diff were removed as overkill for the viewer.
 
 export type FileViewerKind = 'text' | 'image' | 'pdf' | 'html'
-export type FileViewerTab = 'preview' | 'history' | 'diff' | 'backlinks'
+export type FileViewerTab = 'preview' | 'backlinks'
 // Artifacts render by default and show their source on demand. Code view is
 // also the only place they can be edited, since editing needs the source.
 export type HtmlArtifactView = 'preview' | 'code'
-
-export interface SnapshotMeta {
-  seq: number
-  ts: string
-  action: string
-  tool: string
-  size: number
-  truncated?: boolean
-}
 
 export function fileViewerKindForPath(filePath: string): FileViewerKind {
   const cleaned = filePath.replace(/:\d+$/, '').toLowerCase()
@@ -54,25 +42,10 @@ export const useFileViewerStore = defineStore('fileViewer', () => {
   // can then be saved back over the current file.
   let fetchSeq = 0
 
-  // Snapshot-related state. `chatId` is set by callers that have a chat
-  // context (the inline file card) so we can fetch history. When omitted
-  // we still render the Preview tab but History/Diff are unavailable.
+  // `chatId` is kept for pin/open context (inline card). History/Diff were
+  // removed from the UI so no snapshot state is needed.
   const chatId = ref('')
   const tab = ref<FileViewerTab>('preview')
-  const snapshots = ref<SnapshotMeta[]>([])
-  const snapshotsLoading = ref(false)
-  const snapshotsError = ref('')
-
-  // Diff tab state: `diffSeqA` is the "before", `diffSeqB` is the "after".
-  // 0 means "current on-disk content" — useful when you want to diff a
-  // snapshot against where the file is right now (e.g. after an external
-  // edit). Defaults are wired in `setTab('diff')`.
-  const diffSeqA = ref(0)
-  const diffSeqB = ref(0)
-  const diffContentA = ref('')
-  const diffContentB = ref('')
-  const diffLoading = ref(false)
-  const diffError = ref('')
 
   // Edit state. When `editing` is true the modal swaps the read-only viewer
   // for a textarea pre-filled with `content`. `editBuffer` holds the in-flight
@@ -113,13 +86,6 @@ export const useFileViewerStore = defineStore('fileViewer', () => {
     error.value = ''
     loading.value = false
     tab.value = 'preview'
-    snapshots.value = []
-    snapshotsError.value = ''
-    diffSeqA.value = 0
-    diffSeqB.value = 0
-    diffContentA.value = ''
-    diffContentB.value = ''
-    diffError.value = ''
     editing.value = false
     editBuffer.value = ''
     editError.value = ''
@@ -308,92 +274,10 @@ export const useFileViewerStore = defineStore('fileViewer', () => {
     return true
   }
 
-  // ── Tabs / history / diff ──────────────────────────────────────────────
+  // ── Tabs ─────────────────────────────────────────────────────────────────
 
   async function setTab(t: FileViewerTab): Promise<void> {
     tab.value = t
-    if (t === 'history' || t === 'diff') {
-      await loadHistory()
-    }
-    if (t === 'diff' && snapshots.value.length >= 2) {
-      // Default to comparing the last two snapshots.
-      diffSeqA.value = snapshots.value[snapshots.value.length - 2].seq
-      diffSeqB.value = snapshots.value[snapshots.value.length - 1].seq
-      await loadDiff()
-    } else if (t === 'diff' && snapshots.value.length === 1) {
-      // Only one snapshot: compare against current on-disk content.
-      diffSeqA.value = snapshots.value[0].seq
-      diffSeqB.value = 0  // 0 → "current"
-      await loadDiff()
-    }
-  }
-
-  async function loadHistory(): Promise<void> {
-    if (!chatId.value || !path.value) {
-      snapshots.value = []
-      snapshotsError.value = chatId.value ? 'No file selected.' : 'No chat context — open the file from an inline card.'
-      return
-    }
-    snapshotsLoading.value = true
-    snapshotsError.value = ''
-    try {
-      const url = `/api/file-history?chat_id=${encodeURIComponent(chatId.value)}&file_path=${encodeURIComponent(path.value)}`
-      const resp = await fetch(url, { credentials: 'same-origin' })
-      if (!resp.ok) {
-        snapshotsError.value = `Failed to load history (HTTP ${resp.status}).`
-        snapshots.value = []
-        return
-      }
-      const body = await resp.json()
-      snapshots.value = Array.isArray(body.snapshots) ? body.snapshots : []
-    } catch (e) {
-      snapshotsError.value = e instanceof Error ? e.message : String(e)
-      snapshots.value = []
-    } finally {
-      snapshotsLoading.value = false
-    }
-  }
-
-  async function loadDiff(): Promise<void> {
-    diffLoading.value = true
-    diffError.value = ''
-    try {
-      const [a, b] = await Promise.all([
-        _fetchSeq(diffSeqA.value),
-        _fetchSeq(diffSeqB.value),
-      ])
-      diffContentA.value = a
-      diffContentB.value = b
-    } catch (e) {
-      diffError.value = e instanceof Error ? e.message : String(e)
-    } finally {
-      diffLoading.value = false
-    }
-  }
-
-  async function _fetchSeq(seq: number): Promise<string> {
-    if (seq === 0) {
-      // Current on-disk content. Reuse the open() text path: we already have
-      // it in `content` for the active preview, but it might be stale by the
-      // time the user opens Diff, so refetch.
-      const resp = await fetch(
-        `/api/workspace-file?path=${encodeURIComponent(path.value)}`,
-        { credentials: 'same-origin' },
-      )
-      if (!resp.ok) throw new Error(`current content HTTP ${resp.status}`)
-      return resp.text()
-    }
-    const url = `/api/file-content?chat_id=${encodeURIComponent(chatId.value)}&file_path=${encodeURIComponent(path.value)}&seq=${seq}`
-    const resp = await fetch(url, { credentials: 'same-origin' })
-    if (!resp.ok) throw new Error(`snapshot ${seq} HTTP ${resp.status}`)
-    const body = await resp.json()
-    return typeof body.content === 'string' ? body.content : ''
-  }
-
-  async function setDiffSeqs(a: number, b: number): Promise<void> {
-    diffSeqA.value = a
-    diffSeqB.value = b
-    await loadDiff()
   }
 
   // ── Edit mode ──────────────────────────────────────────────────────────
@@ -435,15 +319,12 @@ export const useFileViewerStore = defineStore('fileViewer', () => {
         editError.value = `Save failed (HTTP ${resp.status}).`
         return false
       }
-      // Adopt the saved buffer as the new preview content. Refresh history
-      // so the new snapshot (if any) shows up immediately in the History tab.
       content.value = editBuffer.value
       editing.value = false
       editBuffer.value = ''
       // Artifacts render from a URL, so adopting the buffer is not enough:
       // bump the token or Preview keeps showing the pre-save page.
       if (kind.value === 'html') loadToken.value++
-      if (chatId.value) await loadHistory()
       return true
     } catch (e) {
       editError.value = e instanceof Error ? e.message : String(e)
@@ -451,32 +332,6 @@ export const useFileViewerStore = defineStore('fileViewer', () => {
     } finally {
       editSaving.value = false
     }
-  }
-
-  async function restoreSnapshot(seq: number): Promise<boolean> {
-    if (!chatId.value || !path.value || seq <= 0) return false
-    const resp = await fetch('/api/file-restore', {
-      method: 'POST',
-      credentials: 'same-origin',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        chat_id: chatId.value,
-        file_path: path.value,
-        seq,
-      }),
-    })
-    if (!resp.ok) return false
-    // Reload content + history so the modal reflects the new state.
-    await Promise.all([
-      (async () => {
-        const r = await fetch(`/api/workspace-file?path=${encodeURIComponent(path.value)}`, { credentials: 'same-origin' })
-        if (r.ok) content.value = await r.text()
-      })(),
-      loadHistory(),
-    ])
-    // Same reason as saveEdits: the artifact frame reloads from its URL.
-    if (kind.value === 'html') loadToken.value++
-    return true
   }
 
   return {
@@ -491,15 +346,6 @@ export const useFileViewerStore = defineStore('fileViewer', () => {
     loadToken,
     chatId,
     tab,
-    snapshots,
-    snapshotsLoading,
-    snapshotsError,
-    diffSeqA,
-    diffSeqB,
-    diffContentA,
-    diffContentB,
-    diffLoading,
-    diffError,
     editing,
     isDirty,
     editBuffer,
@@ -521,12 +367,9 @@ export const useFileViewerStore = defineStore('fileViewer', () => {
     close,
     loadMarkdownPaths,
     setTab,
-    loadHistory,
-    setDiffSeqs,
     startEditing,
     cancelEditing,
     saveEdits,
-    restoreSnapshot,
     installLibreoffice,
   }
 })


### PR DESCRIPTION
- Memory sidebar: CLAUDE.md/AGENTS.md card before search with bounded regions (chars ≈ tokens, pct bar, over-cap warning, expired/malformed counts) and Open/Discuss actions; per-workspace fetch with fallback (ProjectSidebar.vue:558,1220).
- File viewers: Discuss in chat button (FileViewerModal.vue:65, PinnedFilePanel.vue:57) creates General chat, seeds prompt, pins file.
- File viewer: remove History/Diff tabs and prune snapshot/diff code (FileViewerModal.vue:80, fileViewer.ts:10 — tabs now preview|backlinks only).
- Memory map: remove duplicate description (MemoryMapView.vue:178), resizable right panel (MemoryMapView.vue:7,266), cursor-centered wheel zoom (MemoryMapView.vue:1304).

Verified: `cd web && npm run build` + `npm run test -- --run` 74 files/826 tests pass.