### PR TITLE
fix(housekeeping): fire missed one-time reminders and show name with link

### DIFF
--- a/ciao/operator_actions.py
+++ b/ciao/operator_actions.py
@@ -731,6 +731,31 @@ def _schedule_display_name(entry: Any) -> str:
     return str(getattr(entry, "schedule_id", ""))
 
 
+def _once_target_datetime(entry: Any) -> datetime | None:
+    """The aware fire time of a ``once`` schedule, or ``None`` if malformed.
+
+    A one-time reminder fires at ``daily_time_utc`` on ``run_at_date`` in
+    ``timezone_name`` — the same target ``schedules.compute_next_run`` builds
+    for ``once`` entries. Treating midnight of ``run_at_date`` as the target
+    would mark a reminder due later today as already missed and let "Fire now"
+    dispatch (and delete) it early.
+    """
+    run_at_date = str(getattr(entry, "run_at_date", "") or "").strip()
+    if not run_at_date:
+        return None
+    try:
+        tz = ZoneInfo(entry.timezone_name or "UTC")
+        target_date = datetime.fromisoformat(run_at_date).date()
+        hh, mm = str(getattr(entry, "daily_time_utc", "") or "00:00").split(":", 1)
+        target_h, target_m = int(hh), int(mm)
+    except (ValueError, AttributeError):
+        return None
+    return datetime(
+        target_date.year, target_date.month, target_date.day,
+        target_h, target_m, tzinfo=tz,
+    )
+
+
 def _detect_missed_schedules(context: DetectionContext) -> list[OperatorAction]:
     """One collapsed tile for every missed one-time schedule.
 
@@ -757,10 +782,8 @@ def _detect_missed_schedules(context: DetectionContext) -> list[OperatorAction]:
             continue
         if not entry.run_at_date:
             continue
-        try:
-            tz = ZoneInfo(entry.timezone_name or "UTC")
-            target = datetime.fromisoformat(entry.run_at_date).replace(tzinfo=tz)
-        except (ValueError, AttributeError):
+        target = _once_target_datetime(entry)
+        if target is None:
             continue
         if now >= target:
             missed.append(entry)
@@ -1339,10 +1362,8 @@ async def _run_missed_schedules(context: DetectionContext) -> tuple[dict[str, An
             continue
         if not entry.run_at_date:
             continue
-        try:
-            tz = ZoneInfo(entry.timezone_name or "UTC")
-            target = datetime.fromisoformat(entry.run_at_date).replace(tzinfo=tz)
-        except (ValueError, AttributeError):
+        target = _once_target_datetime(entry)
+        if target is None:
             continue
         if now < target:
             continue

--- a/ciao/operator_actions.py
+++ b/ciao/operator_actions.py
@@ -31,6 +31,7 @@ Contract, enforced in tests
 
 from __future__ import annotations
 
+import inspect
 import json
 import logging
 import os
@@ -716,6 +717,20 @@ def _detect_unmigrated_links(context: DetectionContext) -> list[OperatorAction]:
 # -- missed one-time schedules ----------------------------------------------
 
 
+def _schedule_display_name(entry: Any) -> str:
+    """Human label for a schedule: title > prompt snippet."""
+    title = str(getattr(entry, "title", "") or "").strip()
+    if title:
+        return title
+    raw = str(getattr(entry, "prompt", "") or "").strip()
+    if raw:
+        first = raw.splitlines()[0].strip() if raw.splitlines() else raw
+        if len(first) > 60:
+            return first[:57] + "…"
+        return first
+    return str(getattr(entry, "schedule_id", ""))
+
+
 def _detect_missed_schedules(context: DetectionContext) -> list[OperatorAction]:
     """One collapsed tile for every missed one-time schedule.
 
@@ -734,7 +749,7 @@ def _detect_missed_schedules(context: DetectionContext) -> list[OperatorAction]:
         logger.exception("operator actions: schedule store read failed")
         return []
     now = context.now or datetime.now(UTC)
-    missed: list[str] = []
+    missed: list[Any] = []
     for entry in entries:
         if entry.frequency != "once" or not entry.enabled:
             continue
@@ -748,28 +763,53 @@ def _detect_missed_schedules(context: DetectionContext) -> list[OperatorAction]:
         except (ValueError, AttributeError):
             continue
         if now >= target:
-            missed.append(entry.schedule_id)
+            missed.append(entry)
     if not missed:
         return []
+    # Build a detail that names each missed reminder with a link to its
+    # schedule detail (rendered as markdown in the strip). Cap the list so a
+    # burst does not blow up the tile.
+    preview = missed[:5]
+    bullet_lines: list[str] = []
+    for entry in preview:
+        label = _schedule_display_name(entry).replace("[", "\\[").replace("]", "\\]")
+        due = str(getattr(entry, "run_at_date", "") or "")
+        due_suffix = f" — due {due}" if due else ""
+        # Markdown link: [label](/schedules/schedule_id)
+        sid = str(getattr(entry, "schedule_id", ""))
+        bullet_lines.append(f"- [{label}](/schedules/{sid}){due_suffix}")
+    if len(missed) > len(preview):
+        bullet_lines.append(f"- …and {len(missed) - len(preview)} more")
+    detail_base = (
+        f"The server was down past {len(missed)} one-time reminder(s). "
+        "They were not auto-fired because they are stale by now."
+    )
+    detail = detail_base + "\n\nMissed:\n" + "\n".join(bullet_lines) if bullet_lines else detail_base
+    # Chat prompt also enumerates names so the operator can decide per item.
+    chat_lines = [
+        f"- { _schedule_display_name(e)} (/schedules/{getattr(e, 'schedule_id', '')}) — due {getattr(e, 'run_at_date', '')}"
+        for e in preview
+    ]
+    chat_prompt = (
+        f"{len(missed)} one-time reminder(s) were missed while the server "
+        "was off and were not auto-fired because they are stale. "
+        + "Missed:\n"
+        + "\n".join(chat_lines)
+        + ("\n…and more" if len(missed) > len(preview) else "")
+        + "\n\nFire the ones that are still relevant, or dismiss the rest."
+    )
     return [
         OperatorAction(
             id="missed-schedules",
             kind="missed-schedules",
             severity=10,
             title=f"{len(missed)} one-time reminder(s) were missed",
-            detail=(
-                f"The server was down past {len(missed)} one-time reminder(s). "
-                "They were not auto-fired because they are stale by now."
-            ),
+            detail=detail,
             glyph="⏰",
             workspace="",
             run_label="Fire now",
             chat_label="Review in chat",
-            chat_prompt=(
-                f"{len(missed)} one-time reminder(s) were missed while the server "
-                "was off and were not auto-fired because they are stale. Fire the "
-                "ones that are still relevant, or dismiss the rest."
-            ),
+            chat_prompt=chat_prompt,
         )
     ]
 
@@ -1151,7 +1191,7 @@ _DETECTORS: list[Callable[[DetectionContext], list[OperatorAction]]] = [
 # -- run dispatch -----------------------------------------------------------
 
 
-def run_action(action_id: str, context: DetectionContext) -> tuple[dict[str, Any], str]:
+async def run_action(action_id: str, context: DetectionContext) -> tuple[dict[str, Any], str]:
     """Perform the mechanical work for one action id.
 
     Returns ``(result, summary_text)``. Raises :class:`ValueError` for an
@@ -1166,7 +1206,7 @@ def run_action(action_id: str, context: DetectionContext) -> tuple[dict[str, Any
     if action_id == "vault-vocabulary":
         return _run_vault_vocabulary(context)
     if action_id == "missed-schedules":
-        return _run_missed_schedules(context)
+        return await _run_missed_schedules(context)
     if action_id == "workspace-unmigrated":
         return _run_workspace_reroot(context)
     if action_id.startswith(("workspace-root-missing:", "workspace-assets-stale:")):
@@ -1285,7 +1325,7 @@ def _run_vault_vocabulary(context: DetectionContext) -> tuple[dict[str, Any], st
     return summary, f"{renamed} type(s) renamed, {failed} failed."
 
 
-def _run_missed_schedules(context: DetectionContext) -> tuple[dict[str, Any], str]:
+async def _run_missed_schedules(context: DetectionContext) -> tuple[dict[str, Any], str]:
     manager = context.schedule_store
     if manager is None or not hasattr(manager, "dispatch_now"):
         raise ValueError("no schedule manager to fire missed one-timers")
@@ -1307,7 +1347,9 @@ def _run_missed_schedules(context: DetectionContext) -> tuple[dict[str, Any], st
         if now < target:
             continue
         try:
-            manager.dispatch_now(entry.schedule_id)
+            res = manager.dispatch_now(entry.schedule_id)
+            if inspect.iscoroutine(res) or inspect.isawaitable(res):
+                await res
             fired.append(entry.schedule_id)
         except Exception as exc:  # noqa: BLE001 — one failure must not stop the rest
             errors.append(str(exc))

--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -7932,7 +7932,7 @@ async def run_housekeeping_action(request: Request) -> JSONResponse:
     action_id = request.path_params["action_id"]
     context = _housekeeping_context(request)
     try:
-        result, summary = operator_actions.run_action(action_id, context)
+        result, summary = await operator_actions.run_action(action_id, context)
     except ValueError as exc:
         return JSONResponse({"error": str(exc)}, status_code=404)
     except Exception as exc:  # noqa: BLE001 — a failed run is a tile, not a crash

--- a/tests/test_operator_actions.py
+++ b/tests/test_operator_actions.py
@@ -181,11 +181,11 @@ def test_github_star_resurfaces_after_snooze_expires(tmp_path: Path) -> None:
     assert "github-star" in [a.id for a in detect_actions(context)]
 
 
-def test_github_star_run_records_starred(tmp_path: Path) -> None:
+async def test_github_star_run_records_starred(tmp_path: Path) -> None:
     from ciao.operator_actions import run_action
 
     context = _context(tmp_path)
-    result, _summary = run_action("github-star", context)
+    result, _summary = await run_action("github-star", context)
     assert result["status"] == "starred"
     assert "github-star" not in [a.id for a in detect_actions(context)]
 
@@ -547,9 +547,9 @@ def test_scan_vault_is_never_touched(tmp_path: Path) -> None:
     spy.assert_not_called()
 
 
-def test_run_action_unknown_id_raises_value_error(tmp_path: Path) -> None:
+async def test_run_action_unknown_id_raises_value_error(tmp_path: Path) -> None:
     with pytest.raises(ValueError):
-        run_action("no-such-action", DetectionContext(config=_FakeConfig(tmp_path)))
+        await run_action("no-such-action", DetectionContext(config=_FakeConfig(tmp_path)))
 
 
 def test_unmigrated_links_tile_does_not_assert_wikilinks_it_cannot_verify(

--- a/tests/test_operator_actions.py
+++ b/tests/test_operator_actions.py
@@ -69,6 +69,8 @@ class _Entry:
         self.timezone_name = kw.get("timezone_name", "UTC")
         self.schedule_id = kw.get("schedule_id", "sched-1")
         self.title = kw.get("title", "")
+        self.prompt = kw.get("prompt", "")
+        self.daily_time_utc = kw.get("daily_time_utc", "00:00")
 
 
 class _Store:
@@ -336,6 +338,55 @@ def test_missed_schedules_fires_collapsed_tile(tmp_path: Path) -> None:
     )
     tiles = [a for a in detect_actions(context) if a.kind == "missed-schedules"]
     assert tiles == []
+
+
+def test_missed_schedules_honors_fire_time_of_day(tmp_path: Path) -> None:
+    """A once reminder due later today is not missed, and not fired early.
+
+    The target is ``daily_time_utc`` on ``run_at_date`` in the entry's
+    timezone, not midnight of ``run_at_date``. At 09:00 a reminder due at
+    23:00 today must stay out of the strip (and out of "Fire now"), or it
+    would be dispatched — and deleted — hours early.
+    """
+    now = datetime(2026, 1, 20, 9, 0, tzinfo=UTC)
+    store = _Store(
+        [
+            _Entry(
+                frequency="once",
+                run_at_date="2026-01-20",
+                daily_time_utc="23:00",
+                schedule_id="sched-later-today",
+            ),
+        ]
+    )
+    context = DetectionContext(
+        config=_FakeConfig(tmp_path, workspaces=("personal",)),
+        runtime_dir=_runtime(tmp_path),
+        schedule_store=store,
+        now=now,
+    )
+    tiles = [a for a in detect_actions(context) if a.kind == "missed-schedules"]
+    assert tiles == []
+
+    # The same reminder is missed once its fire time has passed.
+    store = _Store(
+        [
+            _Entry(
+                frequency="once",
+                run_at_date="2026-01-20",
+                daily_time_utc="23:00",
+                schedule_id="sched-later-today",
+            ),
+        ]
+    )
+    context = DetectionContext(
+        config=_FakeConfig(tmp_path, workspaces=("personal",)),
+        runtime_dir=_runtime(tmp_path),
+        schedule_store=store,
+        now=datetime(2026, 1, 20, 23, 30, tzinfo=UTC),
+    )
+    tiles = [a for a in detect_actions(context) if a.kind == "missed-schedules"]
+    assert len(tiles) == 1
 
 
 def test_review_queue_depth_counts_skill_proposal_files(tmp_path: Path) -> None:

--- a/web/src/components/HousekeepingStrip.vue
+++ b/web/src/components/HousekeepingStrip.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useHousekeepingStore } from '../stores/housekeeping'
 import { useProjectStore } from '../stores/projects'
 import type { OperatorAction } from '../lib/types'
+import { renderMarkdown } from '../lib/safeMarkdown'
 
 const housekeeping = useHousekeepingStore()
 const projectStore = useProjectStore()
@@ -101,6 +102,24 @@ async function openView(action: OperatorAction): Promise<void> {
   await router.push(action.view_route)
 }
 
+function renderedDetail(detail: string): string {
+  // Missed-schedule detail is markdown (bullets with [name](/schedules/id)).
+  // Other tiles are plain sentences — markdown rendering keeps them as <p>.
+  return renderMarkdown(detail)
+}
+
+async function onDetailClick(event: MouseEvent): Promise<void> {
+  const anchor = (event.target as HTMLElement)?.closest('a')
+  if (!anchor) return
+  const href = anchor.getAttribute('href') || ''
+  // Internal schedule links should route without a full reload.
+  if (href.startsWith('/schedules')) {
+    event.preventDefault()
+    const { router } = await import('../router')
+    await router.push(href)
+  }
+}
+
 async function openChat(action: OperatorAction): Promise<void> {
   if (chatBusy.value || !action.chat_prompt) return
   chatBusy.value = true
@@ -142,7 +161,8 @@ async function openChat(action: OperatorAction): Promise<void> {
       <span class="housekeeping-glyph" aria-hidden="true">{{ action.glyph }}</span>
       <div class="housekeeping-body">
         <p class="housekeeping-title">{{ action.title }}</p>
-        <p class="housekeeping-detail">{{ action.detail }}</p>
+        <!-- eslint-disable-next-line vue/no-v-html — rendered via DOMPurify -->
+        <div class="housekeeping-detail" v-html="renderedDetail(action.detail)" @click="onDetailClick"></div>
       </div>
       <div class="housekeeping-actions">
         <button
@@ -278,6 +298,29 @@ async function openChat(action: OperatorAction): Promise<void> {
   margin: var(--space-1) 0 0;
   font-size: var(--text-sm);
   color: var(--fg2);
+}
+
+.housekeeping-detail :deep(a) {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.housekeeping-detail :deep(ul) {
+  margin: var(--space-1) 0 0;
+  padding-left: 1.1em;
+}
+
+.housekeeping-detail :deep(li) {
+  margin: 2px 0;
+}
+
+.housekeeping-detail :deep(p) {
+  margin: 0;
+}
+
+.housekeeping-detail :deep(p + ul) {
+  margin-top: var(--space-1);
 }
 
 .housekeeping-actions {


### PR DESCRIPTION
**Why**
- `Fire now` on the missed-schedules tile was a no-op: `ciao/operator_actions.py:1310` called `ScheduleManager.dispatch_now` (async in `ciao/schedules.py:802`) without `await`, so the coroutine was never run and the entry stayed in the store.
- Tile detail showed only a count, so the operator couldn't tell which reminder was missed.

**What**
- `ciao/operator_actions.py`: add `_schedule_display_name`, enrich `_detect_missed_schedules` detail with `[name](/schedules/<id>) — due <date>` markdown bullets (cap 5 + overflow) and mirror names in `chat_prompt`; make `run_action`/`_run_missed_schedules` async and `await` an awaitable `dispatch_now` (handles real async manager and sync mock).
- `ciao/web/routes_api.py:7935`: `await operator_actions.run_action(...)`.
- `web/src/components/HousekeepingStrip.vue`: render `detail` via `renderMarkdown` (`lib/safeMarkdown.ts`) with `v-html` + `onDetailClick` router intercept for `/schedules/*`, add link/list styling.
- `tests/test_operator_actions.py`: adapt `test_github_star_run_records_starred` and `test_run_action_unknown_id_raises_value_error` to async/await.

**Verification**
- `PYTHONPATH=. .venv/bin/python -m pytest tests/test_operator_actions.py tests/test_web_housekeeping.py tests/test_schedules.py -q` → 107 passed
- `web: npx vue-tsc --noEmit` → ok, `npx vite build` → ok
- Manual async-manager repro: detail now contains `[My reminder](/schedules/…)` and `Fire now` deletes the entry / calls dispatch.