### PR TITLE
fix(chat): ensure answer displays without opening Activity view

### DIFF
--- a/web/src/stores/projects.ts
+++ b/web/src/stores/projects.ts
@@ -1882,7 +1882,9 @@ export const useProjectStore = defineStore('projects', () => {
 
   async function syncLatest() {
     if (latestSyncInFlight) return
-    if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return
+    // Do not gate on visibility — answers must appear in the active chat
+    // even while the tab is hidden, otherwise the reply stays invisible
+    // until the user opens the Activity view (visibilitychange).
     latestSyncInFlight = true
     try {
       // Active-only: the server skips the (possibly thousands of) archived
@@ -3964,6 +3966,12 @@ export const useProjectStore = defineStore('projects', () => {
         api.get<ChatInfo[]>('/api/chats?active_only=1')
           .then(c => reconcileActiveChats(c))
           .catch(() => { /* ignore */ })
+        // Ensure the active chat's transcript refreshes even when the tab is
+        // hidden — otherwise the answer stays invisible until the user opens
+        // the Activity view (which fires a visibilitychange).
+        if (msg.chat_id === activeChatId.value) {
+          void reconcileAfterResult(msg.chat_id)
+        }
         break
       }
       case 'chat_subagents_ready': {


### PR DESCRIPTION
### Problem
Sometimes Ciaobot doesn't show the answer unless the Activity view is opened. Occurs when a turn finishes while the PWA tab is hidden/background.

**Root cause:**
- `syncLatest()` (15s fallback poll) returned early when `document.visibilityState !== 'visible'` (`web/src/stores/projects.ts:1885`)
- `chat_result_ready` only refreshed the chat list, not `activeChatId` messages, so transcript stayed stale until next `visibilitychange`

### Fix
- Remove visibility gate from `syncLatest` so active chat transcript always refreshes.
- In `chat_result_ready` always `reconcileAfterResult(activeChatId)` when result belongs to active chat.

Closes the Activity-tab visibility bug. Tested: `chatActivity.test.ts` 27 passed, `projects.test.ts` 168 passed.