### PR TITLE
fix(auth): detect Claude CLI login state

### DIFF
--- a/ciao/critique.py
+++ b/ciao/critique.py
@@ -42,28 +42,17 @@ _OPENCODE_AVAILABLE_CACHE: tuple[float, bool] | None = None
 _PROVIDER_AVAILABLE_TTL = 30.0  # seconds — panel resolution is read-hot
 
 def is_anthropic_available() -> bool:
-    """True when Anthropic API key or Claude Code OAuth credentials are present."""
+    """True when Anthropic API key or Claude Code reports an active login."""
     if os.environ.get("ANTHROPIC_API_KEY", "").strip():
         return True
-    for p in [
-        Path.home() / ".claude-agent" / "credentials.json",
-        Path.home() / ".claude" / ".credentials.json",
-    ]:
-        try:
-            if p.is_file():
-                return True
-        except Exception:
-            pass
-    raw_cfg = os.environ.get("CLAUDE_CONFIG_PATH", "").strip()
-    config_path = Path(raw_cfg).expanduser() if raw_cfg else Path.home() / ".claude.json"
     try:
-        if config_path.is_file():
-            data = json.loads(config_path.read_text(encoding="utf-8"))
-            if isinstance(data, dict) and data.get("oauthAccount"):
-                return True
+        from ciao.setup_status import claude_auth_status, claude_cli_path
+
+        binary = claude_cli_path()
+        return bool(binary and claude_auth_status(binary, env=os.environ)["logged_in"])
     except Exception:
-        pass
-    return False
+        # Availability probing must never prevent critique resolution.
+        return False
 
 
 def is_opencode_available() -> bool:

--- a/ciao/providers/claude.py
+++ b/ciao/providers/claude.py
@@ -226,7 +226,7 @@ def auth_command(*, device_auth: bool = False) -> list[str]:
     binary = get_bundled_claude_path() or resolve_tool("claude")
     if not binary:
         raise FileNotFoundError("Claude CLI not found")
-    return [binary, "login"]
+    return [binary, "auth", "login"]
 
 
 # Patterns from the bundled Claude Code CLI's stderr that are harmless noise

--- a/ciao/setup_status.py
+++ b/ciao/setup_status.py
@@ -35,6 +35,7 @@ _CLAUDE_DISCOVERY_EMPTY_TTL_SECONDS = 15.0
 # it blows past 12s — at which point the old timeout swallowed the error and
 # cached the empty list for five minutes. Give the health pass real headroom.
 _CLAUDE_MCP_LIST_TIMEOUT_SECONDS = 30.0
+_CLAUDE_AUTH_STATUS_TIMEOUT_SECONDS = 5.0
 logger = logging.getLogger(__name__)
 
 _claude_mcps_cache: tuple[float, str, tuple[str, ...], int] | None = None
@@ -641,10 +642,8 @@ def claude_install_command() -> str:
 def claude_app_path() -> str:
     """Path to an installed Claude desktop app, or "".
 
-    The desktop app ships Claude Code too, but Ciaobot drives the ``claude``
-    CLI through the Agent SDK, so an app-only install still needs the CLI.
-    Detecting it lets setup say "you have the app, add the CLI" instead of the
-    blunter "not installed".
+    The desktop app ships Claude Code too. Detecting it lets setup explain that
+    its app-private login is separate from the CLI credential store.
     """
     home = Path.home()
     candidates: list[Path] = []
@@ -741,22 +740,38 @@ def _claude_status(
             mcps=claude_mcps,
             cli_path=binary,
         )
-    if credentials_path.is_file():
+    auth_status = claude_auth_status(
+        binary,
+        env=env,
+        credentials_path=credentials_path,
+        config_path=config_path,
+    )
+    if auth_status["logged_in"]:
+        email = auth_status.get("email", "")
+        org_name = auth_status.get("org_name", "")
+        account = email or org_name or "Claude OAuth"
+        detail = f"Signed in as {email}" if email else "Claude OAuth is connected."
+        if org_name and email:
+            detail += f" Organization: {org_name}."
         return _provider(
             name="claude",
             ok=True,
             auth="oauth",
             command="ciao auth claude",
-            detail=str(credentials_path),
+            detail=detail,
             version=version,
-            account="OAuth credentials",
+            account=account,
             protocol="Agent SDK ready",
             skills=claude_skills,
             mcps=claude_mcps,
             cli_path=binary,
         )
-    account = _claude_oauth_account(config_path)
-    if account:
+    # Keep compatibility with older CLI output, but only for malformed output.
+    # A timeout or process error is not evidence of authentication.
+    if auth_status["unparseable"] and _claude_credential_heuristic(
+        credentials_path, config_path
+    ):
+        account = _claude_oauth_account(config_path) or "OAuth credentials"
         return _provider(
             name="claude",
             ok=True,
@@ -770,12 +785,19 @@ def _claude_status(
             mcps=claude_mcps,
             cli_path=binary,
         )
+    app_path = claude_app_path()
+    detail = (
+        "Claude Desktop uses an app-private login. Sign in once via `ciao auth claude`; "
+        "no separate CLI install is needed."
+        if app_path
+        else "Run Claude OAuth or set ANTHROPIC_API_KEY."
+    )
     return _provider(
         name="claude",
         ok=False,
         auth="missing",
         command="ciao auth claude",
-        detail="Run Claude OAuth or set ANTHROPIC_API_KEY.",
+        detail=detail,
         version=version,
         skills=claude_skills,
         mcps=claude_mcps,
@@ -783,13 +805,61 @@ def _claude_status(
     )
 
 
+def _claude_credential_heuristic(credentials_path: Path, config_path: Path) -> bool:
+    """Legacy compatibility check used only when the probe output is malformed."""
+    return credentials_path.is_file() or bool(_claude_oauth_account(config_path))
+
+
+def claude_auth_status(
+    binary: str,
+    *,
+    env: Mapping[str, str] | None = None,
+    credentials_path: Path | None = None,
+    config_path: Path | None = None,
+) -> dict[str, Any]:
+    """Probe the Claude Code credential store without making a network call."""
+    result: dict[str, Any] = {
+        "logged_in": False,
+        "unparseable": False,
+        "email": "",
+        "org_name": "",
+    }
+    process_env = os.environ.copy()
+    if env is not None:
+        process_env.update(env)
+    try:
+        completed = subprocess.run(
+            [binary, "auth", "status", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=_CLAUDE_AUTH_STATUS_TIMEOUT_SECONDS,
+            check=False,
+            env=process_env,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return result
+    if completed.returncode != 0:
+        return result
+    try:
+        payload = json.loads(completed.stdout or "")
+    except (TypeError, ValueError):
+        result["unparseable"] = True
+        return result
+    if not isinstance(payload, dict):
+        result["unparseable"] = True
+        return result
+    result["logged_in"] = payload.get("loggedIn") is True
+    result["email"] = str(payload.get("email", "")).strip()
+    result["org_name"] = str(payload.get("orgName", "")).strip()
+    return result
+
+
 def _claude_oauth_account(config_path: Path) -> str:
-    """Return a short identifier from ``~/.claude.json``'s ``oauthAccount``.
+    """Return legacy account metadata from ``~/.claude.json``'s ``oauthAccount``.
 
     Returns an empty string when the file is missing, unparseable, or has no
-    usable account metadata. We deliberately avoid touching the Keychain: the
-    server process often cannot unlock it, and the account block is enough to
-    confirm a completed OAuth login.
+    usable account metadata. It is retained only as a compatibility fallback
+    when a CLI status probe returns malformed output; it does not prove login.
     """
     try:
         data = json.loads(config_path.read_text(encoding="utf-8"))

--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -72,7 +72,7 @@ from ciao.schedules import (
     normalize_archive_policy,
     was_dispatched_since,
 )
-from ciao.setup_status import setup_status
+from ciao.setup_status import claude_auth_status, claude_cli_path, setup_status
 from ciao.cli import _auth_command_for_provider
 from ciao.rate_limits import is_rate_limit_telemetry
 from ciao.skills_inventory import build_skill_inventory
@@ -1182,18 +1182,23 @@ def _read_env_value(path: Path, key: str) -> str:
 
 
 def _claude_oauth_ready() -> bool:
-    """True when Claude Code OAuth credentials are present on disk."""
-    from ciao.setup_status import _claude_oauth_account
-
+    """True when the Claude Code CLI reports an active OAuth session."""
     raw = os.environ.get("CLAUDE_CREDENTIALS_PATH", "").strip()
     credentials_path = (
         Path(raw).expanduser() if raw else Path.home() / ".claude" / ".credentials.json"
     )
-    if credentials_path.is_file():
-        return True
     raw_cfg = os.environ.get("CLAUDE_CONFIG_PATH", "").strip()
     config_path = Path(raw_cfg).expanduser() if raw_cfg else Path.home() / ".claude.json"
-    return bool(_claude_oauth_account(config_path))
+    binary = claude_cli_path()
+    if not binary:
+        return False
+    status = claude_auth_status(
+        binary,
+        env=os.environ,
+        credentials_path=credentials_path,
+        config_path=config_path,
+    )
+    return bool(status["logged_in"])
 
 
 def _provider_key_auth_method(config, key: str) -> str:

--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -72,7 +72,7 @@ from ciao.schedules import (
     normalize_archive_policy,
     was_dispatched_since,
 )
-from ciao.setup_status import claude_auth_status, claude_cli_path, setup_status
+from ciao.setup_status import setup_status
 from ciao.cli import _auth_command_for_provider
 from ciao.rate_limits import is_rate_limit_telemetry
 from ciao.skills_inventory import build_skill_inventory
@@ -1181,44 +1181,31 @@ def _read_env_value(path: Path, key: str) -> str:
     return ""
 
 
-def _claude_oauth_ready() -> bool:
-    """True when the Claude Code CLI reports an active OAuth session."""
-    raw = os.environ.get("CLAUDE_CREDENTIALS_PATH", "").strip()
-    credentials_path = (
-        Path(raw).expanduser() if raw else Path.home() / ".claude" / ".credentials.json"
-    )
-    raw_cfg = os.environ.get("CLAUDE_CONFIG_PATH", "").strip()
-    config_path = Path(raw_cfg).expanduser() if raw_cfg else Path.home() / ".claude.json"
-    binary = claude_cli_path()
-    if not binary:
-        return False
-    status = claude_auth_status(
-        binary,
-        env=os.environ,
-        credentials_path=credentials_path,
-        config_path=config_path,
-    )
-    return bool(status["logged_in"])
+def _provider_key_auth_method(config, key: str, providers: dict) -> str:
+    """Return how a provider key is authenticated: 'api_key', 'oauth', or 'missing'.
 
-
-def _provider_key_auth_method(config, key: str) -> str:
-    """Return how a provider key is authenticated: 'api_key', 'oauth', or 'missing'."""
+    ``providers`` is the already-computed ``setup_status()`` result for this
+    request; reusing it avoids re-running the Claude CLI credential probe a
+    second time per request.
+    """
     env_value = os.environ.get(key, "").strip()
     if env_value:
         return "api_key"
     file_value = _read_env_value(_env_path(config), key)
     if file_value:
         return "api_key"
-    if key == "ANTHROPIC_API_KEY" and _claude_oauth_ready():
+    if key == "ANTHROPIC_API_KEY" and providers.get("claude", {}).get("auth") == "oauth":
         return "oauth"
     return "missing"
 
 
 def _provider_config_payload(config) -> dict:
+    providers = setup_status(config, env=os.environ).get("providers", {})
+
     def key_payload(meta_by_key: dict) -> dict:
         keys = {}
         for key, meta in meta_by_key.items():
-            auth_method = _provider_key_auth_method(config, key)
+            auth_method = _provider_key_auth_method(config, key, providers)
             keys[key] = {
                 **meta,
                 "configured": auth_method != "missing",
@@ -1226,7 +1213,6 @@ def _provider_config_payload(config) -> dict:
             }
         return keys
 
-    providers = setup_status(config, env=os.environ).get("providers", {})
     return {
         "keys": key_payload(_PROVIDER_KEY_META),
         "service_keys": key_payload(_SERVICE_KEY_META),
@@ -5953,7 +5939,7 @@ async def open_chat_endpoint(request: Request) -> JSONResponse:
 
 async def setup_status_endpoint(request: Request) -> JSONResponse:
     """Return first-run setup readiness for the onboarding wizard."""
-    return JSONResponse(setup_status(request.app.state.config))
+    return JSONResponse(await asyncio.to_thread(setup_status, request.app.state.config))
 
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1034,7 +1034,7 @@ def test_auth_claude_uses_bundled_cli(monkeypatch) -> None:
 
     assert cli.main(["auth", "claude"]) == 0
 
-    assert calls == [["/opt/ciao/claude", "login"]]
+    assert calls == [["/opt/ciao/claude", "auth", "login"]]
 
 
 def test_vault_index_accepts_arbitrary_workspace_name(monkeypatch) -> None:

--- a/tests/test_setup_status.py
+++ b/tests/test_setup_status.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import json
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -14,7 +15,7 @@ from starlette.routing import Route
 from starlette.testclient import TestClient
 
 from ciao.config import CiaoConfig
-from ciao.setup_status import setup_status
+from ciao.setup_status import claude_auth_status, setup_status
 from ciao.web.auth import AuthMiddleware
 from ciao.web.routes_api import (
     provider_connection_action,
@@ -37,6 +38,15 @@ def claude_cli_present(monkeypatch):
         "ciao.setup_status.claude_cli_path", lambda: "/usr/local/bin/claude"
     )
     monkeypatch.setattr("ciao.setup_status._cli_version", lambda binary: "2.0.0 (Claude Code)")
+    monkeypatch.setattr(
+        "ciao.setup_status.claude_auth_status",
+        lambda *args, **kwargs: {
+            "logged_in": False,
+            "unparseable": False,
+            "email": "",
+            "org_name": "",
+        },
+    )
 
 
 def _config(tmp_path, env_extra: dict[str, str] | None = None) -> CiaoConfig:
@@ -170,29 +180,32 @@ def test_setup_status_marks_bootstrap_mode(tmp_path) -> None:
     assert data["configured"] is False
 
 
-def test_setup_status_detects_claude_api_key_and_credentials_file(tmp_path) -> None:
+def test_setup_status_detects_claude_api_key_and_cli_oauth(tmp_path, monkeypatch) -> None:
     config = _config(tmp_path, {"ANTHROPIC_API_KEY": "sk-anthropic"})
     data = setup_status(config, env={"ANTHROPIC_API_KEY": "sk-anthropic"})
     assert data["providers"]["claude"]["ok"] is True
     assert data["providers"]["claude"]["auth"] == "api_key"
 
-    credentials = tmp_path / "claude" / ".credentials.json"
-    credentials.parent.mkdir()
-    credentials.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(
+        "ciao.setup_status.claude_auth_status",
+        lambda *args, **kwargs: {
+            "logged_in": True,
+            "unparseable": False,
+            "email": "operator@example.com",
+            "org_name": "Example Org",
+        },
+    )
     data = setup_status(
         config,
         env={},
-        claude_credentials_path=credentials,
     )
     assert data["providers"]["claude"]["ok"] is True
     assert data["providers"]["claude"]["auth"] == "oauth"
+    assert "operator@example.com" in data["providers"]["claude"]["detail"]
 
 
-def test_setup_status_detects_claude_oauth_via_config_json(tmp_path) -> None:
-    """macOS Claude Code stores the OAuth token in the Keychain and writes the
-    account metadata to ~/.claude.json. The probe must treat a populated
-    ``oauthAccount`` block as a logged-in session even when no credentials
-    file exists and no API key is set."""
+def test_setup_status_does_not_treat_oauth_account_metadata_as_auth(tmp_path) -> None:
+    """Desktop metadata alone must not make setup claim Claude is connected."""
     config = _config(tmp_path)
     config_path = tmp_path / ".claude.json"
     config_path.write_text(
@@ -204,9 +217,8 @@ def test_setup_status_detects_claude_oauth_via_config_json(tmp_path) -> None:
     data = setup_status(config, env={}, claude_config_path=config_path)
 
     claude = data["providers"]["claude"]
-    assert claude["ok"] is True
-    assert claude["auth"] == "oauth"
-    assert "operator@example.com" in claude["detail"]
+    assert claude["ok"] is False
+    assert claude["auth"] == "missing"
 
 
 def test_setup_status_ignores_empty_oauth_account(tmp_path) -> None:
@@ -218,6 +230,59 @@ def test_setup_status_ignores_empty_oauth_account(tmp_path) -> None:
 
     assert data["providers"]["claude"]["ok"] is False
     assert data["providers"]["claude"]["auth"] == "missing"
+
+
+def test_claude_auth_status_parses_logged_in_json(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "ciao.setup_status.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(
+            stdout='{"loggedIn":true,"email":"a@example.com","orgName":"Org"}',
+            returncode=0,
+        ),
+    )
+    assert claude_auth_status("/claude") == {
+        "logged_in": True,
+        "unparseable": False,
+        "email": "a@example.com",
+        "org_name": "Org",
+    }
+
+
+def test_claude_auth_status_timeout_is_not_authenticated(monkeypatch) -> None:
+    def timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(args[0], 5)
+
+    monkeypatch.setattr("ciao.setup_status.subprocess.run", timeout)
+    assert claude_auth_status("/claude")["logged_in"] is False
+    assert claude_auth_status("/claude")["unparseable"] is False
+
+
+def test_claude_auth_status_malformed_json_is_marked_legacy_fallback(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "ciao.setup_status.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(stdout="not json", returncode=0),
+    )
+    status = claude_auth_status("/claude")
+    assert status["logged_in"] is False
+    assert status["unparseable"] is True
+
+
+def test_claude_auth_status_missing_binary_is_not_authenticated(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "ciao.setup_status.subprocess.run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError()),
+    )
+    assert claude_auth_status("/missing")["logged_in"] is False
+
+
+def test_setup_status_explains_desktop_login_is_app_private(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("ciao.setup_status.claude_app_path", lambda: "/Applications/Claude.app")
+    config = _config(tmp_path)
+    claude = setup_status(config, env={})["providers"]["claude"]
+    assert claude["ok"] is False
+    assert "app-private" in claude["detail"]
+    assert "ciao auth claude" in claude["detail"]
+    assert "no separate CLI install" in claude["detail"]
 
 
 def test_setup_status_reports_a_missing_claude_cli_as_an_install_step(


### PR DESCRIPTION
## Summary
- use `claude auth login` for Ciaobot Claude login
- probe the bundled CLI with `claude auth status --json` instead of trusting Desktop metadata or credential-file presence
- explain the app-private Desktop login path when the CLI is signed out
- share the probe with Settings/API and critique availability checks

## Verification
- `.venv/bin/pytest tests/`
- `cd web && npm run build`

Closes #347