### PR TITLE
fix(desktop): stop the notification tail replaying the host backlog, plus three adjacent fixes

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -549,7 +549,10 @@ fn run_full_update(app: AppHandle, force: bool) {
             show_error(
                 &app,
                 "Ciaobot engine unavailable",
-                "The ciao executable was not found.",
+                format!(
+                    "The ciao executable was not found.\n\n{}",
+                    service::missing_engine_detail()
+                ),
             );
             return;
         };
@@ -908,7 +911,10 @@ fn build_windows(
             }
             None => append_log(
                 &runtime.runtime_root,
-                "bootstrap FAILED: the ciao executable was not found",
+                &format!(
+                    "bootstrap FAILED: the ciao executable was not found. {}",
+                    service::missing_engine_detail().replace('\n', " ")
+                ),
             ),
         }
     }
@@ -1118,7 +1124,10 @@ fn invoke_service_action(app: AppHandle, action: &'static str, force: bool, exit
             show_error(
                 &app,
                 "Ciaobot engine unavailable",
-                "The ciao executable was not found.",
+                format!(
+                    "The ciao executable was not found.\n\n{}",
+                    service::missing_engine_detail()
+                ),
             );
             return;
         };
@@ -1217,8 +1226,12 @@ fn set_login_enabled(app: &AppHandle, enabled: bool) -> Result<(), String> {
         .autolaunch()
         .is_enabled()
         .map_err(|error| error.to_string())?;
-    let binary = service::resolve_ciao(env::var("PATH").ok().as_deref())
-        .ok_or_else(|| "The ciao engine executable was not found.".to_string())?;
+    let binary = service::resolve_ciao(env::var("PATH").ok().as_deref()).ok_or_else(|| {
+        format!(
+            "The ciao engine executable was not found.\n\n{}",
+            service::missing_engine_detail()
+        )
+    })?;
     let action = if enabled { "enable" } else { "disable" };
     let result = service::invoke(&binary, "login", &[action])?;
     if !result.ok {

--- a/desktop/src-tauri/src/notification_log.rs
+++ b/desktop/src-tauri/src/notification_log.rs
@@ -17,14 +17,30 @@ use std::{
 /// The cursor starts unset and the first poll only primes it, so launching the
 /// app (or connecting to a host with a full log) never replays a backlog.
 ///
-/// `primed` records that first poll separately from `cursor`. An empty log at
-/// launch leaves the cursor unset, so deriving "is this the priming poll?" from
+/// Priming is recorded separately from `cursor`. An empty log at launch leaves
+/// the cursor unset, so deriving "is this the priming poll?" from
 /// `cursor.is_none()` would prime twice and swallow the first real entry.
+///
+/// It is recorded *per source*, because the engine and the file are not the
+/// same log on a client node. The app restarts the engine as it launches, so
+/// the first poll — one second in — usually lands while the engine is still
+/// unreachable and falls back to the file. On a client that file holds only
+/// what this machine itself ran, so priming from it parked the cursor days in
+/// the past; the next poll, with the engine up, asked the *host* for
+/// everything after that stale timestamp and posted the lot as fresh banners.
+/// Letting each source prime once means the first answer the engine gives is
+/// still a priming answer, whatever the file did before it.
+///
+/// The cost is bounded and deliberate: an entry written in the one poll
+/// interval between the last answer from one source and the first answer from
+/// the other is swallowed with that priming batch. Losing at most a second of
+/// banners on a single handover beats replaying a whole backlog.
 #[derive(Debug)]
 pub struct NotificationLogTail {
     path: PathBuf,
     cursor: Option<f64>,
-    primed: bool,
+    primed_by_engine: bool,
+    primed_by_file: bool,
     seen: HashSet<String>,
 }
 
@@ -49,7 +65,8 @@ impl NotificationLogTail {
         Self {
             path: path.into(),
             cursor: None,
-            primed: false,
+            primed_by_engine: false,
+            primed_by_file: false,
             seen: HashSet::new(),
         }
     }
@@ -64,8 +81,20 @@ impl NotificationLogTail {
     /// `fetched` is the engine's answer, or `None` when the call failed — the
     /// caller owns the HTTP so this stays testable without a server.
     pub fn poll(&mut self, fetched: Option<Vec<Value>>) -> Vec<Value> {
-        let priming = !self.primed;
-        self.primed = true;
+        // Each source primes once. A file-fallback poll must not consume the
+        // engine's priming turn: it reads a different log on a client node,
+        // and the cursor it leaves behind is a timestamp in that other log.
+        let from_engine = fetched.is_some();
+        let priming = if from_engine {
+            !self.primed_by_engine
+        } else {
+            !self.primed_by_file
+        };
+        if from_engine {
+            self.primed_by_engine = true;
+        } else {
+            self.primed_by_file = true;
+        }
         let entries = match fetched {
             Some(entries) => entries,
             // Engine down: read this machine's own log, applying the cursor the
@@ -226,6 +255,43 @@ mod tests {
         assert_eq!(posted.len(), 1);
         assert_eq!(posted[0]["title"], "new");
         assert!(tail.poll(None).is_empty());
+    }
+
+    // The client-mode restart flood: launching the app restarts the engine, so
+    // the first poll falls back to this machine's own log. On a client that log
+    // is stale — only what this machine ran — and priming from it left the
+    // cursor days in the past. The engine's first answer, tunnelled to the
+    // host, then carried the host's whole backlog and posted every entry.
+    #[test]
+    fn a_stale_file_prime_does_not_replay_the_hosts_backlog() {
+        let temp = tempdir().unwrap();
+        let path = temp.path().join("notifications.jsonl");
+        fs::write(&path, "{\"ts\":1.0,\"title\":\"days old, local\"}\n").unwrap();
+        let mut tail = NotificationLogTail::at_end(&path);
+
+        // Engine still starting: falls back to the stale local log.
+        assert!(tail.poll(None).is_empty());
+        assert_eq!(tail.cursor(), 1.0);
+
+        // Engine up. The host answers with everything after that stale cursor;
+        // none of it may be posted, because the engine has not primed yet.
+        let backlog = vec![
+            entry(2.0, "host, read days ago"),
+            entry(3.0, "host, read yesterday"),
+        ];
+        assert!(
+            tail.poll(Some(backlog)).is_empty(),
+            "the host backlog must not be replayed as banners"
+        );
+        assert_eq!(tail.cursor(), 3.0);
+
+        // Genuinely new host entries still arrive.
+        let posted = tail.poll(Some(vec![
+            entry(3.0, "host, read yesterday"),
+            entry(4.0, "new"),
+        ]));
+        assert_eq!(posted.len(), 1);
+        assert_eq!(posted[0]["title"], "new");
     }
 
     #[test]

--- a/desktop/src-tauri/src/service.rs
+++ b/desktop/src-tauri/src/service.rs
@@ -26,12 +26,59 @@ fn resolve_ciao_from(path_value: Option<&str>, preferred: &[PathBuf]) -> Option<
         .find(|candidate| candidate.is_file())
 }
 
-fn bundled_ciao_from(executable: Option<&Path>) -> Option<PathBuf> {
-    let app_bundle = executable?
+fn app_bundle_of(executable: Option<&Path>) -> Option<PathBuf> {
+    executable?
         .ancestors()
-        .find(|path| path.extension().and_then(|value| value.to_str()) == Some("app"))?;
-    let candidate = app_bundle.join("Contents/Resources/ciao-runtime/bin/ciao");
+        .find(|path| path.extension().and_then(|value| value.to_str()) == Some("app"))
+        .map(Path::to_path_buf)
+}
+
+fn bundled_ciao_from(executable: Option<&Path>) -> Option<PathBuf> {
+    let candidate = app_bundle_of(executable)?.join("Contents/Resources/ciao-runtime/bin/ciao");
     candidate.is_file().then_some(candidate)
+}
+
+/// Why [`resolve_ciao`] came up empty, as lines naming each lookup in order.
+///
+/// "The ciao executable was not found." alone does not separate the three ways
+/// this happens, and they need different fixes: a repo-built bundle never had a
+/// runtime staged into Contents/Resources (build one, or run the installed
+/// app), CIAO_ENGINE_PATH points somewhere the file is not, or a dev build is
+/// relying on a PATH lookup that only happens under CIAO_DEV_MODE.
+fn missing_engine_detail_from(
+    bundle: Option<&Path>,
+    engine_path: Option<&str>,
+    dev_mode: bool,
+) -> String {
+    let mut lines = Vec::new();
+    lines.push(match bundle {
+        Some(bundle) => format!(
+            "• no bundled engine at {}",
+            bundle
+                .join("Contents/Resources/ciao-runtime/bin/ciao")
+                .display()
+        ),
+        None => "• not running from an .app bundle, so there is no bundled engine".to_string(),
+    });
+    lines.push(match engine_path {
+        Some(value) => format!("• CIAO_ENGINE_PATH is set to {value}, which is not a file"),
+        None => "• CIAO_ENGINE_PATH is not set".to_string(),
+    });
+    lines.push(if dev_mode {
+        "• CIAO_DEV_MODE is on, but no `ciao` is on PATH".to_string()
+    } else {
+        "• PATH was not searched — that fallback only runs under CIAO_DEV_MODE".to_string()
+    });
+    lines.join("\n")
+}
+
+/// [`missing_engine_detail_from`] against this process's environment.
+pub fn missing_engine_detail() -> String {
+    missing_engine_detail_from(
+        app_bundle_of(env::current_exe().ok().as_deref()).as_deref(),
+        env::var("CIAO_ENGINE_PATH").ok().as_deref(),
+        env::var_os("CIAO_DEV_MODE").is_some(),
+    )
 }
 
 pub fn resolve_ciao(path_value: Option<&str>) -> Option<PathBuf> {
@@ -159,6 +206,36 @@ mod tests {
             resolve_ciao_from(path.to_str(), &[]).as_deref(),
             Some(binary.as_path())
         );
+    }
+
+    // The repo-built bundle: `cargo tauri build` stages no runtime, so the app
+    // launches and every engine action dead-ends. Naming the path it wanted is
+    // what separates that from a broken install.
+    #[test]
+    fn the_detail_names_the_bundle_path_it_expected() {
+        let detail = missing_engine_detail_from(Some(Path::new("/tmp/Ciaobot.app")), None, false);
+        assert!(
+            detail.contains("/tmp/Ciaobot.app/Contents/Resources/ciao-runtime/bin/ciao"),
+            "{detail}"
+        );
+        assert!(detail.contains("CIAO_ENGINE_PATH is not set"), "{detail}");
+        assert!(detail.contains("only runs under CIAO_DEV_MODE"), "{detail}");
+    }
+
+    // A dev build run straight from target/: no bundle, and the PATH fallback
+    // is the one that was supposed to work.
+    #[test]
+    fn the_detail_reports_a_stale_override_and_an_exhausted_path() {
+        let detail = missing_engine_detail_from(None, Some("/gone/ciao"), true);
+        assert!(
+            detail.contains("not running from an .app bundle"),
+            "{detail}"
+        );
+        assert!(
+            detail.contains("CIAO_ENGINE_PATH is set to /gone/ciao"),
+            "{detail}"
+        );
+        assert!(detail.contains("no `ciao` is on PATH"), "{detail}");
     }
 
     #[test]

--- a/scripts/check-desktop.sh
+++ b/scripts/check-desktop.sh
@@ -41,6 +41,34 @@ if [[ -n "$missing" ]]; then
   exit 1
 fi
 
+# Tauri resolves every bundle.resources path while running the build script, so
+# an absent desktop/runtime aborts `cargo fmt`/`clippy`/`test` before a single
+# check runs — the gate is unusable on a fresh checkout. CI builds the real
+# runtime first (.github/workflows/ci.yml), but that downloads a pinned CPython
+# and takes minutes, which is more than this gate is for. A placeholder
+# satisfies the path lookup; none of the Rust checks read its contents.
+RUNTIME="$DESKTOP/runtime"
+STUBBED_RUNTIME=0
+if [[ ! -d "$RUNTIME" ]]; then
+  mkdir -p "$RUNTIME"
+  cat > "$RUNTIME/README.txt" <<'EOF'
+Placeholder created by scripts/check-desktop.sh so Tauri can resolve the
+`../runtime` resource path. The real bundled Python runtime is built by
+scripts/build-bundled-runtime.sh. An app bundled against this placeholder has
+no engine inside it: resolve_ciao() finds no Contents/Resources/ciao-runtime/
+bin/ciao and reports "Ciaobot engine unavailable".
+EOF
+  STUBBED_RUNTIME=1
+fi
+
+runtime_note() {
+  [[ "$STUBBED_RUNTIME" -eq 1 ]] || return 0
+  echo
+  echo "Note: desktop/runtime was missing, so a placeholder was created. The"
+  echo "Rust checks above are unaffected, but any .app built from this tree has"
+  echo "no engine bundled. Run scripts/build-bundled-runtime.sh for a real one."
+}
+
 step() { printf '\n=== %s ===\n' "$1"; }
 
 step "sidecar build (swiftc, aarch64)"
@@ -58,6 +86,7 @@ step "cargo test"
 if [[ "$FAST" -eq 1 ]]; then
   echo
   echo "Desktop gate passed (--fast: bundle build skipped)."
+  runtime_note
   exit 0
 fi
 
@@ -82,3 +111,4 @@ codesign -v "$APP" || { echo "FAIL: bundle signature invalid" >&2; exit 1; }
 
 echo
 echo "Desktop gate passed: sidecar bundled, aarch64, signed, and runnable."
+runtime_note

--- a/tests/test_proposal_outcomes.py
+++ b/tests/test_proposal_outcomes.py
@@ -349,7 +349,12 @@ def test_rotation_preserves_lifetime_totals(tmp_path: Path, monkeypatch) -> None
             # Distinct timestamps: byte-identical lines are what a crash
             # duplicate looks like, and the fold de-duplicates those on
             # purpose — so a fixture must not write the same ts twice.
-            old = (datetime.now(UTC) - timedelta(days=90, microseconds=n)).isoformat()
+            # Offset from the `base` captured above rather than re-reading the
+            # clock: `now() - n µs` inside the loop lets wall-clock advance
+            # cancel the decrement, so rows collide, the fold drops them as
+            # crash duplicates, and the totals come up short by however many
+            # microseconds the loop happened to take on that machine.
+            old = (base - timedelta(microseconds=n)).isoformat()
             f.write(json.dumps({
                 "ts": old, "workspace": "personal" if n % 2 else "work",
                 "kind": "memory", "action": "promoted", "via": "pwa",


### PR DESCRIPTION
Four independent fixes, one commit each. The first is the reported bug; the other three came out of investigating and verifying it.

---

## 1. `fix(desktop)`: the notification tail replayed the host's backlog

On a client node, restarting the desktop app posted a dozen native banners at once for notifications read days earlier — all stamped "now".

Reproduced from the runtime logs on a client (`node_state.json` → `"role": "client"`):

1. Launching the app restarts the engine (`com.ciao.server` PID changed, exit `-15`). The tray log shows `engine start: ok` → `refresh: reachable=false` → `reachable=true`.
2. `start_notification_tail` polls one second in. That poll landed inside the unreachable window, so `poll()` fell back to reading this machine's own `.runtime/notifications.jsonl` — consuming the single priming turn.
3. On a client that file is not the log the engine serves. It holds only what this machine itself ran, while the engine tunnels `/api/menubar-notifications` to the host. Priming from it parked the cursor at the local log's newest entry, three days stale.
4. A second later, with the engine up, the next poll asked the host for everything after that timestamp. `priming` was spent and `seen` held only the boundary entry, so the host's whole backlog posted as fresh banners.

The priming guard assumed the first poll and the second read the same feed. Across an engine restart on a client, they don't.

**Fix:** record priming per source. A file-fallback poll no longer consumes the engine's priming turn, so the first answer the engine gives is still a priming answer. The fallback keeps its own turn, so an engine outage still surfaces new local entries.

The bounded cost is documented on the struct: an entry written in the one poll interval between the last answer from one source and the first from the other is swallowed with that priming batch. A second of banners on a single handover, versus a whole backlog.

New test `a_stale_file_prime_does_not_replay_the_hosts_backlog` reproduces the sequence. Verified failing on the previous behaviour, passing on this one.

## 2. `test`: the rotation fixture raced the clock

`test_rotation_preserves_lifetime_totals` re-read the clock inside its write loop (`now() - timedelta(days=90, microseconds=n)`), so wall-clock advance during the loop cancelled the per-row decrement. Rows collided, the fold dropped them as the crash duplicates they were indistinguishable from, and totals came up short by however long the loop took — 1816 and 1990 against an expected 2025 on two runs of the same machine.

Offsets from the `base` captured just above the loop instead, which was already computed and unused. Pre-existing on `develop`, not a regression from this branch.

## 3. `build`: the desktop gate could not run on a fresh checkout

Tauri resolves every `bundle.resources` path while running the build script, so an absent `desktop/runtime` aborts `cargo fmt`, `clippy` and `test` before a single check runs:

```
resource path `../runtime` doesn't exist
```

That directory is gitignored and built by `scripts/build-bundled-runtime.sh`, which CI runs first (`ci.yml:115`) but which needs pinned python-build-standalone URLs and takes minutes. So the gate CLAUDE.md tells contributors to run was unusable locally.

Creates a placeholder when missing. The Rust checks never read its contents. A bundle built against it has no engine inside, so the run says so at the end rather than letting a green gate imply a working `.app`.

## 4. `fix(desktop)`: name which engine lookup failed

"The ciao executable was not found." covers three failures needing three different fixes: a repo-built bundle that never had a runtime staged into `Contents/Resources`, a `CIAO_ENGINE_PATH` pointing where the file is not, and a dev build relying on the PATH lookup that only runs under `CIAO_DEV_MODE`. The dialog named none of them, so the first case read as a broken install.

Now reports each lookup in the order `resolve_ciao` tries it, naming the bundle path it wanted and the override it read. Pure formatting split out for testing without touching process env, matching `resolve_ciao_from` / `bundled_ciao_from`.

---

## Verification

- `./scripts/check-desktop.sh --fast` — fmt, clippy `-D warnings`, 51 tests green (49 before, +2 for the new detail helper).
- `pytest tests/` — 3010 passed.
- Gate #3 verified from a clean state (`rm -rf desktop/runtime` then re-run).