### PR TITLE
fix: first message can vanish on new chats; native titles can leak injected context

### DIFF
--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -655,6 +655,9 @@ def _normalize_tier(model: str) -> str:
     return canonical_tier(model) if is_tier(model) else model
 
 
+_INJECTED_CONTEXT_MARKER = "[CIAO_CONTEXT_BEGIN]"
+
+
 def _real_title(title: str) -> str | None:
     """Return *title* if it is a real provider title, else None.
 
@@ -662,9 +665,17 @@ def _real_title(title: str) -> str | None:
     ``New session - <timestamp>``) and only later write the generated title.
     Treating the placeholder as a real title would let the auto-title poll
     stop early and leave the sidebar stuck on it, so it is filtered out here.
+
+    Also rejected: a provider whose own summarizer degrades and echoes the
+    literal first session message back as the "title". That message carries
+    our injected context capsule (see `_build_prompt_prefix`), which is meant
+    to stay invisible to the user - accepting it verbatim both leaked
+    internal state into the sidebar and skipped the 6-word
+    `_fallback_title` truncation, which only runs when no native title is
+    accepted.
     """
     title = (title or "").strip()
-    if not title or _PLACEHOLDER_TITLE_RE.match(title):
+    if not title or _PLACEHOLDER_TITLE_RE.match(title) or _INJECTED_CONTEXT_MARKER in title:
         return None
     return title
 

--- a/tests/test_auto_title.py
+++ b/tests/test_auto_title.py
@@ -90,6 +90,27 @@ async def test_native_title_opencode_placeholder_is_not_final(monkeypatch) -> No
 
 
 @pytest.mark.asyncio
+async def test_native_title_claude_rejects_leaked_context_capsule(monkeypatch) -> None:
+    """A provider summarizer that echoes the injected capsule must not win.
+
+    Some providers' own titlers degrade on occasion and echo the literal
+    first session message back as the "title" - which carries our injected
+    [CIAO_CONTEXT_BEGIN] capsule. Accepting it verbatim would leak internal
+    routing state into the sidebar.
+    """
+    from ciao.web import project_chats as pc
+
+    manager = _manager(chats={"chat-1": _chat(provider="claude")})
+
+    class FakeInfo:
+        custom_title = "[CIAO_CONTEXT_BEGIN]\n[Chat ID: \"chat-1\"]\n[CIAO_CONTEXT_END]\n\nWhat's the weather?"
+        summary = "Claude Summary"
+
+    monkeypatch.setattr(pc, "get_session_info", lambda _sid, directory=None: FakeInfo())
+    assert await manager._native_chat_title(manager._chats["chat-1"]) is None
+
+
+@pytest.mark.asyncio
 async def test_native_title_claude(monkeypatch) -> None:
     from ciao.web import project_chats as pc
 

--- a/web/src/stores/projects.test.ts
+++ b/web/src/stores/projects.test.ts
@@ -437,9 +437,13 @@ describe('unacknowledged send recovery', () => {
     store.activeChatId = chatId
     apiGet.mockImplementation((path: string) => {
       if (path.includes('/messages')) {
-        // Current servers answer with the paginated envelope; an empty one
-        // adopts-wholesale over the optimistic timeline, wiping the bubble
-        // exactly like the production reload does.
+        // Current servers answer with the paginated envelope. The reload no
+        // longer wipes the optimistic bubble on an empty window (see
+        // 'optimistic user bubble reconciliation' above), so this exercises
+        // the resend path on its own terms: the send is simply never
+        // acknowledged (no user_echo, no server-indexed row), so the
+        // unacked-send timer fires and resends it regardless of what the
+        // history reload rendered in the meantime.
         return Promise.resolve({
           items: [],
           total: 0,
@@ -1986,6 +1990,27 @@ describe('optimistic user bubble reconciliation', () => {
     )
     expect(userMsgs.length).toBe(1)
     expect(userMsgs[0].turn_index).toBe(1)
+  })
+
+  test('loadMessages background reload does not wipe the optimistic bubble on a still-empty server window', async () => {
+    // Regression for "first message can vanish on new chats": a background
+    // reload (the 15s poll, say) landing before the first turn persisted
+    // server-side used to wholesale-adopt the still-empty envelope, wiping
+    // the just-sent optimistic bubble until the next reload.
+    const store = useProjectStore()
+    const chatId = 'chat-new-empty-window'
+    store.messages[chatId] = [
+      { role: 'user', content: 'first message', timestamp: '', turn_index: undefined },
+    ]
+    apiGet.mockResolvedValue({
+      items: [], total: 0, offset: 0, limit: 50, hasMore: false, nextOffset: null,
+    })
+
+    await store.loadMessages(chatId, { background: true })
+
+    expect(
+      store.messages[chatId].some(m => m.role === 'user' && m.content === 'first message'),
+    ).toBe(true)
   })
 
   test('loadMessages discards trailing optimistic user bubbles when server has settled without them', async () => {

--- a/web/src/stores/projects.ts
+++ b/web/src/stores/projects.ts
@@ -2758,13 +2758,20 @@ export const useProjectStore = defineStore('projects', () => {
         }
         if (
           !local.length ||
-          typeof firstIndex !== 'number' ||
-          env.total <= firstIndex ||
+          // A local cache holding only un-indexed rows (the optimistic user
+          // bubble on a brand-new chat's first turn, say) has no firstIndex
+          // to merge by - but only adopt the window wholesale once the
+          // server actually has rows to offer. An empty window here just
+          // means the turn hasn't persisted yet (still "Thinking..."), and
+          // wholesale-adopting it would wipe the pending optimistic bubble
+          // until the next reload repopulates it.
+          (typeof firstIndex !== 'number' && windowRows.length > 0) ||
+          (typeof firstIndex === 'number' && env.total <= firstIndex) ||
           // The server assembled FEWER rows than we hold - a pruned or
           // unreadable session segment. Merging by index would refresh the
           // prefix and leave the stale tail untouched, showing messages that
           // are no longer part of the chat, so the window wins outright.
-          env.total < cachedEnd
+          (typeof firstIndex === 'number' && env.total < cachedEnd)
         ) {
           // Empty cache, cache from a pre-envelope server, or the session
           // reset/shrank: adopt the window wholesale.


### PR DESCRIPTION
## Summary
- `projects.ts`: `loadMessagesFromServer` only wholesale-adopted the server window when the local cache had no server-indexed row — the case for a brand-new chat's optimistic user bubble. A background reload (15s poll, WS reconnect) firing before the first turn persisted server-side returned an empty window, wiping the just-sent message until the next reload repopulated it. The wholesale-adopt path now requires the window to actually have rows.
- `project_chats.py`: `_real_title` accepted a provider's native title verbatim, including the literal injected `[CIAO_CONTEXT_BEGIN]` context capsule when a provider's own summarizer degraded and echoed the first message back. That also bypassed the 6-word `_fallback_title` truncation, which only runs when no native title is accepted. Titles containing the marker are now rejected so the deterministic fallback kicks in.

## Test plan
- [x] `pytest tests/` (full suite, incl. new `test_native_title_claude_rejects_leaked_context_capsule`)
- [x] `cd web && npx vitest run src/stores/projects.test.ts` (incl. new regression test for the vanishing optimistic bubble)
- [x] `cd web && npm run build`