### PR TITLE
fix(web): clear active chat when navigating to the bare chat route

### DIFF
--- a/web/src/components/ChatLayout.vue
+++ b/web/src/components/ChatLayout.vue
@@ -706,7 +706,16 @@ watch(
   () => route.params.chatId,
   (chatId) => {
     const id = chatId as string
-    if (!id) return
+    if (!id) {
+      // The sidebar's "chats" nav tab (and any other plain link to `/` or
+      // `/chat`) navigates here without going through closeChat(), so
+      // activeChatId - and the ChatPanel/keyboard-shortcut logic keyed off
+      // it - stayed on the chat the user left. Only bare chat routes mean
+      // "go home": project/settings/schedules routes deliberately leave
+      // activeChatId populated underneath them (see the Esc handler above).
+      if (viewMode.value === 'chat' && store.activeChatId) void store.closeChat()
+      return
+    }
     if (!store.chats.find(c => c.chat_id === id)) return
     if (store.activeChatId !== id) void store.openChatFromDeepLink(id)
     else void store.markRead(id)

--- a/web/src/components/ChatLayout.vue
+++ b/web/src/components/ChatLayout.vue
@@ -712,7 +712,10 @@ watch(
       // activeChatId - and the ChatPanel/keyboard-shortcut logic keyed off
       // it - stayed on the chat the user left. Only bare chat routes mean
       // "go home": project/settings/schedules routes deliberately leave
-      // activeChatId populated underneath them (see the Esc handler above).
+      // activeChatId populated underneath them (see the Esc handler above),
+      // so this only fires when chatId itself changed away from a real id -
+      // not on a settings/schedules -> `/` transition, where chatId was
+      // already undefined and the retained chat is meant to resurface.
       if (viewMode.value === 'chat' && store.activeChatId) void store.closeChat()
       return
     }

--- a/web/src/components/ChatLayout.vue
+++ b/web/src/components/ChatLayout.vue
@@ -716,7 +716,11 @@ watch(
       // so this only fires when chatId itself changed away from a real id -
       // not on a settings/schedules -> `/` transition, where chatId was
       // already undefined and the retained chat is meant to resurface.
-      if (viewMode.value === 'chat' && store.activeChatId) void store.closeChat()
+      // Route through the local closeChat() wrapper, not store.closeChat()
+      // directly, so a failed close (e.g. the DELETE request itself erroring
+      // out) surfaces the same toast the close button and Esc already show,
+      // instead of an unhandled rejection with no explanation.
+      if (viewMode.value === 'chat' && store.activeChatId) closeChat()
       return
     }
     if (!store.chats.find(c => c.chat_id === id)) return

--- a/web/src/components/__tests__/ChatLayout.test.ts
+++ b/web/src/components/__tests__/ChatLayout.test.ts
@@ -297,6 +297,69 @@ describe('ChatLayout', () => {
     wrapper.unmount()
   })
 
+  // Regression: the sidebar's "chats" nav tab links straight to `/` instead
+  // of calling closeChat(), so activeChatId used to stay pointed at the chat
+  // the user left. That stale id kept ChatPanel/the home-arrow shortcut
+  // gate thinking a chat was still open even though the URL said otherwise.
+  it('clears the active chat when a plain route change lands on the bare chat route', async () => {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', component: EmptyStub },
+        { path: '/chat/:chatId?', component: EmptyStub },
+      ],
+    })
+    await router.push('/chat/chat-1')
+    await router.isReady()
+
+    const store = useProjectStore()
+    store.projects = [{
+      project_id: 'project-1',
+      name: 'General',
+      workspace: 'personal',
+    }] as unknown as typeof store.projects
+    store.chats = [{
+      chat_id: 'chat-1',
+      project_id: 'project-1',
+      title: 'Test chat',
+    }] as unknown as typeof store.chats
+    store.activeChatId = 'chat-1'
+    store.bootstrapped = true
+    vi.spyOn(store, 'fetchAll').mockResolvedValue()
+
+    const taskStore = useTaskStore()
+    vi.spyOn(taskStore, 'fetchSchedules').mockResolvedValue()
+    vi.spyOn(taskStore, 'fetchLoops').mockResolvedValue()
+
+    const { default: ChatLayout } = await import('../ChatLayout.vue')
+    const wrapper = mount(ChatLayout, {
+      global: {
+        plugins: [router],
+        stubs: {
+          ChatPanel: ChatPanelStub,
+          ProjectSidebar: EmptyStub,
+          ProjectView: EmptyStub,
+          SchedulePanel: EmptyStub,
+          SettingsView: EmptyStub,
+          FileViewerModal: EmptyStub,
+          PinnedFilePanel: EmptyStub,
+          PaneHeader: EmptyStub,
+          HomeRecentChats: EmptyStub,
+        },
+      },
+    })
+    await flushPromises()
+    expect(store.activeChatId).toBe('chat-1')
+
+    // Simulates clicking the sidebar's "chats" nav-item / any plain link to
+    // `/`: a route change that never goes through closeChat().
+    await router.push('/')
+    await flushPromises()
+
+    expect(store.activeChatId).toBeNull()
+    wrapper.unmount()
+  })
+
   it('switches to the workspace matching the displayed number', async () => {
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,

--- a/web/src/components/__tests__/ChatLayout.test.ts
+++ b/web/src/components/__tests__/ChatLayout.test.ts
@@ -360,6 +360,73 @@ describe('ChatLayout', () => {
     wrapper.unmount()
   })
 
+  // From /settings (which deliberately retains activeChatId), chatId is
+  // undefined both before and after landing on `/` via the "chats" nav tab,
+  // so the chatId watcher does not fire - intentionally. That mirrors Esc's
+  // retention (see "leaves a retained hidden chat alone when escaping
+  // Settings" below): the nav tab, like Esc, should resurface the chat you
+  // left rather than force an empty home screen.
+  it('leaves a retained chat alone when navigating home from Settings via the nav tab', async () => {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: '/', component: EmptyStub },
+        { path: '/chat/:chatId?', component: EmptyStub },
+        { path: '/settings', component: EmptyStub },
+      ],
+    })
+    await router.push('/settings')
+    await router.isReady()
+
+    const store = useProjectStore()
+    store.projects = [{
+      project_id: 'project-1',
+      name: 'General',
+      workspace: 'personal',
+    }] as unknown as typeof store.projects
+    store.chats = [{
+      chat_id: 'chat-1',
+      project_id: 'project-1',
+      title: 'Test chat',
+    }] as unknown as typeof store.chats
+    store.activeChatId = 'chat-1'
+    store.bootstrapped = true
+    vi.spyOn(store, 'fetchAll').mockResolvedValue()
+
+    const taskStore = useTaskStore()
+    vi.spyOn(taskStore, 'fetchSchedules').mockResolvedValue()
+    vi.spyOn(taskStore, 'fetchLoops').mockResolvedValue()
+
+    const { default: ChatLayout } = await import('../ChatLayout.vue')
+    const wrapper = mount(ChatLayout, {
+      global: {
+        plugins: [router],
+        stubs: {
+          ChatPanel: ChatPanelStub,
+          ProjectSidebar: EmptyStub,
+          ProjectView: EmptyStub,
+          SchedulePanel: EmptyStub,
+          SettingsView: EmptyStub,
+          FileViewerModal: EmptyStub,
+          PinnedFilePanel: EmptyStub,
+          PaneHeader: EmptyStub,
+          HomeRecentChats: EmptyStub,
+        },
+      },
+    })
+    await flushPromises()
+    // Settings deliberately retains the chat underneath it.
+    expect(store.activeChatId).toBe('chat-1')
+
+    // Simulates clicking the sidebar's "chats" nav-item from Settings:
+    // route.params.chatId stays undefined the whole way through.
+    await router.push('/')
+    await flushPromises()
+
+    expect(store.activeChatId).toBe('chat-1')
+    wrapper.unmount()
+  })
+
   it('switches to the workspace matching the displayed number', async () => {
     Object.defineProperty(window, 'innerWidth', {
       configurable: true,

--- a/web/src/stores/projects.test.ts
+++ b/web/src/stores/projects.test.ts
@@ -1454,6 +1454,37 @@ describe('chat closing and re-entry orientation', () => {
     expect(routerPush).toHaveBeenCalledWith('/')
   })
 
+  test('clears the reopened draft without ejecting the user from Settings', async () => {
+    // The user reopens the same draft, then leaves for Settings (which
+    // retains activeChatId, so reopening plus that navigation leaves it
+    // still equal to draftId). Once the delete lands the dangling id must
+    // still be cleared, but the user must not be yanked out of Settings.
+    const { router } = await import('../router')
+    const store = useProjectStore()
+    const draftId = 'chat-draft'
+    store.chats = [{
+      chat_id: draftId, project_id: 'p1', title: 'New Chat', model: 'sonnet',
+      provider: 'claude', mode: 'auto', session_id: '', created_at: '', archived: false,
+    }]
+    store.messages[draftId] = []
+    store.activeChatId = draftId
+    let resolveDelete: (value: { ok: boolean; deleted: boolean }) => void = () => {}
+    apiDel.mockImplementation(() => new Promise(resolve => { resolveDelete = resolve }))
+    routerPush.mockClear()
+
+    const closing = store.closeChat()
+    await vi.waitFor(() => expect(apiDel).toHaveBeenCalled())
+    store.activeChatId = draftId
+    router.currentRoute.value.path = '/settings'
+    resolveDelete({ ok: true, deleted: true })
+    await closing
+
+    expect(store.chats).toHaveLength(0)
+    expect(store.activeChatId).toBeNull()
+    expect(routerPush).not.toHaveBeenCalledWith('/')
+    router.currentRoute.value.path = '/'
+  })
+
   test('does not force navigation home when the user left for Settings mid-delete', async () => {
     // activeChatId is null here too (Settings retains it, but this draft
     // close already cleared it before the DELETE started) - the stale

--- a/web/src/stores/projects.test.ts
+++ b/web/src/stores/projects.test.ts
@@ -1417,6 +1417,9 @@ describe('chat closing and re-entry orientation', () => {
 
     const closing = store.closeChat()
     expect(store.activeChatId).toBeNull()
+    // closeChat() awaits a dynamic router import before calling deleteChat();
+    // wait for the actual DELETE call so resolveDelete is the real resolver.
+    await vi.waitFor(() => expect(apiDel).toHaveBeenCalled())
     // The user opens a different chat before the DELETE resolves.
     store.activeChatId = otherId
     resolveDelete({ ok: true, deleted: true })
@@ -1441,6 +1444,7 @@ describe('chat closing and re-entry orientation', () => {
 
     const closing = store.closeChat()
     expect(store.activeChatId).toBeNull()
+    await vi.waitFor(() => expect(apiDel).toHaveBeenCalled())
     store.activeChatId = draftId
     resolveDelete({ ok: true, deleted: true })
     await closing
@@ -1469,8 +1473,36 @@ describe('chat closing and re-entry orientation', () => {
 
     const closing = store.closeChat()
     expect(store.activeChatId).toBeNull()
+    await vi.waitFor(() => expect(apiDel).toHaveBeenCalled())
     // The user navigates to Settings before the DELETE resolves.
     router.currentRoute.value.path = '/settings'
+    resolveDelete({ ok: true, deleted: true })
+    await closing
+
+    expect(routerPush).not.toHaveBeenCalledWith('/')
+    router.currentRoute.value.path = '/'
+  })
+
+  // /device lives entirely outside ChatLayout (the escape hatch when a
+  // remote host is unreachable), so it can never appear in a list of
+  // "routes that retain the chat" - the fix has to be route-agnostic.
+  test('does not force navigation home when the user left for the device page mid-delete', async () => {
+    const { router } = await import('../router')
+    const store = useProjectStore()
+    const draftId = 'chat-draft'
+    store.chats = [{
+      chat_id: draftId, project_id: 'p1', title: 'New Chat', model: 'sonnet',
+      provider: 'claude', mode: 'auto', session_id: '', created_at: '', archived: false,
+    }]
+    store.messages[draftId] = []
+    store.activeChatId = draftId
+    let resolveDelete: (value: { ok: boolean; deleted: boolean }) => void = () => {}
+    apiDel.mockImplementation(() => new Promise(resolve => { resolveDelete = resolve }))
+    routerPush.mockClear()
+
+    const closing = store.closeChat()
+    await vi.waitFor(() => expect(apiDel).toHaveBeenCalled())
+    router.currentRoute.value.path = '/device'
     resolveDelete({ ok: true, deleted: true })
     await closing
 

--- a/web/src/stores/projects.test.ts
+++ b/web/src/stores/projects.test.ts
@@ -1392,6 +1392,63 @@ describe('chat closing and re-entry orientation', () => {
     expect(routerPush).toHaveBeenCalledWith('/')
   })
 
+  test('does not clobber a different chat opened while the draft delete is in flight', async () => {
+    // closeChat() clears activeChatId synchronously so the close gesture
+    // feels immediate, then awaits the DELETE. If the user opens a different
+    // chat during that window, the delayed cleanup must leave it alone.
+    const store = useProjectStore()
+    const draftId = 'chat-draft'
+    const otherId = 'chat-other'
+    store.chats = [
+      {
+        chat_id: draftId, project_id: 'p1', title: 'New Chat', model: 'sonnet',
+        provider: 'claude', mode: 'auto', session_id: '', created_at: '', archived: false,
+      },
+      {
+        chat_id: otherId, project_id: 'p1', title: 'Another chat', model: 'sonnet',
+        provider: 'claude', mode: 'auto', session_id: 'session-1', created_at: '', archived: false,
+      },
+    ] as unknown as typeof store.chats
+    store.messages[draftId] = []
+    store.activeChatId = draftId
+    let resolveDelete: (value: { ok: boolean; deleted: boolean }) => void = () => {}
+    apiDel.mockImplementation(() => new Promise(resolve => { resolveDelete = resolve }))
+
+    const closing = store.closeChat()
+    expect(store.activeChatId).toBeNull()
+    // The user opens a different chat before the DELETE resolves.
+    store.activeChatId = otherId
+    resolveDelete({ ok: true, deleted: true })
+    await closing
+
+    expect(store.activeChatId).toBe(otherId)
+  })
+
+  test('clears the reopened draft once its own delete succeeds', async () => {
+    // Same race, but the user reopens the *same* draft. Once the delete
+    // lands it is gone server-side, so the view must not stay pointed at it.
+    const store = useProjectStore()
+    const draftId = 'chat-draft'
+    store.chats = [{
+      chat_id: draftId, project_id: 'p1', title: 'New Chat', model: 'sonnet',
+      provider: 'claude', mode: 'auto', session_id: '', created_at: '', archived: false,
+    }]
+    store.messages[draftId] = []
+    store.activeChatId = draftId
+    let resolveDelete: (value: { ok: boolean; deleted: boolean }) => void = () => {}
+    apiDel.mockImplementation(() => new Promise(resolve => { resolveDelete = resolve }))
+
+    const closing = store.closeChat()
+    expect(store.activeChatId).toBeNull()
+    store.activeChatId = draftId
+    resolveDelete({ ok: true, deleted: true })
+    await closing
+
+    expect(store.chats).toHaveLength(0)
+    expect(store.activeChatId).toBeNull()
+    expect(routerPush).toHaveBeenCalledWith('/')
+  })
+
   test('starts the summary when a completed chat closes and reuses it on reopen', async () => {
     const store = useProjectStore()
     const chatId = 'chat-reentry'

--- a/web/src/stores/projects.test.ts
+++ b/web/src/stores/projects.test.ts
@@ -40,7 +40,8 @@ vi.mock('../router', () => ({
     push: routerPush,
     currentRoute: {
       value: {
-        params: {}
+        params: {},
+        path: '/',
       }
     }
   }
@@ -1447,6 +1448,34 @@ describe('chat closing and re-entry orientation', () => {
     expect(store.chats).toHaveLength(0)
     expect(store.activeChatId).toBeNull()
     expect(routerPush).toHaveBeenCalledWith('/')
+  })
+
+  test('does not force navigation home when the user left for Settings mid-delete', async () => {
+    // activeChatId is null here too (Settings retains it, but this draft
+    // close already cleared it before the DELETE started) - the stale
+    // cleanup must not use that to yank the user back to `/`.
+    const { router } = await import('../router')
+    const store = useProjectStore()
+    const draftId = 'chat-draft'
+    store.chats = [{
+      chat_id: draftId, project_id: 'p1', title: 'New Chat', model: 'sonnet',
+      provider: 'claude', mode: 'auto', session_id: '', created_at: '', archived: false,
+    }]
+    store.messages[draftId] = []
+    store.activeChatId = draftId
+    let resolveDelete: (value: { ok: boolean; deleted: boolean }) => void = () => {}
+    apiDel.mockImplementation(() => new Promise(resolve => { resolveDelete = resolve }))
+    routerPush.mockClear()
+
+    const closing = store.closeChat()
+    expect(store.activeChatId).toBeNull()
+    // The user navigates to Settings before the DELETE resolves.
+    router.currentRoute.value.path = '/settings'
+    resolveDelete({ ok: true, deleted: true })
+    await closing
+
+    expect(routerPush).not.toHaveBeenCalledWith('/')
+    router.currentRoute.value.path = '/'
   })
 
   test('starts the summary when a completed chat closes and reuses it on reopen', async () => {

--- a/web/src/stores/projects.ts
+++ b/web/src/stores/projects.ts
@@ -2271,17 +2271,6 @@ export const useProjectStore = defineStore('projects', () => {
     return !loaded.some(message => message.role === 'user')
   }
 
-  // Mirrors ChatLayout's viewMode: routes here deliberately retain
-  // activeChatId underneath them (Settings/Schedules/Memory/Proposals), or
-  // are a different screen entirely (a project). Forcing a stray `/` push
-  // onto one of these mid-navigation would eject the user from wherever
-  // they went next.
-  function retainsChatAcrossNavigation(path: string): boolean {
-    return path.startsWith('/settings') || path.startsWith('/schedules')
-      || path.startsWith('/memory') || path.startsWith('/proposals')
-      || path.startsWith('/project/')
-  }
-
   async function closeChat(chatId = activeChatId.value): Promise<void> {
     if (!chatId) return
     const emptyDraft = isEmptyDraft(chatId)
@@ -2295,6 +2284,13 @@ export const useProjectStore = defineStore('projects', () => {
         activeChatId.value = null
         persistState()
       }
+      // Snapshot where the user was when this close began. Enumerating
+      // "routes that retain activeChatId" here to decide whether to force a
+      // `/` navigation kept missing pages outside ChatLayout entirely (e.g.
+      // /device) - checking whether the route has moved AT ALL covers every
+      // page, present and future, without a list to maintain.
+      const { router } = await import('../router')
+      const pathBeforeDelete = router.currentRoute.value.path
       // onlyIfEmpty: the server re-checks with the full rule and declines if
       // this is not actually a discardable draft. Closing a chat must never
       // be able to destroy one.
@@ -2311,14 +2307,10 @@ export const useProjectStore = defineStore('projects', () => {
         //     view on a chat that no longer exists.
         //   - this chat was reopened and the delete was declined (no longer
         //     empty): it is a real chat again, leave it alone too.
-        //   - nothing reopened it, but the user navigated to Settings,
-        //     Schedules, Memory, or a project: those retain activeChatId
-        //     by design, so a null activeChatId here does not mean "still
-        //     on the view this close started from" - do not force them
-        //     back to `/`.
-        const { router } = await import('../router')
-        const stillOnChatView = !retainsChatAcrossNavigation(router.currentRoute.value.path)
-        await leaveChatView(wasActive && ((activeChatId.value === null && stillOnChatView)
+        //   - nothing reopened it, but the route has moved since: wherever
+        //     the user went, forcing them back to `/` would eject them.
+        const stillOnStartingRoute = router.currentRoute.value.path === pathBeforeDelete
+        await leaveChatView(wasActive && ((activeChatId.value === null && stillOnStartingRoute)
           || (deleted && activeChatId.value === chatId)))
       }
       return

--- a/web/src/stores/projects.ts
+++ b/web/src/stores/projects.ts
@@ -2284,13 +2284,6 @@ export const useProjectStore = defineStore('projects', () => {
         activeChatId.value = null
         persistState()
       }
-      // Snapshot where the user was when this close began. Enumerating
-      // "routes that retain activeChatId" here to decide whether to force a
-      // `/` navigation kept missing pages outside ChatLayout entirely (e.g.
-      // /device) - checking whether the route has moved AT ALL covers every
-      // page, present and future, without a list to maintain.
-      const { router } = await import('../router')
-      const pathBeforeDelete = router.currentRoute.value.path
       // onlyIfEmpty: the server re-checks with the full rule and declines if
       // this is not actually a discardable draft. Closing a chat must never
       // be able to destroy one.
@@ -2301,17 +2294,30 @@ export const useProjectStore = defineStore('projects', () => {
         // The view is already cleared. A failed DELETE must not also strand
         // the router on /chat/<id> with no active chat behind it. But the
         // user may have moved on while the DELETE was in flight:
-        //   - a different chat is now active: leave it alone.
+        //   - a different chat is now active: leave it alone entirely.
         //   - this chat was reopened and the delete succeeded: it is gone
-        //     server-side, so still navigate home rather than strand the
-        //     view on a chat that no longer exists.
+        //     server-side, so the dangling activeChatId must be cleared -
+        //     regardless of where the user has since navigated.
         //   - this chat was reopened and the delete was declined (no longer
-        //     empty): it is a real chat again, leave it alone too.
-        //   - nothing reopened it, but the route has moved since: wherever
-        //     the user went, forcing them back to `/` would eject them.
-        const stillOnStartingRoute = router.currentRoute.value.path === pathBeforeDelete
-        await leaveChatView(wasActive && ((activeChatId.value === null && stillOnStartingRoute)
-          || (deleted && activeChatId.value === chatId)))
+        //     empty): it is a real chat again, leave it alone entirely.
+        const shouldClear = wasActive && (activeChatId.value === null
+          || (deleted && activeChatId.value === chatId))
+        if (shouldClear) {
+          activeChatId.value = null
+          persistState()
+          // Only force the `/` navigation while still in the chat area
+          // itself (home, or any open chat). Settings/Schedules/Memory/
+          // Proposals/a project retain activeChatId across navigation by
+          // design, and pages like /device sit outside ChatLayout entirely
+          // - forcing a `/` push onto any of them would eject the user from
+          // wherever they've gone, even though the stale id above still
+          // needed clearing.
+          const { router } = await import('../router')
+          const path = router.currentRoute.value.path
+          if (path === '/' || path === '/chat' || path.startsWith('/chat/')) {
+            await router.push('/')
+          }
+        }
       }
       return
     }

--- a/web/src/stores/projects.ts
+++ b/web/src/stores/projects.ts
@@ -2291,8 +2291,11 @@ export const useProjectStore = defineStore('projects', () => {
         await deleteChat(chatId, { selectNext: false, onlyIfEmpty: true })
       } finally {
         // The view is already cleared. A failed DELETE must not also strand
-        // the router on /chat/<id> with no active chat behind it.
-        await leaveChatView(wasActive)
+        // the router on /chat/<id> with no active chat behind it. But the
+        // user may have opened a different chat while the DELETE was in
+        // flight - only navigate home if nothing has claimed activeChatId
+        // since, or this would clobber that newly opened chat back to null.
+        await leaveChatView(wasActive && activeChatId.value === null)
       }
       return
     }

--- a/web/src/stores/projects.ts
+++ b/web/src/stores/projects.ts
@@ -2287,15 +2287,22 @@ export const useProjectStore = defineStore('projects', () => {
       // onlyIfEmpty: the server re-checks with the full rule and declines if
       // this is not actually a discardable draft. Closing a chat must never
       // be able to destroy one.
+      let deleted = false
       try {
-        await deleteChat(chatId, { selectNext: false, onlyIfEmpty: true })
+        deleted = await deleteChat(chatId, { selectNext: false, onlyIfEmpty: true })
       } finally {
         // The view is already cleared. A failed DELETE must not also strand
         // the router on /chat/<id> with no active chat behind it. But the
-        // user may have opened a different chat while the DELETE was in
-        // flight - only navigate home if nothing has claimed activeChatId
-        // since, or this would clobber that newly opened chat back to null.
-        await leaveChatView(wasActive && activeChatId.value === null)
+        // user may have reopened *this same* chat, or a different one,
+        // while the DELETE was in flight:
+        //   - a different chat is now active: leave it alone.
+        //   - this chat was reopened and the delete succeeded: it is gone
+        //     server-side, so still navigate home rather than strand the
+        //     view on a chat that no longer exists.
+        //   - this chat was reopened and the delete was declined (no longer
+        //     empty): it is a real chat again, leave it alone too.
+        await leaveChatView(wasActive && (activeChatId.value === null
+          || (deleted && activeChatId.value === chatId)))
       }
       return
     }

--- a/web/src/stores/projects.ts
+++ b/web/src/stores/projects.ts
@@ -2271,6 +2271,17 @@ export const useProjectStore = defineStore('projects', () => {
     return !loaded.some(message => message.role === 'user')
   }
 
+  // Mirrors ChatLayout's viewMode: routes here deliberately retain
+  // activeChatId underneath them (Settings/Schedules/Memory/Proposals), or
+  // are a different screen entirely (a project). Forcing a stray `/` push
+  // onto one of these mid-navigation would eject the user from wherever
+  // they went next.
+  function retainsChatAcrossNavigation(path: string): boolean {
+    return path.startsWith('/settings') || path.startsWith('/schedules')
+      || path.startsWith('/memory') || path.startsWith('/proposals')
+      || path.startsWith('/project/')
+  }
+
   async function closeChat(chatId = activeChatId.value): Promise<void> {
     if (!chatId) return
     const emptyDraft = isEmptyDraft(chatId)
@@ -2293,15 +2304,21 @@ export const useProjectStore = defineStore('projects', () => {
       } finally {
         // The view is already cleared. A failed DELETE must not also strand
         // the router on /chat/<id> with no active chat behind it. But the
-        // user may have reopened *this same* chat, or a different one,
-        // while the DELETE was in flight:
+        // user may have moved on while the DELETE was in flight:
         //   - a different chat is now active: leave it alone.
         //   - this chat was reopened and the delete succeeded: it is gone
         //     server-side, so still navigate home rather than strand the
         //     view on a chat that no longer exists.
         //   - this chat was reopened and the delete was declined (no longer
         //     empty): it is a real chat again, leave it alone too.
-        await leaveChatView(wasActive && (activeChatId.value === null
+        //   - nothing reopened it, but the user navigated to Settings,
+        //     Schedules, Memory, or a project: those retain activeChatId
+        //     by design, so a null activeChatId here does not mean "still
+        //     on the view this close started from" - do not force them
+        //     back to `/`.
+        const { router } = await import('../router')
+        const stillOnChatView = !retainsChatAcrossNavigation(router.currentRoute.value.path)
+        await leaveChatView(wasActive && ((activeChatId.value === null && stillOnChatView)
           || (deleted && activeChatId.value === chatId)))
       }
       return


### PR DESCRIPTION
## Summary
- The sidebar's "chats" nav-item links to `/` without going through `closeChat()`, so `activeChatId` stayed pointed at the chat the user left.
- With `activeChatId` still truthy, ChatLayout kept the `ChatPanel` mounted instead of showing the home screen, and the arrow-key handler for the home recent-chats grid (which bails whenever `store.activeChat` is set) stayed dead — matching the report that arrow-key navigation between chats on the home screen only started working after some other action (e.g. switching workspaces, which explicitly clears `activeChatId`) reset the stale state.
- Clears `activeChatId` when the `chatId` route param drops out while `viewMode` is the bare `'chat'` view. Project/settings/schedules/memory routes are untouched, matching the existing Esc handling that deliberately keeps `activeChatId` populated there.

## Test plan
- [x] `npm test` (816 tests passed, including a new regression test for this route-change case)
- [x] `npm run build`