### PR TITLE
feat(gws): surface Google Workspace connection status to the agent

### DIFF
--- a/ciao/control_plane.py
+++ b/ciao/control_plane.py
@@ -396,6 +396,55 @@ class CiaoControlPlane:
             "startup": self.startup_tracker.to_dict() if self.startup_tracker else None,
         })
 
+    def gws_status(self, principal: McpPrincipal) -> dict[str, Any]:
+        """Report Google Workspace connection status for the active workspace.
+
+        Resolves the workspace's linked ``gws_profile`` (falling back to the
+        operator-level default), then reports whether credentials are present and
+        whether the periodic health monitor's last reading says the token is
+        valid. Read-only and cheap: it never runs ``gws auth status`` itself, so
+        the agent can answer "is Google connected?" without a subprocess.
+        """
+        workspace = self._workspace(principal)
+        from ciao import gws_auth
+
+        profile = str(
+            getattr(self.config.workspace(workspace), "gws_profile", "") or ""
+        ).strip()
+        if not profile:
+            profile = str(getattr(self.config, "gws_default_profile", "") or "").strip()
+        if not profile:
+            return _ok(
+                {
+                    "profile": "",
+                    "configured": False,
+                    "connected": False,
+                    "needs_relogin": False,
+                }
+            )
+
+        config_dir = gws_auth.profile_config_dir(self.config, profile)
+        credentials_present = bool(config_dir) and any(
+            (config_dir / name).is_file()
+            for name in ("credentials.json", "credentials.enc")
+        )
+        health = gws_auth.read_health_cache(
+            Path(self.config.state_path).parent
+        ).get(profile, {})
+        token_valid = (
+            bool(health.get("token_valid")) if "token_valid" in health else None
+        )
+        return _ok(
+            {
+                "profile": profile,
+                "configured": credentials_present,
+                "connected": bool(credentials_present and token_valid is not False),
+                "token_valid": token_valid,
+                "needs_relogin": bool(credentials_present and token_valid is False),
+                "token_error": str(health.get("token_error") or ""),
+            }
+        )
+
     def memory_status(self, principal: McpPrincipal) -> dict[str, Any]:
         """Report native guide memory usage without copying its contents."""
         workspace = self._workspace(principal)

--- a/ciao/control_plane.py
+++ b/ciao/control_plane.py
@@ -441,13 +441,23 @@ class CiaoControlPlane:
         # disabled, or an unavailable probe), the connection is unknown rather
         # than assumed good.
         connected = bool(credentials_present and token_valid is True)
+        # The health monitor debounces a single invalid reading (notify_threshold
+        # consecutive invalid runs) before treating a login as dead. Mirror that:
+        # only a confirmed invalid state (notified_invalid) surfaces as
+        # needs_relogin, so a transient reading does not trigger a false
+        # re-authentication prompt.
+        needs_relogin = bool(
+            credentials_present
+            and token_valid is False
+            and health.get("notified_invalid")
+        )
         return _ok(
             {
                 "profile": profile,
                 "configured": credentials_present,
                 "connected": connected,
                 "token_valid": token_valid,
-                "needs_relogin": bool(credentials_present and token_valid is False),
+                "needs_relogin": needs_relogin,
                 "token_error": str(health.get("token_error") or ""),
             }
         )

--- a/ciao/control_plane.py
+++ b/ciao/control_plane.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import sqlite3
+import time
 import uuid
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, replace
@@ -41,6 +42,12 @@ logger = logging.getLogger(__name__)
 # normal ``= None`` default loses information before the control plane sees
 # it.
 _UNSET = object()
+
+# A GWS health reading older than this is treated as stale: the monitor
+# preserves prior state when probes are unavailable or checks are disabled, so
+# a cached "valid" reading can outlive the token it described. Mirrors the
+# default CIAO_GWS_HEALTH_INTERVAL (900s) plus a small grace period.
+_GWS_HEALTH_STALE_AFTER = 1200.0
 
 @dataclass(frozen=True, slots=True)
 class McpPrincipal:
@@ -436,11 +443,17 @@ class CiaoControlPlane:
         token_valid = (
             bool(health.get("token_valid")) if "token_valid" in health else None
         )
-        # Only a confirmed valid reading establishes a connection. When the
-        # health monitor has not produced a reading yet (startup delay, checks
-        # disabled, or an unavailable probe), the connection is unknown rather
-        # than assumed good.
-        connected = bool(credentials_present and token_valid is True)
+        # The health monitor preserves prior state when a probe is unavailable or
+        # checks are disabled (CIAO_GWS_HEALTH_INTERVAL=0), so a cached reading
+        # can outlive the token it described. Only a fresh, confirmed valid
+        # reading establishes a connection; a stale one is reported as unknown
+        # rather than assumed good.
+        checked_at = health.get("checked_at")
+        fresh = (
+            isinstance(checked_at, (int, float))
+            and (time.time() - float(checked_at)) <= _GWS_HEALTH_STALE_AFTER
+        )
+        connected = bool(credentials_present and token_valid is True and fresh)
         # The health monitor debounces a single invalid reading (notify_threshold
         # consecutive invalid runs) before treating a login as dead. Mirror that:
         # only a confirmed invalid state (notified_invalid) surfaces as
@@ -459,6 +472,8 @@ class CiaoControlPlane:
                 "token_valid": token_valid,
                 "needs_relogin": needs_relogin,
                 "token_error": str(health.get("token_error") or ""),
+                "checked_at": checked_at,
+                "stale": bool(credentials_present and not fresh),
             }
         )
 

--- a/ciao/control_plane.py
+++ b/ciao/control_plane.py
@@ -399,8 +399,9 @@ class CiaoControlPlane:
     def gws_status(self, principal: McpPrincipal) -> dict[str, Any]:
         """Report Google Workspace connection status for the active workspace.
 
-        Resolves the workspace's linked ``gws_profile`` (falling back to the
-        operator-level default), then reports whether credentials are present and
+        Resolves the workspace's linked ``gws_profile`` the same way the runtime
+        does (the operator-level default only counts when it names an account
+        that actually exists), then reports whether credentials are present and
         whether the periodic health monitor's last reading says the token is
         valid. Read-only and cheap: it never runs ``gws auth status`` itself, so
         the agent can answer "is Google connected?" without a subprocess.
@@ -412,7 +413,8 @@ class CiaoControlPlane:
             getattr(self.config.workspace(workspace), "gws_profile", "") or ""
         ).strip()
         if not profile:
-            profile = str(getattr(self.config, "gws_default_profile", "") or "").strip()
+            default = str(getattr(self.config, "gws_default_profile", "") or "").strip()
+            profile = default if default in gws_auth.known_profiles(self.config) else ""
         if not profile:
             return _ok(
                 {
@@ -434,11 +436,16 @@ class CiaoControlPlane:
         token_valid = (
             bool(health.get("token_valid")) if "token_valid" in health else None
         )
+        # Only a confirmed valid reading establishes a connection. When the
+        # health monitor has not produced a reading yet (startup delay, checks
+        # disabled, or an unavailable probe), the connection is unknown rather
+        # than assumed good.
+        connected = bool(credentials_present and token_valid is True)
         return _ok(
             {
                 "profile": profile,
                 "configured": credentials_present,
-                "connected": bool(credentials_present and token_valid is not False),
+                "connected": connected,
                 "token_valid": token_valid,
                 "needs_relogin": bool(credentials_present and token_valid is False),
                 "token_error": str(health.get("token_error") or ""),

--- a/ciao/execution_modes.py
+++ b/ciao/execution_modes.py
@@ -83,6 +83,7 @@ AUTO_APPROVED_MCP_TOOLS: tuple[str, ...] = (
     "memory_status",
     "memory_update",
     "vault_search",
+    "gws_status",
     "projects_list",
     "project_get",
     "project",

--- a/ciao/gws_skills.py
+++ b/ciao/gws_skills.py
@@ -60,6 +60,17 @@ ciao gws "$GWS_PROFILE" <service> <subcommand> [flags]
 
 OAuth setup: Settings → Workspaces (Google Workspace card). Credentials live in `secrets/gws-<account>/` (the pre-existing `personal` and `work` accounts use `secrets/gws-personal/` and `secrets/gws/`).
 
+## Connection status
+
+Before promising a Google call will work, check whether the active workspace's
+Google account is connected and its token is valid with the `gws_status` MCP
+tool. It reports the linked profile, whether credentials are present, the last
+health-monitor token reading, and whether a re-login is needed. It is read-only
+and never runs `gws auth status` itself. If `needs_relogin` is true, tell the
+user to re-authenticate in Settings → Workspaces (Google Workspace card) — the
+one-click "Sign in with Google" flow there restores Gmail, Calendar, Drive, and
+scheduled Google tasks.
+
 """
 
 

--- a/ciao/mcp_server.py
+++ b/ciao/mcp_server.py
@@ -966,6 +966,18 @@ class CiaoMcpService:
             """Full-text search the active workspace vault."""
             return await self._invoke("vault_search", lambda cp, p: cp.vault_search(p, query, limit))
 
+        @tool(name="gws_status", annotations=_READ, structured_output=True)
+        async def gws_status() -> dict[str, Any]:
+            """Report whether the active workspace's Google Workspace account is
+            connected and its token is valid.
+
+            Returns the linked profile name, whether credentials are present,
+            the last health-monitor token reading, and whether a re-login is
+            needed. Read-only: never runs ``gws auth status``. Use this before
+            promising a Google call will work, and to tell the user their Google
+            login has expired."""
+            return await self._invoke("gws_status", lambda cp, p: cp.gws_status(p))
+
         # vault_index_refresh -> `ciao index`; vault_lint -> `ciao lint`.
 
         @tool(name="projects_list", annotations=_READ, structured_output=True)

--- a/ciao/stock/skills/gws-shared/SKILL.md
+++ b/ciao/stock/skills/gws-shared/SKILL.md
@@ -23,6 +23,17 @@ ciao gws "$GWS_PROFILE" <service> <subcommand> [flags]
 
 OAuth setup: Settings → Workspaces (Google Workspace card). Credentials live in `secrets/gws-<account>/` (the pre-existing `personal` and `work` accounts use `secrets/gws-personal/` and `secrets/gws/`).
 
+## Connection status
+
+Before promising a Google call will work, check whether the active workspace's
+Google account is connected and its token is valid with the `gws_status` MCP
+tool. It reports the linked profile, whether credentials are present, the last
+health-monitor token reading, and whether a re-login is needed. It is read-only
+and never runs `gws auth status` itself. If `needs_relogin` is true, tell the
+user to re-authenticate in Settings → Workspaces (Google Workspace card) — the
+one-click "Sign in with Google" flow there restores Gmail, Calendar, Drive, and
+scheduled Google tasks.
+
 ## Global Flags
 
 | Flag | Description |

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -146,6 +146,7 @@ skill surface (admin or redundant with native tools).
 | Context | `context_get` (includes `system` status) |
 | Bounded memory | `memory_status`, `memory_update` (review proposals via the CLI: `ciao memory-proposal-add`, `ciao memory-proposals`, `ciao memory-proposal-dismiss`) |
 | Vault | `vault_search` |
+| Google Workspace | `gws_status` (read-only connection/token health) |
 | Projects | `projects_list`, `project_get`, `project` (create/update/restore), `project_action` (complete/delete) |
 | Workspaces | `workspaces_list`, `workspace_create` (update/delete via PWA Settings) |
 | Chats | `chats_list`, `chat_get`, `chat_create`, `chat_update`, `chat_send`, `chat_continue`, `chat_retry`, `chat_handover`, `chat_fork`, `chat_archive`, `chat_delete`, `chat_stop` |

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1248,9 +1248,9 @@ def test_gws_status_reports_unlinked_workspace(tmp_path: Path) -> None:
 
     assert result["ok"] is True
     data = result["data"]
-    # No workspace link, so the operator-level default profile applies; it has
-    # no credentials yet, so nothing is connected.
-    assert data["profile"] == "personal"
+    # No workspace link, and the operator-level default "personal" does not name
+    # a real account on a fresh install, so nothing is reported as connected.
+    assert data["profile"] == ""
     assert data["configured"] is False
     assert data["connected"] is False
 
@@ -1362,6 +1362,48 @@ def test_gws_status_reports_needs_relogin(tmp_path: Path) -> None:
     assert data["connected"] is False
     assert data["needs_relogin"] is True
     assert data["token_error"] == "invalid_grant"
+
+
+def test_gws_status_reports_unknown_health_as_not_connected(tmp_path: Path) -> None:
+    from ciao import gws_auth
+    from ciao.config import CiaoConfig, WorkspaceConfig
+
+    config = CiaoConfig(
+        pwa_auth_token="test-token",
+        workspace_root=tmp_path,
+        state_path=tmp_path / ".runtime" / "state.json",
+        media_root=tmp_path / ".runtime" / "media",
+        workspaces={
+            "personal": WorkspaceConfig(
+                name="personal", vault_root="memory-vault/personal", gws_profile="personal"
+            )
+        },
+    )
+    config_dir = gws_auth.profile_config_dir(config, "personal")
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "credentials.json").write_text("{}", encoding="utf-8")
+    # No gws_health.json: the monitor has not produced a reading yet.
+    pcm = SimpleNamespace(
+        refresh_workspaces=lambda: [],
+        active_chat_ids=lambda: [],
+    )
+    plane = CiaoControlPlane(
+        config,
+        project_chat_manager=pcm,
+        schedule_manager=SimpleNamespace(),
+        loop_manager=SimpleNamespace(),
+    )
+
+    result = plane.gws_status(_chat_create_principal())
+
+    assert result["ok"] is True
+    data = result["data"]
+    assert data["profile"] == "personal"
+    assert data["configured"] is True
+    assert data["token_valid"] is None
+    # Without a confirmed valid reading, the connection is unknown, not assumed.
+    assert data["connected"] is False
+    assert data["needs_relogin"] is False
 
 
 def test_workspace_create_registers_and_persists(tmp_path: Path) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+import time
 from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
@@ -1282,6 +1283,7 @@ def test_gws_status_reports_connected_profile(tmp_path: Path) -> None:
                     "personal": {
                         "token_valid": True,
                         "token_error": "",
+                        "checked_at": time.time(),
                     }
                 }
             }
@@ -1463,6 +1465,65 @@ def test_gws_status_reports_unknown_health_as_not_connected(tmp_path: Path) -> N
     # Without a confirmed valid reading, the connection is unknown, not assumed.
     assert data["connected"] is False
     assert data["needs_relogin"] is False
+
+
+def test_gws_status_reports_stale_reading_as_not_connected(tmp_path: Path) -> None:
+    from ciao import gws_auth
+    from ciao.config import CiaoConfig, WorkspaceConfig
+
+    config = CiaoConfig(
+        pwa_auth_token="test-token",
+        workspace_root=tmp_path,
+        state_path=tmp_path / ".runtime" / "state.json",
+        media_root=tmp_path / ".runtime" / "media",
+        workspaces={
+            "personal": WorkspaceConfig(
+                name="personal", vault_root="memory-vault/personal", gws_profile="personal"
+            )
+        },
+    )
+    config_dir = gws_auth.profile_config_dir(config, "personal")
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "credentials.json").write_text("{}", encoding="utf-8")
+    runtime = tmp_path / ".runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    # A valid reading that is far older than the health interval: the monitor
+    # preserves it when checks are disabled or probes are unavailable, so it can
+    # no longer be trusted as a live connection.
+    (runtime / "gws_health.json").write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "personal": {
+                        "token_valid": True,
+                        "token_error": "",
+                        "checked_at": time.time() - 3600,
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    pcm = SimpleNamespace(
+        refresh_workspaces=lambda: [],
+        active_chat_ids=lambda: [],
+    )
+    plane = CiaoControlPlane(
+        config,
+        project_chat_manager=pcm,
+        schedule_manager=SimpleNamespace(),
+        loop_manager=SimpleNamespace(),
+    )
+
+    result = plane.gws_status(_chat_create_principal())
+
+    assert result["ok"] is True
+    data = result["data"]
+    assert data["profile"] == "personal"
+    assert data["configured"] is True
+    assert data["token_valid"] is True
+    assert data["stale"] is True
+    assert data["connected"] is False
 
 
 def test_workspace_create_registers_and_persists(tmp_path: Path) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1240,6 +1240,130 @@ def test_workspaces_list_lists_all_configured_workspaces(tmp_path: Path) -> None
     assert personal["default_provider"] == "claude"
 
 
+def test_gws_status_reports_unlinked_workspace(tmp_path: Path) -> None:
+    plane, _config, _refreshes = _workspace_control_plane(tmp_path)
+    principal = _chat_create_principal()
+
+    result = plane.gws_status(principal)
+
+    assert result["ok"] is True
+    data = result["data"]
+    # No workspace link, so the operator-level default profile applies; it has
+    # no credentials yet, so nothing is connected.
+    assert data["profile"] == "personal"
+    assert data["configured"] is False
+    assert data["connected"] is False
+
+
+def test_gws_status_reports_connected_profile(tmp_path: Path) -> None:
+    from ciao import gws_auth
+    from ciao.config import CiaoConfig, WorkspaceConfig
+
+    config = CiaoConfig(
+        pwa_auth_token="test-token",
+        workspace_root=tmp_path,
+        state_path=tmp_path / ".runtime" / "state.json",
+        media_root=tmp_path / ".runtime" / "media",
+        workspaces={
+            "personal": WorkspaceConfig(
+                name="personal", vault_root="memory-vault/personal", gws_profile="personal"
+            )
+        },
+    )
+    config_dir = gws_auth.profile_config_dir(config, "personal")
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "credentials.json").write_text("{}", encoding="utf-8")
+    runtime = tmp_path / ".runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    (runtime / "gws_health.json").write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "personal": {
+                        "token_valid": True,
+                        "token_error": "",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    pcm = SimpleNamespace(
+        refresh_workspaces=lambda: [],
+        active_chat_ids=lambda: [],
+    )
+    plane = CiaoControlPlane(
+        config,
+        project_chat_manager=pcm,
+        schedule_manager=SimpleNamespace(),
+        loop_manager=SimpleNamespace(),
+    )
+
+    result = plane.gws_status(_chat_create_principal())
+
+    assert result["ok"] is True
+    data = result["data"]
+    assert data["profile"] == "personal"
+    assert data["configured"] is True
+    assert data["connected"] is True
+    assert data["needs_relogin"] is False
+
+
+def test_gws_status_reports_needs_relogin(tmp_path: Path) -> None:
+    from ciao import gws_auth
+    from ciao.config import CiaoConfig, WorkspaceConfig
+
+    config = CiaoConfig(
+        pwa_auth_token="test-token",
+        workspace_root=tmp_path,
+        state_path=tmp_path / ".runtime" / "state.json",
+        media_root=tmp_path / ".runtime" / "media",
+        workspaces={
+            "personal": WorkspaceConfig(
+                name="personal", vault_root="memory-vault/personal", gws_profile="personal"
+            )
+        },
+    )
+    config_dir = gws_auth.profile_config_dir(config, "personal")
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "credentials.json").write_text("{}", encoding="utf-8")
+    runtime = tmp_path / ".runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    (runtime / "gws_health.json").write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "personal": {
+                        "token_valid": False,
+                        "token_error": "invalid_grant",
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    pcm = SimpleNamespace(
+        refresh_workspaces=lambda: [],
+        active_chat_ids=lambda: [],
+    )
+    plane = CiaoControlPlane(
+        config,
+        project_chat_manager=pcm,
+        schedule_manager=SimpleNamespace(),
+        loop_manager=SimpleNamespace(),
+    )
+
+    result = plane.gws_status(_chat_create_principal())
+
+    assert result["ok"] is True
+    data = result["data"]
+    assert data["profile"] == "personal"
+    assert data["configured"] is True
+    assert data["connected"] is False
+    assert data["needs_relogin"] is True
+    assert data["token_error"] == "invalid_grant"
+
+
 def test_workspace_create_registers_and_persists(tmp_path: Path) -> None:
     plane, config, refreshes = _workspace_control_plane(tmp_path)
     principal = _chat_create_principal()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1336,6 +1336,7 @@ def test_gws_status_reports_needs_relogin(tmp_path: Path) -> None:
                     "personal": {
                         "token_valid": False,
                         "token_error": "invalid_grant",
+                        "notified_invalid": True,
                     }
                 }
             }
@@ -1362,6 +1363,64 @@ def test_gws_status_reports_needs_relogin(tmp_path: Path) -> None:
     assert data["connected"] is False
     assert data["needs_relogin"] is True
     assert data["token_error"] == "invalid_grant"
+
+
+def test_gws_status_suppresses_debounced_invalid_reading(tmp_path: Path) -> None:
+    from ciao import gws_auth
+    from ciao.config import CiaoConfig, WorkspaceConfig
+
+    config = CiaoConfig(
+        pwa_auth_token="test-token",
+        workspace_root=tmp_path,
+        state_path=tmp_path / ".runtime" / "state.json",
+        media_root=tmp_path / ".runtime" / "media",
+        workspaces={
+            "personal": WorkspaceConfig(
+                name="personal", vault_root="memory-vault/personal", gws_profile="personal"
+            )
+        },
+    )
+    config_dir = gws_auth.profile_config_dir(config, "personal")
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "credentials.json").write_text("{}", encoding="utf-8")
+    runtime = tmp_path / ".runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    # A single invalid reading with notified_invalid=false is the monitor's
+    # debounce window: it may be a transient failure, so it must not surface as
+    # needs_relogin.
+    (runtime / "gws_health.json").write_text(
+        json.dumps(
+            {
+                "profiles": {
+                    "personal": {
+                        "token_valid": False,
+                        "token_error": "invalid_grant",
+                        "notified_invalid": False,
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    pcm = SimpleNamespace(
+        refresh_workspaces=lambda: [],
+        active_chat_ids=lambda: [],
+    )
+    plane = CiaoControlPlane(
+        config,
+        project_chat_manager=pcm,
+        schedule_manager=SimpleNamespace(),
+        loop_manager=SimpleNamespace(),
+    )
+
+    result = plane.gws_status(_chat_create_principal())
+
+    assert result["ok"] is True
+    data = result["data"]
+    assert data["profile"] == "personal"
+    assert data["configured"] is True
+    assert data["connected"] is False
+    assert data["needs_relogin"] is False
 
 
 def test_gws_status_reports_unknown_health_as_not_connected(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #321

## Summary

The Settings UI already wires the server-managed GWS re-login endpoints into a one-click "Sign in with Google" connect button (merged earlier). The remaining gap from #321 was the agent-facing path: the agent had no way to know whether a Google account is connected or its token is valid, so it could not tell the user their login expired or confirm a Google call will work.

This adds a read-only `gws_status` MCP tool that reports the active workspace's Google Workspace connection state.

## Changes

- `ciao/control_plane.py`: `gws_status` resolves the workspace's linked `gws_profile` (falling back to the operator-level default), checks whether credentials are present, and reads the persisted health-monitor cache for the last token reading. It never runs `gws auth status`, so it is cheap and secret-free.
- `ciao/mcp_server.py`: registers `gws_status` as a `_READ` tool.
- `ciao/execution_modes.py`: adds `gws_status` to `AUTO_APPROVED_MCP_TOOLS` (read-only, no approval card).
- `ciao/gws_skills.py` + `ciao/stock/skills/gws-shared/SKILL.md`: document the tool and the re-login path in the shared gws skill (both the curated file and the regeneration source).
- `docs/MCP.md`: catalog entry.
- `tests/test_mcp_server.py`: control-plane tests for the unlinked, connected, and needs-relogin cases.

## Verification

- `pytest tests/test_mcp_server.py tests/test_gws_skills.py tests/test_gws_auth.py tests/test_gws_relogin_routes.py tests/test_gws_wrapper.py` passes (the one failure, `test_chat_archive_defaults_to_caller_chat`, is pre-existing on the clean tree).
- No frontend changes; `npm run build` unaffected.