### PR TITLE
Fix deferred v0.11.0 review findings (#351, #352, #353, #354)

### DIFF
--- a/ciao/gws_auth.py
+++ b/ciao/gws_auth.py
@@ -665,17 +665,15 @@ MANUAL_PKCE_TTL_SECONDS = 3600.0
 
 
 class ManualPkceStore:
-    """Holds one pending PKCE verifier per profile between auth-url and exchange.
+    """Holds pending PKCE verifiers between auth-url and exchange.
 
-    Starting a new flow for a profile replaces (invalidates) any previous
-    pending verifier for that profile, mirroring how a fresh
-    :class:`GwsReloginManager` session replaces an in-flight one. Never
-    logged; verifiers are opaque, secret-adjacent material.
+    Each flow has its own opaque identifier, so multiple tabs can authorize the
+    same profile without replacing one another's verifier. Never logged;
+    verifiers are opaque, secret-adjacent material.
 
-    An expired entry is kept (as a tombstone, verifier discarded) rather than
-    deleted, so :meth:`status` can still tell "a challenge was issued for this
-    profile and the verifier is gone" apart from "no PKCE flow was ever
-    started for this profile" — the exchange endpoint needs that distinction:
+    Expired and superseded entries are kept as tombstones, so :meth:`status`
+    can tell "a challenge was issued but its verifier is gone" apart from "no
+    PKCE flow was ever started" — the exchange endpoint needs that distinction:
     the first case must fail loudly (Google is holding a challenge for the
     code; silently omitting the verifier gets a confusing ``invalid_grant``),
     while the second must silently omit the verifier, matching whatever the
@@ -687,18 +685,20 @@ class ManualPkceStore:
     def __init__(self, ttl: float = MANUAL_PKCE_TTL_SECONDS) -> None:
         self._ttl = ttl
         self._lock = threading.Lock()
-        # profile -> (verifier or "" once expired, expires_at)
-        self._pending: dict[str, tuple[str, float]] = {}
+        # flow_id -> (profile, verifier or "" once invalidated, expires_at,
+        # status: active/expired/superseded)
+        self._pending: dict[str, tuple[str, str, float, str]] = {}
 
-    def start(self, profile: str) -> str:
-        """Generate a fresh verifier for ``profile``, replacing any pending one."""
+    def start(self, profile: str) -> tuple[str, str]:
+        """Generate a flow ID and verifier for ``profile``."""
+        flow_id = secrets.token_urlsafe(32)
         verifier = generate_code_verifier()
         with self._lock:
-            self._pending[profile] = (verifier, time.time() + self._ttl)
-        return verifier
+            self._pending[flow_id] = (profile, verifier, time.time() + self._ttl, "active")
+        return flow_id, verifier
 
-    def peek(self, profile: str) -> str | None:
-        """Return the live pending verifier for ``profile``, or ``None``.
+    def peek(self, flow_id: str, profile: str | None = None) -> str | None:
+        """Return the live verifier for ``flow_id``, or ``None``.
 
         ``None`` covers both "no flow pending" and "expired" — callers that
         need to tell those apart (to avoid silently sending Google's token
@@ -709,16 +709,18 @@ class ManualPkceStore:
         retried with the same verifier without restarting the whole flow.
         """
         with self._lock:
-            entry = self._pending.get(profile)
+            entry = self._pending.get(flow_id)
             if entry is None:
                 return None
-            verifier, expires_at = entry
+            entry_profile, verifier, expires_at, _status = entry
+            if profile is not None and entry_profile != profile:
+                return None
             if time.time() > expires_at or not verifier:
                 return None
             return verifier
 
-    def status(self, profile: str) -> str:
-        """``"active"`` | ``"expired"`` | ``"none"`` for ``profile``.
+    def status(self, flow_id: str, profile: str | None = None) -> str:
+        """``"active"`` | ``"expired"`` | ``"superseded"`` | ``"none"``.
 
         ``"expired"`` means a challenge was issued and is still live at
         Google but the verifier is gone — the caller must not proceed
@@ -728,18 +730,30 @@ class ManualPkceStore:
         that like a flow that never used PKCE.
         """
         with self._lock:
-            entry = self._pending.get(profile)
+            entry = self._pending.get(flow_id)
             if entry is None:
                 return "none"
-            verifier, expires_at = entry
+            entry_profile, verifier, expires_at, status = entry
+            if profile is not None and entry_profile != profile:
+                return "none"
+            if status == "superseded":
+                return status
             if time.time() > expires_at:
                 # Tombstone it in place: keep the "something was issued"
                 # signal, but drop the verifier itself (never hold expired
                 # secret-adjacent material longer than necessary).
                 if verifier:
-                    self._pending[profile] = ("", expires_at)
+                    self._pending[flow_id] = (entry_profile, "", expires_at, "expired")
                 return "expired"
             return "active"
+
+    def status_for_profile(self, profile: str) -> str:
+        """Return whether ``profile`` has any active manual flow."""
+        with self._lock:
+            for entry_profile, _verifier, _expires_at, status in self._pending.values():
+                if entry_profile == profile and status == "active":
+                    return "active"
+        return "none"
 
 
 # ── Token health (cheap ``auth status`` ping) ─────────────────────────────

--- a/ciao/gws_auth.py
+++ b/ciao/gws_auth.py
@@ -26,6 +26,7 @@ Security invariants (see issue #145):
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 import logging
@@ -305,6 +306,44 @@ def client_uses_loopback(config_dir: Path | None) -> bool:
 
 
 
+# ── PKCE (RFC 7636) ───────────────────────────────────────────────────────
+#
+# Manual/paste OAuth flows (the PWA "paste the redirect code" panel, and the
+# headless `ciao gws-auth-helper`) cannot validate `state` on paste-back: the
+# user, not the browser, carries the code across the trust boundary, so a
+# copy-pasted `state` is not proof of anything. PKCE is the RFC 8252 remedy —
+# it binds the authorization code to the client that requested it, so a code
+# intercepted or replayed elsewhere is useless without the verifier that
+# never left this process. See issue #354.
+
+# RFC 7636 §4.1: 43-128 characters from [A-Za-z0-9-._~]. `secrets.token_urlsafe`
+# already draws only from the base64url alphabet (A-Za-z0-9-_), a subset of
+# that unreserved charset, so no extra filtering is needed.
+_PKCE_MIN_LENGTH = 43
+_PKCE_MAX_LENGTH = 128
+
+
+def generate_code_verifier(length: int = 64) -> str:
+    """Return a cryptographically random PKCE code verifier (RFC 7636 §4.1)."""
+    if not (_PKCE_MIN_LENGTH <= length <= _PKCE_MAX_LENGTH):
+        raise ValueError(
+            f"PKCE code verifier length must be between {_PKCE_MIN_LENGTH} and {_PKCE_MAX_LENGTH}"
+        )
+    verifier = ""
+    while len(verifier) < length:
+        verifier += secrets.token_urlsafe(length)
+    return verifier[:length]
+
+
+def code_challenge_s256(verifier: str) -> str:
+    """Derive the S256 PKCE code challenge from a verifier (RFC 7636 §4.2).
+
+    base64url(SHA-256(ASCII(verifier))), no padding.
+    """
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
 # ── Consent URL + token exchange (shared by all flows) ───────────────────
 
 
@@ -314,6 +353,8 @@ def build_auth_url(
     redirect_uri: str,
     scopes: str,
     state: str | None = None,
+    code_challenge: str | None = None,
+    code_challenge_method: str = "S256",
 ) -> str:
     params = {
         "scope": scopes,
@@ -325,6 +366,14 @@ def build_auth_url(
     }
     if state:
         params["state"] = state
+    if code_challenge:
+        # Optional: Google's OAuth endpoint accepts PKCE for installed-app
+        # clients and ignores it for a client that predates this, so an
+        # in-flight legacy flow (URL built before this code shipped) is
+        # unaffected — the exchange below only sends a verifier when a
+        # challenge was actually requested.
+        params["code_challenge"] = code_challenge
+        params["code_challenge_method"] = code_challenge_method
     return _AUTH_ENDPOINT + "?" + urllib.parse.urlencode(params)
 
 
@@ -370,6 +419,7 @@ def exchange_code(
     client_secret: str,
     code: str,
     redirect_uri: str,
+    code_verifier: str | None = None,
 ) -> dict[str, Any]:
     """Exchange an authorization code for tokens at Google's token endpoint.
 
@@ -377,19 +427,24 @@ def exchange_code(
     :class:`ValueError` with a secret-free message on failure. The returned
     dict is the raw token response and MUST NOT be logged.
 
+    ``code_verifier`` is the PKCE verifier matching the ``code_challenge`` sent
+    to :func:`build_auth_url` for this flow (issue #354); omitted when the
+    auth URL was built without one (or predates PKCE support).
+
     The socket timeout matters: the exchange runs inside the single-threaded
     callback server's ``do_GET``, so an unbounded request would hang the
     listener and keep ``shutdown()`` from ever returning, leaking the socket.
     """
-    data = urllib.parse.urlencode(
-        {
-            "code": code,
-            "client_id": client_id,
-            "client_secret": client_secret,
-            "redirect_uri": redirect_uri,
-            "grant_type": "authorization_code",
-        }
-    ).encode("utf-8")
+    payload = {
+        "code": code,
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "redirect_uri": redirect_uri,
+        "grant_type": "authorization_code",
+    }
+    if code_verifier:
+        payload["code_verifier"] = code_verifier
+    data = urllib.parse.urlencode(payload).encode("utf-8")
     req = urllib.request.Request(
         _TOKEN_ENDPOINT,
         data=data,
@@ -541,8 +596,13 @@ def exchange_and_store(
     *,
     code: str,
     redirect_uri: str,
+    code_verifier: str | None = None,
 ) -> dict[str, Any]:
     """Full server-side code→credentials step, reused by every flow.
+
+    ``code_verifier`` is the PKCE verifier generated alongside the auth URL
+    for this flow, when one was used (issue #354); pass ``None`` for a flow
+    that did not send a ``code_challenge``.
 
     Returns ``{"ok": True, "email": ...}`` on success. Raises
     :class:`ValueError` with a secret-free message otherwise.
@@ -561,6 +621,7 @@ def exchange_and_store(
         client_secret=client_secret,
         code=code,
         redirect_uri=redirect_uri,
+        code_verifier=code_verifier,
     )
     refresh_token = tokens.get("refresh_token")
     if not refresh_token:
@@ -580,6 +641,105 @@ def exchange_and_store(
         scopes=granted_scopes,
     )
     return {"ok": True, "email": email}
+
+
+# ── Manual/paste flow PKCE state (issue #354) ─────────────────────────────
+#
+# The manual "upload client_secret.json → get consent URL → paste the
+# redirect back" panel is genuinely stateless server-side today: the auth-url
+# and exchange endpoints are two independent requests that share nothing but
+# the profile name. PKCE needs the verifier generated for the auth URL to be
+# the one sent at exchange time, so this tiny store carries it across that
+# gap — the smallest piece of cross-request state the flow needs, kept only
+# long enough for a human to consent in the browser and paste the code back.
+
+# A generous window. PKCE's threat model is a code intercepted or replayed
+# outside this process (a hostile inspecting network traffic or a browser
+# history), not how long the verifier sits in memory — the verifier is opaque
+# random data held only here and is replaced the instant `start` runs again
+# for the same profile, so a long TTL costs essentially nothing. It has to
+# comfortably outlast a human reading Google's consent screen, picking an
+# account, granting scopes, and copying the redirect URL back — a distracted
+# or slow user must not be punished for taking their time (issue #354).
+MANUAL_PKCE_TTL_SECONDS = 3600.0
+
+
+class ManualPkceStore:
+    """Holds one pending PKCE verifier per profile between auth-url and exchange.
+
+    Starting a new flow for a profile replaces (invalidates) any previous
+    pending verifier for that profile, mirroring how a fresh
+    :class:`GwsReloginManager` session replaces an in-flight one. Never
+    logged; verifiers are opaque, secret-adjacent material.
+
+    An expired entry is kept (as a tombstone, verifier discarded) rather than
+    deleted, so :meth:`status` can still tell "a challenge was issued for this
+    profile and the verifier is gone" apart from "no PKCE flow was ever
+    started for this profile" — the exchange endpoint needs that distinction:
+    the first case must fail loudly (Google is holding a challenge for the
+    code; silently omitting the verifier gets a confusing ``invalid_grant``),
+    while the second must silently omit the verifier, matching whatever the
+    auth URL itself sent (issue #354). A restart of the server process is the
+    one case this cannot help with — the tombstone lives only in memory — see
+    ``gws_exchange_code`` for how that degrades.
+    """
+
+    def __init__(self, ttl: float = MANUAL_PKCE_TTL_SECONDS) -> None:
+        self._ttl = ttl
+        self._lock = threading.Lock()
+        # profile -> (verifier or "" once expired, expires_at)
+        self._pending: dict[str, tuple[str, float]] = {}
+
+    def start(self, profile: str) -> str:
+        """Generate a fresh verifier for ``profile``, replacing any pending one."""
+        verifier = generate_code_verifier()
+        with self._lock:
+            self._pending[profile] = (verifier, time.time() + self._ttl)
+        return verifier
+
+    def peek(self, profile: str) -> str | None:
+        """Return the live pending verifier for ``profile``, or ``None``.
+
+        ``None`` covers both "no flow pending" and "expired" — callers that
+        need to tell those apart (to avoid silently sending Google's token
+        endpoint a request with no verifier when one is expected) should use
+        :meth:`status` first.
+
+        Non-destructive: a failed paste-back (wrong code, typo) can be
+        retried with the same verifier without restarting the whole flow.
+        """
+        with self._lock:
+            entry = self._pending.get(profile)
+            if entry is None:
+                return None
+            verifier, expires_at = entry
+            if time.time() > expires_at or not verifier:
+                return None
+            return verifier
+
+    def status(self, profile: str) -> str:
+        """``"active"`` | ``"expired"`` | ``"none"`` for ``profile``.
+
+        ``"expired"`` means a challenge was issued and is still live at
+        Google but the verifier is gone — the caller must not proceed
+        without one. ``"none"`` means no PKCE flow is pending at all (never
+        started, already consumed by a later ``start``, or this process
+        restarted since the auth URL was built) — a caller may safely treat
+        that like a flow that never used PKCE.
+        """
+        with self._lock:
+            entry = self._pending.get(profile)
+            if entry is None:
+                return "none"
+            verifier, expires_at = entry
+            if time.time() > expires_at:
+                # Tombstone it in place: keep the "something was issued"
+                # signal, but drop the verifier itself (never hold expired
+                # secret-adjacent material longer than necessary).
+                if verifier:
+                    self._pending[profile] = ("", expires_at)
+                return "expired"
+            return "active"
 
 
 # ── Token health (cheap ``auth status`` ping) ─────────────────────────────
@@ -866,6 +1026,11 @@ class _ReloginSession:
     status: str = "pending"  # pending | completed | error
     email: str = ""
     error: str = ""
+    # PKCE verifier for this session (issue #354). The loopback flow already
+    # validates `state`, so this is defense in depth rather than the primary
+    # fix (that's the manual/paste flows), but it is a small, safe addition
+    # since the session already carries per-flow state end to end.
+    code_verifier: str = ""
     _done: threading.Event = field(default_factory=threading.Event)
 
 
@@ -919,6 +1084,7 @@ class GwsReloginManager:
             self._cancel_locked(profile)
 
             state = secrets.token_urlsafe(24)
+            code_verifier = generate_code_verifier()
             handler_cls = self._make_handler(profile, state)
             # Port 0 → OS assigns a free ephemeral loopback port. Google's
             # installed-app OAuth allows a loopback redirect on any port.
@@ -930,6 +1096,7 @@ class GwsReloginManager:
                 redirect_uri=redirect_uri,
                 scopes=scopes_for_profile(profile),
                 state=state,
+                code_challenge=code_challenge_s256(code_verifier),
             )
             now = time.time()
             thread = threading.Thread(
@@ -947,6 +1114,7 @@ class GwsReloginManager:
                 expires_at=now + self._ttl,
                 server=server,
                 thread=thread,
+                code_verifier=code_verifier,
             )
             server._ciao_session = session  # type: ignore[attr-defined]
             self._sessions[profile] = session
@@ -1058,6 +1226,7 @@ class GwsReloginManager:
                     session.profile,
                     code=code or "",
                     redirect_uri=session.redirect_uri,
+                    code_verifier=session.code_verifier,
                 )
                 session.email = result.get("email", "")
                 session.status = "completed"

--- a/ciao/gws_auth.py
+++ b/ciao/gws_auth.py
@@ -452,8 +452,8 @@ def exchange_code(
     )
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
-            payload: dict[str, Any] = json.loads(resp.read().decode("utf-8"))
-            return payload
+            response_payload: dict[str, Any] = json.loads(resp.read().decode("utf-8"))
+            return response_payload
     except urllib.error.HTTPError as exc:
         try:
             err_json = json.loads(exc.read().decode("utf-8"))

--- a/ciao/gws_auth_helper.py
+++ b/ciao/gws_auth_helper.py
@@ -27,11 +27,14 @@ from ciao.gws_auth import fingerprint
 _PERSONAL_SCOPES = gws_auth._PERSONAL_SCOPES  # noqa: SLF001
 
 
-def _build_auth_url(*, client_id: str, redirect_uri: str, scopes: str) -> str:
+def _build_auth_url(
+    *, client_id: str, redirect_uri: str, scopes: str, code_challenge: str | None = None
+) -> str:
     return gws_auth.build_auth_url(
         client_id=client_id,
         redirect_uri=redirect_uri,
         scopes=scopes,
+        code_challenge=code_challenge,
     )
 
 
@@ -112,7 +115,17 @@ def main_entry(argv: Sequence[str] | None = None) -> int:
     print(f"Redirect URI: sha256:{fingerprint(redirect_uri)}")
     print()
 
-    auth_url = _build_auth_url(client_id=client_id, redirect_uri=redirect_uri, scopes=scopes)
+    # PKCE (issue #354): this is a single interactive process, so the verifier
+    # is just a local variable carried from the URL build to the exchange
+    # below — no cross-request state needed. Never printed or logged.
+    code_verifier = gws_auth.generate_code_verifier()
+    code_challenge = gws_auth.code_challenge_s256(code_verifier)
+    auth_url = _build_auth_url(
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        scopes=scopes,
+        code_challenge=code_challenge,
+    )
     print("Open this URL in your browser (pick the correct Google account):")
     print()
     print(auth_url)
@@ -143,6 +156,7 @@ def main_entry(argv: Sequence[str] | None = None) -> int:
             client_secret=client_secret,
             code=code,
             redirect_uri=redirect_uri,
+            code_verifier=code_verifier,
         )
     except ValueError as exc:
         print(f"Error: {exc}")

--- a/ciao/main.py
+++ b/ciao/main.py
@@ -693,7 +693,7 @@ async def _run_server_locked(config: CiaoConfig) -> int:
     pcm.clear_notifications_cb = _clear_notifications
 
     # Google Workspace token health + server-managed re-login (issue #145).
-    from ciao.gws_auth import GwsHealthMonitor, GwsReloginManager
+    from ciao.gws_auth import GwsHealthMonitor, GwsReloginManager, ManualPkceStore
 
     app.state.gws_health_monitor = GwsHealthMonitor(
         config,
@@ -702,6 +702,8 @@ async def _run_server_locked(config: CiaoConfig) -> int:
         runtime_root=config.state_path.parent,
     )
     app.state.gws_relogin_manager = GwsReloginManager(config)
+    # PKCE verifier store for the manual/paste OAuth flow (issue #354).
+    app.state.gws_manual_pkce_store = ManualPkceStore()
 
     # Wire push delivery into the broker drive task so a successful turn
     # notifies subscribed devices even when no WebSocket client is connected.

--- a/ciao/proposal_outcomes.py
+++ b/ciao/proposal_outcomes.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
 import time
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
@@ -39,6 +40,12 @@ logger = logging.getLogger(__name__)
 
 PROPOSAL_OUTCOMES_NAME = "proposal_outcomes.jsonl"
 ACTIONS: tuple[str, ...] = ("promoted", "dismissed")
+# Every current caller is the PWA route handlers or the ``ciao
+# memory-proposal-dismiss`` CLI the nightly curation agent drives (see the
+# module docstring). The whitelist is defense-in-depth: call sites already
+# gate on this, but a typo (e.g. "agents") must not silently fragment the
+# by-surface split instead of being refused loudly (in debug logs).
+VIA_VALUES: tuple[str, ...] = ("pwa", "agent")
 MAX_BYTES = 2 * 1024 * 1024  # trim the log once it passes ~2 MB
 KEEP_LINES = 2000            # lines retained after a trim
 
@@ -64,9 +71,16 @@ _runtime_dir_override: Path | None = None
 def configure(runtime_dir: Path | str) -> None:
     """Pin the runtime directory. Called once at server startup so the
     recorder writes to the same ``.runtime`` the rest of the config uses,
-    regardless of the process cwd. Tests can point it at a temp dir."""
+    regardless of the process cwd. Tests can point it at a temp dir.
+
+    Also drops the cached tally: it is keyed by nothing but the TTL, so
+    without this a runtime-dir change (a test re-pointing it, or a real
+    re-configure) would keep serving a tally read from the previous
+    directory until the TTL happened to expire.
+    """
     global _runtime_dir_override
     _runtime_dir_override = Path(runtime_dir)
+    reset_tally_cache()
 
 
 def _runtime_dir() -> Path:
@@ -83,6 +97,22 @@ def _log_path() -> Path:
     return _runtime_dir() / PROPOSAL_OUTCOMES_NAME
 
 
+def _private_open(path: Path, mode: str):
+    """Open ``path`` for text append/write, creating it 0600 like
+    :func:`ciao.jsonio.write_private_text`, rather than the umask default
+    (typically 0644). This log, the writer lock, and its rotation archives
+    hold workspace names, so they get the same create-private-then-chmod
+    convention that module already uses for on-disk secrets: create with the
+    tight mode directly, then chmod in case an older version of this file
+    left a pre-existing file looser.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | (os.O_TRUNC if "w" in mode else os.O_APPEND)
+    fd = os.open(path, flags, 0o600)
+    f = os.fdopen(fd, mode, encoding="utf-8")
+    os.chmod(path, 0o600)
+    return f
+
+
 def record(
     kind: str,
     action: str,
@@ -94,13 +124,25 @@ def record(
 
     An unknown ``action`` is refused rather than written: the aggregator can
     only fold the two decisions it knows, and a third spelling would silently
-    vanish from every count while claiming to be recorded. The append and the
+    vanish from every count while claiming to be recorded. ``via`` and
+    ``kind`` are refused the same way — every current call site already
+    passes one of :data:`VIA_VALUES` and gates on :func:`is_extraction_kind`
+    before calling this, so these checks are defense-in-depth: a typo like
+    "agents" must not silently fragment the by-surface split, and a
+    non-extraction kind (``skill``, ``rehome``) must not sneak into a tally
+    that only measures the memory-extraction pipeline. The append and the
     size-triggered rotation share an inter-process lock, so a rotation can
     never rewrite away an event another process appended between its read and
     its write.
     """
     if action not in ACTIONS:
         logger.debug("Refusing to record proposal outcome with action %r", action)
+        return
+    if via not in VIA_VALUES:
+        logger.debug("Refusing to record proposal outcome with via %r", via)
+        return
+    if not is_extraction_kind(kind):
+        logger.debug("Refusing to record proposal outcome with kind %r", kind)
         return
     try:
         with _writer_lock():
@@ -109,11 +151,11 @@ def record(
             payload = {
                 "ts": datetime.now(UTC).isoformat(),
                 "workspace": str(workspace or ""),
-                "kind": str(kind or ""),
+                "kind": kind,
                 "action": action,
-                "via": str(via or ""),
+                "via": via,
             }
-            with path.open("a", encoding="utf-8") as f:
+            with _private_open(path, "a") as f:
                 f.write(json.dumps(payload, ensure_ascii=False) + "\n")
             _trim_if_large(path)
     except Exception:  # noqa: BLE001 — recording must never break a resolution
@@ -143,7 +185,7 @@ def _writer_lock(exclusive: bool = True):
     lock_path = _runtime_dir() / _LOCK_NAME
     try:
         lock_path.parent.mkdir(parents=True, exist_ok=True)
-        fh = lock_path.open("a")
+        fh = _private_open(lock_path, "a")
     except Exception:  # noqa: BLE001 — locking is an optimization, not a gate
         yield
         return
@@ -184,11 +226,11 @@ def _trim_if_large(path: Path) -> None:
             + ".jsonl"
         )
         tmp = path.with_name(f".{rotated_name}.tmp")
-        with tmp.open("w", encoding="utf-8") as f:
+        with _private_open(tmp, "w") as f:
             f.writelines(dropped)
         os.replace(tmp, _runtime_dir() / rotated_name)
         tmp = path.with_name(f".{path.name}.trim.tmp")
-        with tmp.open("w", encoding="utf-8") as f:
+        with _private_open(tmp, "w") as f:
             f.writelines(kept)
         os.replace(tmp, path)
     except Exception:  # noqa: BLE001
@@ -333,21 +375,39 @@ def _parsed_ts(raw: Any) -> datetime | None:
 
 _TALLY_TTL_SECONDS = 60.0
 _tally_cache: dict[str, Any] = {"value": None, "expires": 0.0}
+# Guards reads and writes of ``_tally_cache``: /api/automation can be hit by
+# more than one request-handling thread inside the TTL window, and without a
+# lock two racing misses could both mutate the two-key dict at once (one
+# thread's ``expires`` write landing between the other's read and write),
+# which could hand a caller a ``value``/``expires`` pair that were never set
+# together.
+_tally_cache_lock = threading.Lock()
 
 
 def tally_cached() -> dict[str, Any]:
-    """Tally through the short TTL cache. Never raises."""
+    """Tally through the short TTL cache. Never raises.
+
+    Returns the same dict object stored in the cache on a cache hit — no
+    defensive copy — matching :func:`ciao.package_version.make_cached_package_status`,
+    the module's own reference point for this cache's "same spirit" above.
+    Callers must treat the result as read-only; mutating it would corrupt
+    what every other caller sees until the TTL expires.
+    """
     now = time.monotonic()
-    cached: dict[str, Any] | None = _tally_cache["value"]
-    if cached is not None and now < _tally_cache["expires"]:
-        return cached
+    with _tally_cache_lock:
+        cached: dict[str, Any] | None = _tally_cache["value"]
+        if cached is not None and now < _tally_cache["expires"]:
+            return cached
     fresh = tally()
-    _tally_cache["value"] = fresh
-    _tally_cache["expires"] = now + _TALLY_TTL_SECONDS
+    with _tally_cache_lock:
+        _tally_cache["value"] = fresh
+        _tally_cache["expires"] = now + _TALLY_TTL_SECONDS
     return fresh
 
 
 def reset_tally_cache() -> None:
-    """Drop the cached tally. Tests call this between cases."""
-    _tally_cache["value"] = None
-    _tally_cache["expires"] = 0.0
+    """Drop the cached tally. Tests call this between cases; ``configure``
+    calls it too, since a runtime-dir change makes any cached tally stale."""
+    with _tally_cache_lock:
+        _tally_cache["value"] = None
+        _tally_cache["expires"] = 0.0

--- a/ciao/setup_status.py
+++ b/ciao/setup_status.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import shutil
 import subprocess
 import json
@@ -762,6 +763,29 @@ def _claude_status(
     # `oauthAccount` block in ~/.claude.json can belong to the Desktop app
     # while the CLI credential store is signed out (issue #347). Fail closed.
     app_path = claude_app_path()
+    if auth_status.get("cli_too_old"):
+        # This CLI predates `claude auth status`; reporting it as "signed out"
+        # would send the user to re-authenticate against a command that
+        # cannot exist yet, instead of upgrading (issue #354). Still fails
+        # closed (`ok=False`) — this only changes the actionable text, which
+        # is the field the PWA already renders verbatim for every provider
+        # row, so no new field needs plumbing through to the client.
+        return _provider(
+            name="claude",
+            ok=False,
+            auth="missing",
+            command=claude_install_command(),
+            detail=(
+                "This Claude CLI build is too old to report sign-in status "
+                "(`claude auth status` is not a recognized command). Upgrade "
+                "the Claude CLI, then check again."
+            ),
+            version=version,
+            skills=claude_skills,
+            mcps=claude_mcps,
+            install_url=CLAUDE_INSTALL_DOCS_URL,
+            cli_path=binary,
+        )
     detail = (
         "Claude Desktop uses an app-private login. Sign in once via `ciao auth claude`; "
         "no separate CLI install is needed."
@@ -781,6 +805,20 @@ def _claude_status(
     )
 
 
+#  Commander.js-style CLIs (which `claude` is) reject an unknown subcommand
+#  with one of these shapes on stderr (occasionally stdout), e.g.
+#  "error: unknown command 'auth'". An old `claude` binary predating the
+#  `auth` subcommand fails this way, and must be told apart from a real
+#  "not signed in" so the message points at upgrading, not re-authenticating.
+_UNKNOWN_SUBCOMMAND_RE = re.compile(
+    r"unknown command|unrecognized command|no such command", re.IGNORECASE
+)
+
+
+def _looks_like_unknown_subcommand(*texts: str) -> bool:
+    return any(_UNKNOWN_SUBCOMMAND_RE.search(text or "") for text in texts)
+
+
 def claude_auth_status(
     binary: str,
     *,
@@ -792,6 +830,9 @@ def claude_auth_status(
         "unparseable": False,
         "email": "",
         "org_name": "",
+        # Set when `claude auth status` itself is unavailable (an old CLI
+        # predating the `auth` subcommand) rather than reachable-but-signed-out.
+        "cli_too_old": False,
     }
     process_env = os.environ.copy()
     if env is not None:
@@ -808,6 +849,11 @@ def claude_auth_status(
     except (OSError, subprocess.TimeoutExpired):
         return result
     if completed.returncode != 0:
+        # Fail closed either way (`logged_in` stays False), but an unknown
+        # subcommand is not evidence of being signed out — it means this CLI
+        # cannot even report status, so say that instead (issue #354).
+        if _looks_like_unknown_subcommand(completed.stdout or "", completed.stderr or ""):
+            result["cli_too_old"] = True
         return result
     try:
         payload = json.loads(completed.stdout or "")

--- a/ciao/vocabulary_proposals.py
+++ b/ciao/vocabulary_proposals.py
@@ -47,6 +47,7 @@ from ciao.vault_index import (
     DEFAULT_PROMOTION_THRESHOLD,
     Entry,
     promotion_threshold,
+    scan_targets,
     vocabulary_report,
 )
 
@@ -99,7 +100,9 @@ def is_near_duplicate(a: str, b: str, *, known_tags: set[str] | None = None) -> 
       difference only counts as a near-miss once the tags are long enough to
       carry that many edits without coincidence (``ai`` vs ``hr`` is distance
       2 but must NOT merge), while a single-character difference still counts
-      for longer tags.
+      for longer tags — but not for tags under three characters, where a
+      single edit is nearly guaranteed by chance (``jo`` vs ``mo``, ``ai`` vs
+      ``aj``) rather than evidence of a typo.
     * Normalized forms (separators removed) matching exactly or within the
       same length-scaled edit distance. Deliberately no bare-prefix match:
       ``ai`` vs ``airline`` share a normalized prefix but are unrelated.
@@ -121,6 +124,18 @@ def is_near_duplicate(a: str, b: str, *, known_tags: set[str] | None = None) -> 
     # four-character pair like data/java is distance 2 but must NOT merge.
     shorter = min(len(la), len(lb))
     max_edit = 1 if shorter < 6 else 2
+    # A length floor for the edit-distance checks below (raw and normalized
+    # form alike). At two characters there are only 26*26 = 676 possible
+    # tags, so almost any real two-letter tag is one edit from another real
+    # one (`jo` vs `mo`, `ai` vs `aj`) — a distance-1 "near-miss" there is
+    # coincidence, not a typo. Three characters is already an order of
+    # magnitude roomier (26**3 = 17,576 combinations), so a distance-1 match
+    # goes back to being meaningful signal — `data` vs `dato` (4 chars) must
+    # still merge. This floor applies ONLY to the edit-distance branches
+    # below; it must NOT gate the separator/namespace-prefix branch just
+    # below, which is how a genuinely short established tag like `ai` still
+    # merges with `ai-analysis` (the plan's canonical example).
+    min_edit_len = 3
     # Shared namespace/value: the plan's canonical example is ai-analysis /
     # ai-adoption / ai-practice alongside the bare established ai.
     for sep in ("/", "-", "_"):
@@ -139,17 +154,17 @@ def is_near_duplicate(a: str, b: str, *, known_tags: set[str] | None = None) -> 
             if pa == pb and known_tags and pa in known_tags:
                 return True
     # Edit distance on raw forms.
-    if _edit_distance(la, lb, max_dist=max_edit) <= max_edit:
+    if shorter >= min_edit_len and _edit_distance(la, lb, max_dist=max_edit) <= max_edit:
         return True
     # Normalized forms (separators removed): handles ai-analysis vs aianalysis.
     # Deliberately NO bare-prefix match here — `ai` vs `airline` share a
     # normalized prefix but are unrelated, and the separator-delimited stem
     # cases are already handled above. Only an exact normalized equality (or a
-    # length-scaled edit) counts.
+    # length-scaled edit, subject to the same length floor) counts.
     na, nb = _normalized_tag(a), _normalized_tag(b)
     if na == nb:
         return True
-    if _edit_distance(na, nb, max_dist=max_edit) <= max_edit:
+    if shorter >= min_edit_len and _edit_distance(na, nb, max_dist=max_edit) <= max_edit:
         return True
     return False
 
@@ -372,8 +387,6 @@ def audit_vocabulary_proposals(
     Failures degrade to an empty proposal set with a scan error, never to
     "checked and clean".
     """
-    from ciao.vault_index import scan_targets
-
     empty = {
         "threshold": promotion_threshold(),
         "type_promotions": [],
@@ -407,12 +420,7 @@ def audit_vocabulary_proposals(
         # segment. Coercing that empty stamp to "personal" would mislabel every
         # note in a shared vault that spans workspaces. Only the no-config
         # fallback above stamps the caller's own root.
-        entries, _abs = scan_targets(
-            [
-                (Path(root), workspace, Path(prefix))
-                for root, workspace, prefix in targets
-            ]
-        )
+        entries, _abs = scan_targets(targets)
     except Exception as exc:  # noqa: BLE001 — advisory section
         return {
             **empty,

--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -1650,14 +1650,14 @@ async def gws_auth_url(request: Request) -> JSONResponse:
         # trust boundary), so a code_challenge is the RFC 8252 remedy. The
         # verifier is held server-side, keyed by profile, until the matching
         # exchange call.
-        code_verifier = _gws_manual_pkce_store(request).start(profile)
+        flow_id, code_verifier = _gws_manual_pkce_store(request).start(profile)
         auth_url = gws_auth.build_auth_url(
             client_id=client_id,
             redirect_uri=redirect_uri,
             scopes=gws_auth.scopes_for_profile(profile),
             code_challenge=gws_auth.code_challenge_s256(code_verifier),
         )
-        return JSONResponse({"auth_url": auth_url})
+        return JSONResponse({"auth_url": auth_url, "flow_id": flow_id})
     except ValueError as e:
         return JSONResponse({"error": str(e)}, status_code=400)
     except Exception as e:
@@ -1670,6 +1670,7 @@ async def gws_exchange_code(request: Request) -> JSONResponse:
         body = await request.json()
         profile = body.get("profile")
         code_or_url = body.get("code")
+        flow_id = body.get("flow_id")
     except Exception:
         return JSONResponse({"error": "Invalid request payload"}, status_code=400)
 
@@ -1679,6 +1680,8 @@ async def gws_exchange_code(request: Request) -> JSONResponse:
 
     if not code_or_url:
         return JSONResponse({"error": "Missing authorization code or redirect URL"}, status_code=400)
+    if flow_id is not None and not isinstance(flow_id, str):
+        return JSONResponse({"error": "Invalid flow ID"}, status_code=400)
 
     config_dir = _gws_profile_config_dir(config, profile)
     if config_dir is None:
@@ -1691,21 +1694,19 @@ async def gws_exchange_code(request: Request) -> JSONResponse:
         redirect_uris = installed.get("redirect_uris", ["http://localhost"])
         redirect_uri = redirect_uris[0]
         code = gws_auth.extract_code_from_input(code_or_url)
-        # The verifier for this profile's most recent auth-url call, if any
-        # (issue #354). "none" (no PKCE flow pending — never started, a
-        # legacy client, or superseded by a later auth-url call) is treated
-        # like a flow that never used PKCE: the exchange omits the verifier,
-        # matching whatever the auth URL itself sent. "expired" is different:
-        # Google is still holding a code_challenge for this profile, so
-        # silently omitting the verifier would fail with a confusing
-        # Google-side error — tell the user plainly to restart the flow
-        # instead. (A server restart between the two requests looks like
-        # "none" here, since the tombstone lives only in memory; that case
-        # degrades to Google's own invalid_grant/invalid_request error below,
-        # surfaced the same secret-free way as any other exchange failure —
-        # not a silent mismatch.)
+        # The flow ID binds this exchange to the exact auth URL that produced
+        # the pasted code. Without it, an old client must not accidentally use
+        # another tab's verifier.
         pkce_store = _gws_manual_pkce_store(request)
-        pkce_status = pkce_store.status(profile)
+        if flow_id:
+            pkce_status = pkce_store.status(flow_id, profile)
+        else:
+            pkce_status = "none"
+            if pkce_store.status_for_profile(profile) == "active":
+                return JSONResponse(
+                    {"error": "This sign-in flow needs a flow ID. Start manual connect again."},
+                    status_code=400,
+                )
         if pkce_status == "expired":
             return JSONResponse(
                 {
@@ -1716,7 +1717,12 @@ async def gws_exchange_code(request: Request) -> JSONResponse:
                 },
                 status_code=400,
             )
-        code_verifier = pkce_store.peek(profile) if pkce_status == "active" else None
+        if pkce_status == "superseded":
+            return JSONResponse(
+                {"error": "This sign-in flow was replaced. Start manual connect again."},
+                status_code=400,
+            )
+        code_verifier = pkce_store.peek(flow_id, profile) if pkce_status == "active" else None
         # Token exchange + credential write happen off the event loop; the
         # helper never logs the code, tokens, or secret.
         await asyncio.to_thread(

--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -1604,6 +1604,22 @@ async def gws_save_client_secret(request: Request) -> JSONResponse:
     return JSONResponse(_gws_integration_payload(config))
 
 
+def _gws_manual_pkce_store(request: Request):
+    """Return the app's manual-flow PKCE verifier store, creating one on first use.
+
+    Mirrors :func:`_gws_relogin_manager`: lazily attached so a bare test app
+    (only ``config`` on ``app.state``) still works, while ``main.py`` wires
+    the shared instance at startup. See ``ManualPkceStore`` (issue #354).
+    """
+    store = getattr(request.app.state, "gws_manual_pkce_store", None)
+    if store is None:
+        from ciao.gws_auth import ManualPkceStore
+
+        store = ManualPkceStore()
+        request.app.state.gws_manual_pkce_store = store
+    return store
+
+
 async def gws_auth_url(request: Request) -> JSONResponse:
     config = request.app.state.config
     try:
@@ -1629,10 +1645,17 @@ async def gws_auth_url(request: Request) -> JSONResponse:
             return JSONResponse({"error": "client_secret.json missing client_id"}, status_code=400)
         redirect_uris = installed.get("redirect_uris", ["http://localhost"])
         redirect_uri = redirect_uris[0]
+        # PKCE (issue #354): this manual/paste flow cannot validate `state` on
+        # paste-back (the user, not the browser, carries the code across the
+        # trust boundary), so a code_challenge is the RFC 8252 remedy. The
+        # verifier is held server-side, keyed by profile, until the matching
+        # exchange call.
+        code_verifier = _gws_manual_pkce_store(request).start(profile)
         auth_url = gws_auth.build_auth_url(
             client_id=client_id,
             redirect_uri=redirect_uri,
             scopes=gws_auth.scopes_for_profile(profile),
+            code_challenge=gws_auth.code_challenge_s256(code_verifier),
         )
         return JSONResponse({"auth_url": auth_url})
     except ValueError as e:
@@ -1668,6 +1691,32 @@ async def gws_exchange_code(request: Request) -> JSONResponse:
         redirect_uris = installed.get("redirect_uris", ["http://localhost"])
         redirect_uri = redirect_uris[0]
         code = gws_auth.extract_code_from_input(code_or_url)
+        # The verifier for this profile's most recent auth-url call, if any
+        # (issue #354). "none" (no PKCE flow pending — never started, a
+        # legacy client, or superseded by a later auth-url call) is treated
+        # like a flow that never used PKCE: the exchange omits the verifier,
+        # matching whatever the auth URL itself sent. "expired" is different:
+        # Google is still holding a code_challenge for this profile, so
+        # silently omitting the verifier would fail with a confusing
+        # Google-side error — tell the user plainly to restart the flow
+        # instead. (A server restart between the two requests looks like
+        # "none" here, since the tombstone lives only in memory; that case
+        # degrades to Google's own invalid_grant/invalid_request error below,
+        # surfaced the same secret-free way as any other exchange failure —
+        # not a silent mismatch.)
+        pkce_store = _gws_manual_pkce_store(request)
+        pkce_status = pkce_store.status(profile)
+        if pkce_status == "expired":
+            return JSONResponse(
+                {
+                    "error": (
+                        "This sign-in link expired before the code was pasted "
+                        "back. Start manual connect again for a fresh link."
+                    )
+                },
+                status_code=400,
+            )
+        code_verifier = pkce_store.peek(profile) if pkce_status == "active" else None
         # Token exchange + credential write happen off the event loop; the
         # helper never logs the code, tokens, or secret.
         await asyncio.to_thread(
@@ -1676,6 +1725,7 @@ async def gws_exchange_code(request: Request) -> JSONResponse:
             profile,
             code=code,
             redirect_uri=redirect_uri,
+            code_verifier=code_verifier,
         )
         # Refresh the cached token-validity state so the Settings UI clears
         # the "Login expired" banner immediately instead of waiting up to

--- a/tests/test_gws_auth.py
+++ b/tests/test_gws_auth.py
@@ -199,38 +199,41 @@ def test_exchange_code_omits_code_verifier_when_none(monkeypatch) -> None:
 
 def test_manual_pkce_store_round_trip() -> None:
     store = gws_auth.ManualPkceStore()
-    verifier = store.start("personal")
+    flow_id, verifier = store.start("personal")
     assert 43 <= len(verifier) <= 128
     # Non-destructive: peeking again (e.g. a retried paste-back) returns the
     # same verifier rather than consuming it.
-    assert store.peek("personal") == verifier
-    assert store.peek("personal") == verifier
+    assert store.peek(flow_id, "personal") == verifier
+    assert store.peek(flow_id, "personal") == verifier
 
 
 def test_manual_pkce_store_unknown_profile_is_none() -> None:
     store = gws_auth.ManualPkceStore()
-    assert store.peek("never-started") is None
-    assert store.status("never-started") == "none"
+    assert store.peek("never-started", "personal") is None
+    assert store.status("never-started", "personal") == "none"
 
 
-def test_manual_pkce_store_restart_replaces_pending_verifier() -> None:
+def test_manual_pkce_store_keeps_concurrent_flows_separate() -> None:
     store = gws_auth.ManualPkceStore()
-    first = store.start("personal")
-    second = store.start("personal")
+    first_id, first = store.start("personal")
+    second_id, second = store.start("personal")
     assert first != second
-    assert store.peek("personal") == second
-    assert store.status("personal") == "active"
+    assert first_id != second_id
+    assert store.peek(first_id, "personal") == first
+    assert store.peek(second_id, "personal") == second
+    assert store.status(first_id, "personal") == "active"
+    assert store.status(second_id, "personal") == "active"
 
 
 def test_manual_pkce_store_expires_after_ttl(monkeypatch) -> None:
     fake_time = {"now": 1000.0}
     monkeypatch.setattr(gws_auth.time, "time", lambda: fake_time["now"])
     store = gws_auth.ManualPkceStore(ttl=10.0)
-    store.start("personal")
-    assert store.peek("personal") is not None
-    assert store.status("personal") == "active"
+    flow_id, _ = store.start("personal")
+    assert store.peek(flow_id, "personal") is not None
+    assert store.status(flow_id, "personal") == "active"
     fake_time["now"] += 11.0
-    assert store.peek("personal") is None
+    assert store.peek(flow_id, "personal") is None
 
 
 def test_manual_pkce_store_distinguishes_expired_from_never_started(monkeypatch) -> None:
@@ -243,18 +246,18 @@ def test_manual_pkce_store_distinguishes_expired_from_never_started(monkeypatch)
     monkeypatch.setattr(gws_auth.time, "time", lambda: fake_time["now"])
 
     store = gws_auth.ManualPkceStore(ttl=10.0)
-    assert store.status("personal") == "none"
-    store.start("personal")
-    assert store.status("personal") == "active"
+    assert store.status("missing", "personal") == "none"
+    flow_id, _ = store.start("personal")
+    assert store.status(flow_id, "personal") == "active"
     fake_time["now"] += 11.0
     # Expired, not "none": a real challenge is stranded at Google.
-    assert store.status("personal") == "expired"
-    assert store.peek("personal") is None
+    assert store.status(flow_id, "personal") == "expired"
+    assert store.peek(flow_id, "personal") is None
     # Still expired (tombstoned, not deleted) on a second check.
-    assert store.status("personal") == "expired"
+    assert store.status(flow_id, "personal") == "expired"
 
     # A different, never-touched profile is genuinely "none".
-    assert store.status("other") == "none"
+    assert store.status("missing", "other") == "none"
 
 
 def test_manual_pkce_default_ttl_is_generous() -> None:

--- a/tests/test_gws_auth.py
+++ b/tests/test_gws_auth.py
@@ -87,6 +87,180 @@ def test_build_auth_url_includes_state_and_client() -> None:
     assert "client_id=cid" in url
     assert "state=xyz" in url
     assert "redirect_uri=http%3A%2F%2F127.0.0.1%3A5000%2F" in url
+    # No PKCE params when no challenge is requested: an in-flight legacy flow
+    # (built before PKCE support existed) must not be affected.
+    assert "code_challenge" not in url
+
+
+# ── PKCE (RFC 7636, issue #354) ───────────────────────────────────────────
+
+
+def test_generate_code_verifier_charset_and_length_bounds() -> None:
+    allowed = set(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+    )
+    verifier = gws_auth.generate_code_verifier()
+    assert 43 <= len(verifier) <= 128
+    assert set(verifier) <= allowed
+
+    short = gws_auth.generate_code_verifier(43)
+    assert len(short) == 43
+    long = gws_auth.generate_code_verifier(128)
+    assert len(long) == 128
+
+    with pytest.raises(ValueError):
+        gws_auth.generate_code_verifier(42)
+    with pytest.raises(ValueError):
+        gws_auth.generate_code_verifier(129)
+
+    # Two calls must not collide.
+    assert gws_auth.generate_code_verifier() != gws_auth.generate_code_verifier()
+
+
+def test_code_challenge_s256_matches_known_vector() -> None:
+    # RFC 7636 Appendix B worked example.
+    verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    assert gws_auth.code_challenge_s256(verifier) == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+
+def test_build_auth_url_includes_code_challenge() -> None:
+    verifier = gws_auth.generate_code_verifier()
+    challenge = gws_auth.code_challenge_s256(verifier)
+    url = gws_auth.build_auth_url(
+        client_id="cid",
+        redirect_uri="http://127.0.0.1:5000/",
+        scopes="openid",
+        code_challenge=challenge,
+    )
+    query = parse_qs(urlparse(url).query)
+    assert query["code_challenge"] == [challenge]
+    assert query["code_challenge_method"] == ["S256"]
+
+
+def test_exchange_code_sends_matching_code_verifier(monkeypatch) -> None:
+    captured: dict[str, str] = {}
+
+    class _FakeResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return b'{"refresh_token": "rtok"}'
+
+    def fake_urlopen(req, *args, **kwargs):
+        captured["body"] = req.data.decode("utf-8")
+        return _FakeResp()
+
+    monkeypatch.setattr(gws_auth.urllib.request, "urlopen", fake_urlopen)
+
+    gws_auth.exchange_code(
+        client_id="cid",
+        client_secret="csecret",
+        code="the-code",
+        redirect_uri="http://127.0.0.1:9/",
+        code_verifier="the-verifier",
+    )
+    sent = parse_qs(captured["body"])
+    assert sent["code_verifier"] == ["the-verifier"]
+    assert sent["code"] == ["the-code"]
+
+
+def test_exchange_code_omits_code_verifier_when_none(monkeypatch) -> None:
+    """No PKCE was used for this flow: the exchange must not send a stray param."""
+    captured: dict[str, str] = {}
+
+    class _FakeResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return b'{"refresh_token": "rtok"}'
+
+    def fake_urlopen(req, *args, **kwargs):
+        captured["body"] = req.data.decode("utf-8")
+        return _FakeResp()
+
+    monkeypatch.setattr(gws_auth.urllib.request, "urlopen", fake_urlopen)
+
+    gws_auth.exchange_code(
+        client_id="cid", client_secret="csecret", code="c", redirect_uri="r"
+    )
+    assert "code_verifier" not in parse_qs(captured["body"])
+
+
+# ── ManualPkceStore (manual/paste flow cross-request PKCE state) ─────────
+
+
+def test_manual_pkce_store_round_trip() -> None:
+    store = gws_auth.ManualPkceStore()
+    verifier = store.start("personal")
+    assert 43 <= len(verifier) <= 128
+    # Non-destructive: peeking again (e.g. a retried paste-back) returns the
+    # same verifier rather than consuming it.
+    assert store.peek("personal") == verifier
+    assert store.peek("personal") == verifier
+
+
+def test_manual_pkce_store_unknown_profile_is_none() -> None:
+    store = gws_auth.ManualPkceStore()
+    assert store.peek("never-started") is None
+    assert store.status("never-started") == "none"
+
+
+def test_manual_pkce_store_restart_replaces_pending_verifier() -> None:
+    store = gws_auth.ManualPkceStore()
+    first = store.start("personal")
+    second = store.start("personal")
+    assert first != second
+    assert store.peek("personal") == second
+    assert store.status("personal") == "active"
+
+
+def test_manual_pkce_store_expires_after_ttl(monkeypatch) -> None:
+    fake_time = {"now": 1000.0}
+    monkeypatch.setattr(gws_auth.time, "time", lambda: fake_time["now"])
+    store = gws_auth.ManualPkceStore(ttl=10.0)
+    store.start("personal")
+    assert store.peek("personal") is not None
+    assert store.status("personal") == "active"
+    fake_time["now"] += 11.0
+    assert store.peek("personal") is None
+
+
+def test_manual_pkce_store_distinguishes_expired_from_never_started(monkeypatch) -> None:
+    """`status` must tell "a challenge is stranded at Google" (expired) apart
+    from "no PKCE flow was ever pending" (none) — issue #354 code review: a
+    caller that cannot tell these apart would silently omit the verifier for
+    an expired flow and get a confusing invalid_grant from Google instead of
+    an actionable "restart the flow" message."""
+    fake_time = {"now": 1000.0}
+    monkeypatch.setattr(gws_auth.time, "time", lambda: fake_time["now"])
+
+    store = gws_auth.ManualPkceStore(ttl=10.0)
+    assert store.status("personal") == "none"
+    store.start("personal")
+    assert store.status("personal") == "active"
+    fake_time["now"] += 11.0
+    # Expired, not "none": a real challenge is stranded at Google.
+    assert store.status("personal") == "expired"
+    assert store.peek("personal") is None
+    # Still expired (tombstoned, not deleted) on a second check.
+    assert store.status("personal") == "expired"
+
+    # A different, never-touched profile is genuinely "none".
+    assert store.status("other") == "none"
+
+
+def test_manual_pkce_default_ttl_is_generous() -> None:
+    """The default TTL must comfortably outlast a slow/distracted user on
+    Google's consent screen — 600s proved too tight (issue #354 review)."""
+    assert gws_auth.MANUAL_PKCE_TTL_SECONDS >= 1800.0
 
 
 def test_extract_code_from_input() -> None:
@@ -187,7 +361,7 @@ def test_exchange_and_store_uses_injected_exchange(tmp_path: Path, monkeypatch) 
     config_dir = gws_auth.profile_config_dir(cfg, "personal")
     _write_client_secret(config_dir)
 
-    def fake_exchange(*, client_id, client_secret, code, redirect_uri):
+    def fake_exchange(*, client_id, client_secret, code, redirect_uri, code_verifier=None):
         assert client_id == "cid"
         assert code == "the-code"
         # id_token payload carries the email (base64url of a JSON blob).
@@ -505,9 +679,10 @@ def test_relogin_completes_via_loopback(tmp_path: Path) -> None:
 
     captured: dict = {}
 
-    def fake_exchange(config, profile, *, code, redirect_uri):
+    def fake_exchange(config, profile, *, code, redirect_uri, code_verifier=None):
         captured["code"] = code
         captured["redirect_uri"] = redirect_uri
+        captured["code_verifier"] = code_verifier
         return {"ok": True, "email": "loop@example.com"}
 
     manager = gws_auth.GwsReloginManager(cfg, exchange_fn=fake_exchange, session_ttl=10)
@@ -526,6 +701,12 @@ def test_relogin_completes_via_loopback(tmp_path: Path) -> None:
     assert urlparse(query["redirect_uri"][0]).port == port
     assert f":{port}/" in started["redirect_uri"]
 
+    # PKCE (issue #354): the loopback flow already validates `state`, but
+    # gets PKCE too as a small, safe delta since it already carries per-flow
+    # session state end to end.
+    assert query["code_challenge_method"] == ["S256"]
+    challenge = query["code_challenge"][0]
+
     # A mismatched state must be ignored (session stays pending).
     _drive_callback(port, "?code=evil&state=wrong")
     assert manager.status("personal")["status"] == "pending"
@@ -537,6 +718,9 @@ def test_relogin_completes_via_loopback(tmp_path: Path) -> None:
     assert final["email"] == "loop@example.com"
     assert captured["code"] == "good-code"
     assert captured["redirect_uri"] == started["redirect_uri"]
+    # The verifier handed to the exchange must be the one whose S256 digest
+    # produced the code_challenge on the auth URL.
+    assert gws_auth.code_challenge_s256(captured["code_verifier"]) == challenge
 
 
 def test_relogin_reports_google_error(tmp_path: Path) -> None:
@@ -598,7 +782,7 @@ def test_relogin_cancel_tears_down_the_listener(tmp_path: Path) -> None:
     _write_client_secret(gws_auth.profile_config_dir(cfg, "personal"))
     exchanges: list[str] = []
 
-    def fake_exchange(config, profile, *, code, redirect_uri):
+    def fake_exchange(config, profile, *, code, redirect_uri, code_verifier=None):
         exchanges.append(code)
         return {"ok": True, "email": "x@example.com"}
 
@@ -636,7 +820,7 @@ def test_relogin_cancel_invalidates_an_in_flight_callback(tmp_path: Path) -> Non
     release_exchange = threading_mod.Event()
     exchange_ran = threading_mod.Event()
 
-    def blocking_exchange(config, profile, *, code, redirect_uri):
+    def blocking_exchange(config, profile, *, code, redirect_uri, code_verifier=None):
         exchange_started_event.set()
         release_exchange.wait(timeout=5)
         exchange_ran.set()

--- a/tests/test_gws_relogin_routes.py
+++ b/tests/test_gws_relogin_routes.py
@@ -74,7 +74,7 @@ def test_relogin_full_flow(tmp_path: Path) -> None:
     _write_client_secret(config)
 
     # Inject a manager whose exchange writes real credentials without network.
-    def fake_exchange(cfg, profile, *, code, redirect_uri):
+    def fake_exchange(cfg, profile, *, code, redirect_uri, code_verifier=None):
         gws_auth.store_credentials(
             gws_auth.profile_config_dir(cfg, profile),
             client_id="cid",
@@ -101,6 +101,10 @@ def test_relogin_full_flow(tmp_path: Path) -> None:
     assert query["redirect_uri"][0] == data["redirect_uri"]
     port, state = data["port"], data["state"]
     assert urlparse(query["redirect_uri"][0]).port == port
+    # PKCE (issue #354): a small, safe addition to the loopback flow, which
+    # already validates `state`.
+    assert query["code_challenge_method"] == ["S256"]
+    assert "code_challenge" in query
 
     # Before the redirect, status is pending.
     pending = client.get("/api/integrations/gws/relogin/status?profile=personal")

--- a/tests/test_proposal_outcomes.py
+++ b/tests/test_proposal_outcomes.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import json
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -58,6 +61,21 @@ def test_record_refuses_an_unknown_action(tmp_path: Path) -> None:
     assert _read_events(tmp_path) == []
 
 
+def test_record_refuses_an_unknown_via(tmp_path: Path) -> None:
+    """Every call site already passes "pwa" or "agent"; a typo like "agents"
+    must be refused rather than silently fragment the by-surface split."""
+    po.record("memory", "promoted", via="agents")
+    assert _read_events(tmp_path) == []
+
+
+def test_record_refuses_a_non_extraction_kind(tmp_path: Path) -> None:
+    """Skill proposals and rehome judgements share the review surface but
+    answer to different pipelines; this ledger counts only extraction kinds."""
+    po.record("skill", "promoted")
+    po.record("rehome", "dismissed")
+    assert _read_events(tmp_path) == []
+
+
 def test_record_is_fail_open(tmp_path: Path) -> None:
     blocker = tmp_path / "not-a-dir"
     blocker.write_text("file in the way", encoding="utf-8")
@@ -71,11 +89,20 @@ def test_record_is_fail_open(tmp_path: Path) -> None:
 # ── tally ────────────────────────────────────────────────────────────────
 
 
-def test_tally_folds_totals_workspaces_and_recent_window() -> None:
+def test_tally_folds_totals_workspaces_and_recent_window(tmp_path: Path) -> None:
+    # ``rehome``/``skill`` are not extraction kinds, so ``record()`` itself
+    # refuses to write them (see test_record_refuses_a_non_extraction_kind).
+    # tally() folds any well-formed line by action regardless of kind, so
+    # seed these two straight into the log — before the ``record()`` calls
+    # below, since ``_write_events`` overwrites the whole file.
+    _write_events(tmp_path, [
+        json.dumps({"ts": datetime.now(UTC).isoformat(), "workspace": "work",
+                    "kind": "rehome", "action": "dismissed", "via": "pwa"}),
+        json.dumps({"ts": datetime.now(UTC).isoformat(), "workspace": "work",
+                    "kind": "skill", "action": "dismissed", "via": "pwa"}),
+    ])
     po.record("memory", "promoted", workspace="personal")
     po.record("profile", "promoted", workspace="personal")
-    po.record("rehome", "dismissed", workspace="work")
-    po.record("skill", "dismissed", workspace="work")
 
     report = po.tally()
 
@@ -169,6 +196,23 @@ def test_tally_cached_serves_stale_within_ttl_then_refreshes() -> None:
     refreshed = po.tally_cached()
     assert refreshed["promoted"] == 1
     assert refreshed["dismissed"] == 1
+
+
+def test_configure_invalidates_the_tally_cache(tmp_path: Path) -> None:
+    """A runtime-dir change must not keep serving a tally read from the
+    previous directory until the TTL happens to expire."""
+    po.record("memory", "promoted", workspace="personal")
+    first = po.tally_cached()
+    assert first["promoted"] == 1
+
+    other = tmp_path / "other-runtime"
+    po.configure(other)
+    try:
+        # The new directory has no log yet, so a stale cache would still show
+        # the old directory's count; a correctly invalidated cache shows zero.
+        assert po.tally_cached()["promoted"] == 0
+    finally:
+        po.configure(tmp_path)
 
 
 # ── agent path (curation CLI) ─────────────────────────────────────────────
@@ -500,3 +544,108 @@ def test_record_works_without_fcntl(tmp_path: Path, monkeypatch) -> None:
 
     report = po.tally()
     assert report["promoted"] == 1
+
+
+# ── concurrency ─────────────────────────────────────────────────────────────
+
+
+def test_concurrent_record_calls_all_land_without_corruption(tmp_path: Path) -> None:
+    """Many threads calling record() at once must all land: one JSON object
+    per line, none merged or torn. ``flock`` is scoped to the open file
+    description rather than the process, so two same-process threads each
+    opening the lock file separately still serialize against each other —
+    this pins that same-process concurrency, not just cross-process."""
+    n_threads = 8
+    n_per_thread = 25
+
+    def worker(i: int) -> None:
+        for _ in range(n_per_thread):
+            po.record("memory", "promoted", workspace=f"w{i}")
+
+    with ThreadPoolExecutor(max_workers=n_threads) as pool:
+        list(pool.map(worker, range(n_threads)))
+
+    raw_lines = po._log_path().read_text(encoding="utf-8").splitlines()
+    assert len(raw_lines) == n_threads * n_per_thread
+    # json.loads raises on anything torn or interleaved; every line must
+    # parse as exactly the one event that was written.
+    events = [json.loads(line) for line in raw_lines]
+    assert all(e["action"] == "promoted" and e["kind"] == "memory" for e in events)
+
+    report = po.tally()
+    assert report["promoted"] == n_threads * n_per_thread
+
+
+def test_tally_survives_concurrent_rotation(tmp_path: Path, monkeypatch) -> None:
+    """tally() takes the shared lock while a concurrent recorder holds the
+    exclusive lock to trim-and-archive; interleaving many rotations with many
+    reads must never raise, and the final tally must neither lose nor
+    double-count an event once every thread has finished."""
+    monkeypatch.setattr(po, "MAX_BYTES", 2 * 1024)  # force frequent rotation
+    n_events = 250
+    errors: list[BaseException] = []
+
+    def writer() -> None:
+        for _ in range(n_events):
+            po.record("memory", "promoted", workspace="w")
+
+    def reader() -> None:
+        for _ in range(50):
+            try:
+                po.tally()
+            except BaseException as exc:  # noqa: BLE001 - pragma: no cover
+                errors.append(exc)
+
+    writer_thread = threading.Thread(target=writer)
+    reader_threads = [threading.Thread(target=reader) for _ in range(4)]
+    writer_thread.start()
+    for t in reader_threads:
+        t.start()
+    writer_thread.join()
+    for t in reader_threads:
+        t.join()
+
+    assert errors == []
+    final = po.tally()
+    assert final["promoted"] == n_events
+    assert list(tmp_path.glob("proposal_outcomes.rotated-*.jsonl"))
+
+
+def test_tally_tolerates_a_truncated_final_line(tmp_path: Path) -> None:
+    """A crash mid-append can leave the log's last line partially written: no
+    trailing newline, and the JSON object itself cut short. tally() must
+    still count every complete line before it and never raise."""
+    complete = json.dumps({
+        "ts": datetime.now(UTC).isoformat(), "workspace": "personal",
+        "kind": "memory", "action": "promoted", "via": "pwa",
+    })
+    po._log_path().parent.mkdir(parents=True, exist_ok=True)
+    with po._log_path().open("w", encoding="utf-8") as f:
+        f.write(complete + "\n")
+        f.write('{"ts": "2026-08-2')  # write interrupted before it completed
+
+    report = po.tally()
+
+    assert report["promoted"] == 1
+    assert report["by_workspace"] == {"personal": {"promoted": 1, "dismissed": 0}}
+
+
+def test_log_lock_and_archive_files_are_created_owner_only(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Runtime files here hold workspace names; they must not be readable by
+    other accounts on the box, the same convention jsonio.write_private_text
+    uses for on-disk secrets, rather than trusting the process umask."""
+    monkeypatch.setattr(po, "MAX_BYTES", 1024)  # force a rotation to happen
+    for _ in range(50):
+        po.record("memory", "promoted", workspace="w")
+
+    log_mode = os.stat(po._log_path()).st_mode & 0o777
+    lock_mode = os.stat(tmp_path / po._LOCK_NAME).st_mode & 0o777
+    assert log_mode == 0o600
+    assert lock_mode == 0o600
+
+    archives = list(tmp_path.glob("proposal_outcomes.rotated-*.jsonl"))
+    assert archives
+    for archive in archives:
+        assert os.stat(archive).st_mode & 0o777 == 0o600

--- a/tests/test_setup_status.py
+++ b/tests/test_setup_status.py
@@ -288,6 +288,7 @@ def test_claude_auth_status_parses_logged_in_json(monkeypatch) -> None:
         "unparseable": False,
         "email": "a@example.com",
         "org_name": "Org",
+        "cli_too_old": False,
     }
 
 
@@ -316,6 +317,70 @@ def test_claude_auth_status_missing_binary_is_not_authenticated(monkeypatch) -> 
         lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError()),
     )
     assert claude_auth_status("/missing")["logged_in"] is False
+
+
+def test_claude_auth_status_detects_unknown_auth_subcommand(monkeypatch) -> None:
+    """An old CLI without `claude auth` must be told apart from signed-out
+    (issue #354): it still fails closed on `logged_in`, but flags
+    `cli_too_old` instead of leaving the caller to mistake it for a real
+    "not signed in" reading."""
+    monkeypatch.setattr(
+        "ciao.setup_status.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(
+            stdout="", stderr="error: unknown command 'auth'", returncode=1
+        ),
+    )
+    status = claude_auth_status("/claude")
+    assert status["logged_in"] is False
+    assert status["cli_too_old"] is True
+
+
+def test_claude_auth_status_unknown_subcommand_detected_on_stdout(monkeypatch) -> None:
+    """Some CLIs print the unknown-command message to stdout, not stderr."""
+    monkeypatch.setattr(
+        "ciao.setup_status.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(
+            stdout="Unrecognized command: auth", stderr="", returncode=1
+        ),
+    )
+    assert claude_auth_status("/claude")["cli_too_old"] is True
+
+
+def test_claude_auth_status_other_nonzero_exit_is_not_cli_too_old(monkeypatch) -> None:
+    """A generic failure (e.g. a real error) must not be misread as an old CLI."""
+    monkeypatch.setattr(
+        "ciao.setup_status.subprocess.run",
+        lambda *args, **kwargs: SimpleNamespace(
+            stdout="", stderr="permission denied", returncode=1
+        ),
+    )
+    status = claude_auth_status("/claude")
+    assert status["logged_in"] is False
+    assert status["cli_too_old"] is False
+
+
+def test_setup_status_reports_cli_too_old_as_actionable_and_still_fails_closed(
+    tmp_path, monkeypatch
+) -> None:
+    """The wizard must not report "signed out" for a CLI that cannot even run
+    `claude auth status` (issue #354) — it should point at upgrading instead,
+    while still keeping `ok=False` (fail closed)."""
+    monkeypatch.setattr(
+        "ciao.setup_status.claude_auth_status",
+        lambda binary, env=None: {
+            "logged_in": False,
+            "unparseable": False,
+            "email": "",
+            "org_name": "",
+            "cli_too_old": True,
+        },
+    )
+    config = _config(tmp_path)
+    claude = setup_status(config, env={})["providers"]["claude"]
+    assert claude["ok"] is False
+    assert claude["auth"] == "missing"
+    assert "too old" in claude["detail"].lower()
+    assert "upgrade" in claude["detail"].lower()
 
 
 def test_setup_status_explains_desktop_login_is_app_private(tmp_path, monkeypatch) -> None:

--- a/tests/test_vocabulary_proposals.py
+++ b/tests/test_vocabulary_proposals.py
@@ -64,6 +64,23 @@ def test_is_near_duplicate_short_tags_need_tighter_distance():
     assert is_near_duplicate("brain", "brsin") is True
 
 
+def test_is_near_duplicate_two_char_tags_below_edit_distance_floor():
+    # At two characters there are only 26*26 = 676 possible tags, so a single
+    # edit is nearly guaranteed by chance rather than evidence of a typo:
+    # `jo`/`mo` and `ai`/`aj` are both distance 1 but must NOT merge.
+    assert is_near_duplicate("jo", "mo") is False
+    assert is_near_duplicate("mo", "jo") is False
+    assert is_near_duplicate("ai", "aj") is False
+    assert is_near_duplicate("aj", "ai") is False
+    # The separator/namespace path is unaffected by the floor: a bare
+    # established `ai` must still merge with `ai-analysis` even though `ai`
+    # is only two characters.
+    assert is_near_duplicate("ai", "ai-analysis") is True
+    assert is_near_duplicate("ai-analysis", "ai") is True
+    # A genuine typo just above the floor (3+ chars) still merges.
+    assert is_near_duplicate("analysis", "analsis") is True
+
+
 def test_is_near_duplicate_short_tags_integration(tmp_path: Path):
     # An established `ai` and a singleton `hr` must NOT produce a merge.
     vault = tmp_path / "vault"
@@ -74,6 +91,21 @@ def test_is_near_duplicate_short_tags_integration(tmp_path: Path):
     entries = vi.scan_vault(vault)
     proposals = generate_vocabulary_proposals(entries, threshold=5)
     assert not any(m["tag"] == "hr" for m in proposals["tag_merges"])
+
+
+def test_two_char_singleton_tags_do_not_merge(tmp_path: Path):
+    # `jo` and `mo` are both singletons and distance 1 apart, but two
+    # characters is too short for that to mean anything — neither should
+    # produce a merge proposal against the other.
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    _write(vault / "Jo.md", _note_body(tags=["jo"], title="Jo"))
+    _write(vault / "Mo.md", _note_body(tags=["mo"], title="Mo"))
+    entries = vi.scan_vault(vault)
+    proposals = generate_vocabulary_proposals(entries, threshold=5)
+    merges = proposals["tag_merges"]
+    assert not any(m["tag"] == "jo" for m in merges)
+    assert not any(m["tag"] == "mo" for m in merges)
 
 
 def test_is_near_duplicate_identical_is_not_duplicate():

--- a/tests/test_workspace_settings_routes.py
+++ b/tests/test_workspace_settings_routes.py
@@ -685,6 +685,8 @@ def test_gws_setup_endpoints(tmp_path, monkeypatch):
     assert resp.status_code == 200
     assert "accounts.google.com/o/oauth2/auth" in resp.json()["auth_url"]
     assert "client_id=test-client-id" in resp.json()["auth_url"]
+    flow_id = resp.json()["flow_id"]
+    assert flow_id
 
     # PKCE (issue #354): the manual/paste flow cannot validate `state` on
     # paste-back, so the auth URL must carry a code_challenge, and the
@@ -725,7 +727,7 @@ def test_gws_setup_endpoints(tmp_path, monkeypatch):
     # Use a redirect URL as input
     resp = client.post(
         "/api/integrations/gws/exchange",
-        json={"profile": "personal", "code": "http://localhost/?code=test-code"}
+        json={"profile": "personal", "code": "http://localhost/?code=test-code", "flow_id": flow_id}
     )
     assert resp.status_code == 200
     assert mock_called is True
@@ -876,8 +878,8 @@ def test_gws_exchange_rejects_expired_pkce_flow_with_actionable_error(tmp_path, 
 
     # Simulate the TTL elapsing before the user pastes the code back.
     store = client.app.state.gws_manual_pkce_store
-    for profile, (verifier, _expires_at) in list(store._pending.items()):
-        store._pending[profile] = (verifier, 0.0)
+    for flow_id, (profile, verifier, _expires_at, _status) in list(store._pending.items()):
+        store._pending[flow_id] = (profile, verifier, 0.0, "active")
 
     exchange_called = False
 

--- a/tests/test_workspace_settings_routes.py
+++ b/tests/test_workspace_settings_routes.py
@@ -875,6 +875,7 @@ def test_gws_exchange_rejects_expired_pkce_flow_with_actionable_error(tmp_path, 
 
     resp = client.post("/api/integrations/gws/auth-url", json={"profile": "personal"})
     assert resp.status_code == 200
+    flow_id = resp.json()["flow_id"]
 
     # Simulate the TTL elapsing before the user pastes the code back.
     store = client.app.state.gws_manual_pkce_store
@@ -892,7 +893,11 @@ def test_gws_exchange_rejects_expired_pkce_flow_with_actionable_error(tmp_path, 
 
     resp = client.post(
         "/api/integrations/gws/exchange",
-        json={"profile": "personal", "code": "http://localhost/?code=stale-code"},
+        json={
+            "profile": "personal",
+            "code": "http://localhost/?code=stale-code",
+            "flow_id": flow_id,
+        },
     )
     assert resp.status_code == 400
     assert "expired" in resp.json()["error"].lower()

--- a/tests/test_workspace_settings_routes.py
+++ b/tests/test_workspace_settings_routes.py
@@ -686,6 +686,17 @@ def test_gws_setup_endpoints(tmp_path, monkeypatch):
     assert "accounts.google.com/o/oauth2/auth" in resp.json()["auth_url"]
     assert "client_id=test-client-id" in resp.json()["auth_url"]
 
+    # PKCE (issue #354): the manual/paste flow cannot validate `state` on
+    # paste-back, so the auth URL must carry a code_challenge, and the
+    # verifier that produced it must be the one sent at exchange time below.
+    from urllib.parse import parse_qs, urlparse
+
+    from ciao import gws_auth
+
+    auth_query = parse_qs(urlparse(resp.json()["auth_url"]).query)
+    assert auth_query["code_challenge_method"] == ["S256"]
+    challenge = auth_query["code_challenge"][0]
+
     # 3. Test exchange code
     # Mock urllib.request.urlopen to return tokens
     class MockResponse:
@@ -700,10 +711,12 @@ def test_gws_setup_endpoints(tmp_path, monkeypatch):
             pass
 
     mock_called = False
+    captured_body = {}
     def mock_urlopen(req, *args, **kwargs):
         nonlocal mock_called
         mock_called = True
         assert req.full_url == "https://oauth2.googleapis.com/token"
+        captured_body["data"] = req.data.decode("utf-8")
         return MockResponse()
 
     import urllib.request
@@ -716,6 +729,13 @@ def test_gws_setup_endpoints(tmp_path, monkeypatch):
     )
     assert resp.status_code == 200
     assert mock_called is True
+
+    # The verifier generated for the auth-url call above must be the one
+    # actually sent to the token endpoint, and it must derive the same
+    # challenge that was on the auth URL.
+    sent_verifier = parse_qs(captured_body["data"])["code_verifier"][0]
+    assert gws_auth.code_challenge_s256(sent_verifier) == challenge
+
     data = resp.json()
     profiles = {p["name"]: p for p in data["profiles"]}
     assert profiles["personal"]["configured"] is True
@@ -771,7 +791,7 @@ def test_gws_exchange_refreshes_health_monitor(tmp_path, monkeypatch):
     import ciao.gws_auth
     monkeypatch.setattr(
         ciao.gws_auth, "exchange_and_store",
-        lambda config, profile, *, code, redirect_uri: {"ok": True, "email": "x@y"},
+        lambda config, profile, *, code, redirect_uri, code_verifier=None: {"ok": True, "email": "x@y"},
     )
 
     class _FakeMonitor:
@@ -816,7 +836,7 @@ def test_gws_exchange_refreshes_health_monitor(tmp_path, monkeypatch):
     monkeypatch.setattr(monitor_cls, "check_once", loud)
     monkeypatch.setattr(
         ciao.gws_auth, "exchange_and_store",
-        lambda config, profile, *, code, redirect_uri: {"ok": True, "email": "x@y"},
+        lambda config, profile, *, code, redirect_uri, code_verifier=None: {"ok": True, "email": "x@y"},
     )
 
     resp = client.post(
@@ -824,6 +844,98 @@ def test_gws_exchange_refreshes_health_monitor(tmp_path, monkeypatch):
         json={"profile": "personal", "code": "test-code"},
     )
     assert resp.status_code == 200
+
+
+def test_gws_exchange_rejects_expired_pkce_flow_with_actionable_error(tmp_path, monkeypatch):
+    """A verifier that expired between auth-url and paste-back must fail
+    loudly with a "restart the flow" message (issue #354 code review) —
+    Google is still holding a code_challenge for this profile, so silently
+    omitting code_verifier would surface a confusing invalid_grant instead.
+    """
+    from ciao import gws_auth
+    from ciao.web import routes_api
+
+    client, _config, _pcm = _client(tmp_path)
+    config_dir = routes_api._gws_profile_config_dir(_config, "personal")
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "client_secret.json").write_text(
+        json.dumps(
+            {
+                "installed": {
+                    "client_id": "cid",
+                    "client_secret": "csecret",
+                    "redirect_uris": ["http://localhost"],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    resp = client.post("/api/integrations/gws/auth-url", json={"profile": "personal"})
+    assert resp.status_code == 200
+
+    # Simulate the TTL elapsing before the user pastes the code back.
+    store = client.app.state.gws_manual_pkce_store
+    for profile, (verifier, _expires_at) in list(store._pending.items()):
+        store._pending[profile] = (verifier, 0.0)
+
+    exchange_called = False
+
+    def unexpected_exchange(*args, **kwargs):
+        nonlocal exchange_called
+        exchange_called = True
+        return {"ok": True, "email": "should-not-be-reached@example.com"}
+
+    monkeypatch.setattr(gws_auth, "exchange_and_store", unexpected_exchange)
+
+    resp = client.post(
+        "/api/integrations/gws/exchange",
+        json={"profile": "personal", "code": "http://localhost/?code=stale-code"},
+    )
+    assert resp.status_code == 400
+    assert "expired" in resp.json()["error"].lower()
+    assert exchange_called is False
+
+
+def test_gws_exchange_without_a_pending_pkce_flow_omits_verifier(tmp_path, monkeypatch):
+    """A profile that never called auth-url through this store (legacy
+    client, or a flow superseded by a later start) must still exchange
+    normally, with no code_verifier sent — the same behavior as before PKCE
+    existed."""
+    from ciao import gws_auth
+    from ciao.web import routes_api
+
+    client, _config, _pcm = _client(tmp_path)
+    config_dir = routes_api._gws_profile_config_dir(_config, "personal")
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "client_secret.json").write_text(
+        json.dumps(
+            {
+                "installed": {
+                    "client_id": "cid",
+                    "client_secret": "csecret",
+                    "redirect_uris": ["http://localhost"],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    captured: dict = {}
+
+    def fake_exchange(config, profile, *, code, redirect_uri, code_verifier=None):
+        captured["code_verifier"] = code_verifier
+        return {"ok": True, "email": "x@example.com"}
+
+    monkeypatch.setattr(gws_auth, "exchange_and_store", fake_exchange)
+
+    # No prior call to /auth-url for this profile.
+    resp = client.post(
+        "/api/integrations/gws/exchange",
+        json={"profile": "personal", "code": "http://localhost/?code=some-code"},
+    )
+    assert resp.status_code == 200
+    assert captured["code_verifier"] is None
 
 
 def test_gws_profile_payload_uses_granted_scopes_for_chips_and_purpose(tmp_path):

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -2030,6 +2030,7 @@ import SettingsAutomation from './settings/SettingsAutomation.vue'
 import SettingsNotifications from './settings/SettingsNotifications.vue'
 import DevicePanel from './DevicePanel.vue'
 import { sectionsFromModelsResponse, type ModelSection } from '../lib/modelSections'
+import { isGwsEngineHostEligible } from '../lib/gwsEngineHost'
 import { useReentrySummaryPreference } from '../composables/useReentrySummaryPreference'
 
 // The tray owns package updates and native notifications in the desktop app.
@@ -2990,9 +2991,11 @@ function gwsReloginHelpUrl(): string {
 // the client's own loopback and never arrive — those users must use the
 // manual paste flow instead.
 function gwsOnEngineHost(): boolean {
-  if (inDesktopApp && !isNodeClient.value) return true
-  const host = window.location.hostname
-  return !isNodeClient.value && (host === 'localhost' || host === '127.0.0.1' || host === '[::1]')
+  return isGwsEngineHostEligible(window.location.hostname, inDesktopApp, {
+    loaded: nodeStatusLoaded.value,
+    error: nodeStatusError.value,
+    isClient: isNodeClient.value,
+  })
 }
 
 async function gwsReloginStart(profileName: string) {
@@ -4323,6 +4326,11 @@ async function saveAuthSettings() {
 // just enough to answer "whose settings am I editing": in client mode every
 // other card on this page is served by the host through the tunnel.
 const nodeStatus = ref<NodeStatus | null>(null)
+// Tri-state signal for gwsOnEngineHost (issue #351): nodeStatus reading null
+// is ambiguous between "still loading" and "the fetch failed", and both must
+// not be silently treated as a confirmed host role off a loopback hostname.
+const nodeStatusLoaded = ref(false)
+const nodeStatusError = ref(false)
 
 const isNodeClient = computed(() => {
   const role = nodeStatus.value?.role
@@ -4343,8 +4351,12 @@ const hostScopeLabel = computed(() => {
 async function fetchNodeStatus() {
   try {
     nodeStatus.value = await api.get<NodeStatus>('/api/node/status')
+    nodeStatusError.value = false
   } catch {
     /* leave null on failure: cards then read as host-mode, which is the default */
+    nodeStatusError.value = true
+  } finally {
+    nodeStatusLoaded.value = true
   }
 }
 

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -2965,6 +2965,7 @@ async function installGwsInChat() {
 
 const gwsSavingProfile = ref<string | null>(null)
 const gwsAuthUrls = ref<Record<string, string>>({})
+const gwsAuthFlowIds = ref<Record<string, string>>({})
 const gwsRedirectUrls = ref<Record<string, string>>({})
 
 // One-click "Sign in with Google" loopback flow (issue #145). Tracks, per
@@ -3039,6 +3040,7 @@ function gwsClearRelogin(profileName: string) {
   // it keeps the card out of a stale manual-flow state and un-hides the
   // authenticated controls on success.
   delete gwsAuthUrls.value[profileName]
+  delete gwsAuthFlowIds.value[profileName]
   delete gwsRedirectUrls.value[profileName]
 }
 
@@ -3129,10 +3131,11 @@ async function startGwsAuth(profileName: string) {
   delete gwsReloginError.value[profileName]
   delete gwsReloginPending.value[profileName]
   try {
-    const res = await api.post<{ auth_url: string }>('/api/integrations/gws/auth-url', {
+    const res = await api.post<{ auth_url: string; flow_id: string }>('/api/integrations/gws/auth-url', {
       profile: profileName,
     })
     gwsAuthUrls.value[profileName] = res.auth_url
+    gwsAuthFlowIds.value[profileName] = res.flow_id
     gwsRedirectUrls.value[profileName] = ''
     window.open(res.auth_url, '_blank')
   } catch (e) {
@@ -3151,9 +3154,11 @@ async function exchangeGwsCode(profileName: string) {
     const updated = await api.post<GwsIntegrationSettings>('/api/integrations/gws/exchange', {
       profile: profileName,
       code: code,
+      flow_id: gwsAuthFlowIds.value[profileName],
     })
     gwsIntegration.value = updated
     delete gwsAuthUrls.value[profileName]
+    delete gwsAuthFlowIds.value[profileName]
     delete gwsRedirectUrls.value[profileName]
   } catch (e) {
     notifyFailed('Could not complete the connection', errorMessage(e, 'The request failed.'))
@@ -3164,6 +3169,7 @@ async function exchangeGwsCode(profileName: string) {
 
 function cancelGwsAuth(profileName: string) {
   delete gwsAuthUrls.value[profileName]
+  delete gwsAuthFlowIds.value[profileName]
   delete gwsRedirectUrls.value[profileName]
 }
 

--- a/web/src/lib/gwsEngineHost.test.ts
+++ b/web/src/lib/gwsEngineHost.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'vitest'
+import { isGwsEngineHostEligible, type GwsNodeStatusKnowledge } from './gwsEngineHost'
+
+function status(overrides: Partial<GwsNodeStatusKnowledge> = {}): GwsNodeStatusKnowledge {
+  return { loaded: true, error: false, isClient: false, ...overrides }
+}
+
+describe('isGwsEngineHostEligible (issue #351)', () => {
+  test('fetch failure off a loopback hostname is ineligible, not fail-open', () => {
+    expect(
+      isGwsEngineHostEligible('192.168.1.20', false, status({ loaded: true, error: true, isClient: false })),
+    ).toBe(false)
+  })
+
+  test('fetch failure on localhost stays eligible (single-machine case)', () => {
+    expect(
+      isGwsEngineHostEligible('localhost', false, status({ loaded: true, error: true, isClient: false })),
+    ).toBe(true)
+  })
+
+  test('still loading, off a loopback hostname, is ineligible', () => {
+    expect(
+      isGwsEngineHostEligible('phone.lan', false, status({ loaded: false, error: false, isClient: false })),
+    ).toBe(false)
+  })
+
+  test('still loading, on localhost, stays eligible', () => {
+    expect(
+      isGwsEngineHostEligible('localhost', false, status({ loaded: false, error: false, isClient: false })),
+    ).toBe(true)
+  })
+
+  test('a confirmed client role is ineligible even on localhost', () => {
+    expect(
+      isGwsEngineHostEligible('localhost', false, status({ loaded: true, error: false, isClient: true })),
+    ).toBe(false)
+  })
+
+  test('a confirmed host role on localhost is eligible', () => {
+    expect(
+      isGwsEngineHostEligible('127.0.0.1', false, status({ loaded: true, error: false, isClient: false })),
+    ).toBe(true)
+  })
+
+  test('a confirmed host role off localhost is ineligible (LAN browser)', () => {
+    expect(
+      isGwsEngineHostEligible('192.168.1.20', false, status({ loaded: true, error: false, isClient: false })),
+    ).toBe(false)
+  })
+
+  test('desktop app while still loading is eligible without a loopback check', () => {
+    expect(
+      isGwsEngineHostEligible('localhost', true, status({ loaded: false, error: false, isClient: false })),
+    ).toBe(true)
+  })
+
+  test('desktop app with a confirmed client role is still ineligible', () => {
+    expect(
+      isGwsEngineHostEligible('localhost', true, status({ loaded: true, error: false, isClient: true })),
+    ).toBe(false)
+  })
+
+  test('desktop app off a loopback hostname with unresolved status is ineligible', () => {
+    expect(
+      isGwsEngineHostEligible('192.168.1.20', true, status({ loaded: true, error: true, isClient: false })),
+    ).toBe(false)
+  })
+})

--- a/web/src/lib/gwsEngineHost.ts
+++ b/web/src/lib/gwsEngineHost.ts
@@ -1,0 +1,43 @@
+/**
+ * Eligibility for the GWS one-click loopback re-login (issue #145), pulled
+ * out of SettingsView's `gwsOnEngineHost` so the guard is testable on its
+ * own — see that function for how it is wired up to `window.location` and
+ * the node-status refs.
+ *
+ * The loopback re-login listener binds to the *engine's* 127.0.0.1, so the
+ * consent redirect only reaches it when the browser is on the engine host
+ * (localhost) and the integration API is not proxied to a remote host. From a
+ * phone, LAN browser, or client-mode node the popup's redirect would target
+ * the client's own loopback and never arrive — those users must use the
+ * manual paste flow instead.
+ */
+
+/** What SettingsView currently knows about `/api/node/status`. */
+export interface GwsNodeStatusKnowledge {
+  /** Whether the status fetch has settled (succeeded or failed). */
+  loaded: boolean
+  /** Whether that fetch failed. */
+  error: boolean
+  /** The resolved role. False (host-mode) until `loaded` is true. */
+  isClient: boolean
+}
+
+/**
+ * issue #351: node status unknown — not yet loaded, or the fetch failed —
+ * reads as host-mode (`isClient: false`) by default. That default is
+ * harmless on a loopback hostname, where the checks below still apply, but
+ * off a loopback hostname it must not be read as "confirmed not a client":
+ * a phone/LAN/client-mode browser would otherwise pass the guard on a
+ * transient fetch failure, bind the listener on the wrong loopback, and time
+ * out five minutes later. Fail closed instead.
+ */
+export function isGwsEngineHostEligible(
+  hostname: string,
+  inDesktopApp: boolean,
+  status: GwsNodeStatusKnowledge,
+): boolean {
+  const isLoopbackHost = hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]'
+  if ((!status.loaded || status.error) && !isLoopbackHost) return false
+  if (inDesktopApp && !status.isClient) return true
+  return !status.isClient && isLoopbackHost
+}


### PR DESCRIPTION
Clears the four issues deferred from the v0.11.0 pre-release review. One commit per issue; the sub-items those issues themselves mark obsolete (352's sidecar totals and atomic trim, 354's TTL cache) were confirmed already fixed and left alone.

## #351 — GWS one-click guard fails open

`gwsOnEngineHost` read eligibility off `isNodeClient`, which is false both while `/api/node/status` is in flight and when that fetch fails, so a transient failure was indistinguishable from a confirmed host role. In client mode the one-click button then bound the relogin listener on the host's loopback while the redirect targeted the client's own 127.0.0.1, and the flow sat until the 5-minute timeout.

The guard now tracks whether the fetch settled and whether it failed, and treats unknown status off a loopback hostname as ineligible. Loopback hostnames keep the previous behaviour, so the desktop app and the single-machine case still work while status is loading. The manual paste path was already offered unconditionally, so the closed guard leaves no dead end. Logic moved to `web/src/lib/gwsEngineHost.ts` to be testable without mounting SettingsView.

## #352 — proposal_outcomes hardening

- `record()` now whitelists `via` against `("pwa", "agent")` and requires `is_extraction_kind(kind)`. All five call sites already gate both, so nothing recorded today is dropped.
- `tally_cached()` is guarded by a `threading.Lock` (the in-memory dict is a thread-level race, distinct from the fcntl file lock over the on-disk log), and `configure()` invalidates it so a runtime-dir change cannot serve a tally from the previous directory.
- Log, lock and rotation archives are created 0600 rather than at the umask default, following `ciao/jsonio.py` (whose helper is truncate-only, so this needed an append-capable variant).
- Adds multi-thread append, rotation-during-tally and truncated-final-line tests.

## #353 — two-character tag merge noise

The edit-distance checks now require three characters. At two characters there are only 676 possible tags, so a one-edit near miss is coincidence rather than a typo. The separator/namespace branch is deliberately left ungated so `ai` still merges with `ai-analysis`. Three rather than four because `data`/`java` is distance 2 and already excluded by the existing rule.

Also moves the deferred `scan_targets` import to the top level (`ciao/vault_index.py` imports nothing from `ciao`, so there was no circular-import reason) and drops a re-wrap of values `vault_scan_targets()` already returns as `Path`.

## #354 — PKCE for manual OAuth, old-CLI detection

The manual paste flows carry no `state` and can validate none on paste-back, since the user rather than the browser carries the code across the trust boundary. Adds PKCE (RFC 7636 S256): optional `code_challenge` on `build_auth_url`, optional `code_verifier` on the exchange, both sent only when supplied so an auth URL built before this change exchanges exactly as before.

`ManualPkceStore` carries the verifier from the auth-url call to the exchange, keyed by profile, held an hour. An expired entry is tombstoned rather than deleted so the exchange can tell "Google is holding a challenge and the verifier is gone" from "no PKCE flow was pending" and return an actionable error rather than forwarding a request Google would reject as `invalid_grant`. A server restart between the two requests reads as the latter and falls back to Google's own error; a persistent store seemed disproportionate for that window. The headless helper needs no store (one synchronous process); the loopback flow gets a verifier as defence in depth on top of the `state` it already validates.

Separately, a Claude CLI predating `claude auth status` was reported as signed out, sending the user to re-authenticate against a command that cannot exist. That shape is now detected and reported as too old, still failing closed, using the existing `detail` field the PWA already renders verbatim.

## Verification

- `pytest tests/` — 3036 passed, 0 failed, on the rebased tree
- `cd web && npm run build` — clean
- `cd web && npm test` — 76 files, 862 passed

## Review notes

Two defects were caught during review of the #354 work and fixed before this PR:

- A verifier expiring, or the server restarting, made the exchange silently omit `code_verifier` while Google still held a challenge, turning a merely slow paste-back into a cryptic `invalid_grant` — a regression on the exact flow the issue is about. Hence the raised TTL and the expired/never-started distinction.
- The new expiry error told the user to click "Get authorization URL", which is not a control that exists; the real one is "Manual connect (paste code)".