### PR TITLE
refactor(web): proposal-kind descriptor registry (#382 P2)

### DIFF
--- a/web/src/components/ProjectSidebar.vue
+++ b/web/src/components/ProjectSidebar.vue
@@ -1154,6 +1154,7 @@ import { colorForWorkspace } from '../lib/workspaceColors'
 import { ARCHIVE_CONFIRM_MESSAGE, ARCHIVE_MENU_LABEL } from '../lib/archiveCopy'
 import { askConfirm } from '../lib/confirm'
 import { workspaceLabel } from '../lib/workspaceLabel'
+import { kindLabel as reviewKindLabel } from '../lib/proposalKinds'
 import { askPrompt } from '../lib/prompt'
 import { writeClipboard } from '../lib/codeCopy'
 import { formatFileComments } from '../lib/commentContext'
@@ -1185,21 +1186,6 @@ onMounted(() => {
   void proposals.ensureLoaded()
 })
 
-const REVIEW_KIND_LABELS: Record<string, string> = {
-  memory: 'memory',
-  profile: 'profile',
-  user: 'profile',
-  rehome: 're-home',
-  project: 'project',
-  people: 'people',
-  learnings: 'learnings',
-  review: 'review',
-  skill: 'skill',
-}
-
-function reviewKindLabel(kind: string): string {
-  return REVIEW_KIND_LABELS[kind] ?? kind
-}
 // The unlinked list is the one section that can run to hundreds of entries on a
 // real vault, so it grows on demand rather than pushing every other section off
 // the bottom of the sidebar.

--- a/web/src/components/ProposalReviewPanel.vue
+++ b/web/src/components/ProposalReviewPanel.vue
@@ -4,6 +4,8 @@ import { useProposalsStore } from '../stores/proposals'
 import { useProjectStore } from '../stores/projects'
 import { useFileViewerStore } from '../stores/fileViewer'
 import type { ProposalRow } from '../lib/types'
+import { descriptorFor, kindLabel, rehomeMode } from '../lib/proposalKinds'
+import type { ProposalMergeFallback } from '../lib/proposalKinds'
 
 const store = useProposalsStore()
 const projectStore = useProjectStore()
@@ -203,22 +205,6 @@ const groups = computed(() => {
 })
 
 
-const KIND_LABELS: Record<string, string> = {
-  memory: 'memory',
-  profile: 'profile',
-  user: 'profile',
-  rehome: 're-home',
-  project: 'project',
-  people: 'people',
-  learnings: 'learnings',
-  review: 'review',
-  skill: 'skill',
-}
-
-function kindLabel(kind: string): string {
-  return KIND_LABELS[kind] ?? kind
-}
-
 /** The one line that says what this row is about.
  *
  * A re-home bullet is a paragraph of prose that reprints both paths and a CLI
@@ -234,35 +220,13 @@ function rowTitle(row: ProposalRow): string {
   return row.text
 }
 
+/** The line under the title: where an accept would write.
+ *
+ * Every kind's answer lives in its descriptor, including the re-home row's
+ * `from → to · why` form and the skill row's path.
+ */
 function rowSubtitle(row: ProposalRow): string {
-  if (isRehome(row)) {
-    const sig = row.rehome
-    const from = row.workspace
-    if (sig?.candidates?.length && sig.candidates.length > 1) {
-      return `${from} → ${sig.candidates.join(' or ')} · tags name more than one`
-    }
-    if (sig?.destination) {
-      const to = sig.destination.split('/')[0]
-      return sig.justified
-        ? `${from} → ${to} · tags back this`
-        : `${from} → ${to} · no tag backs it`
-    }
-    // A stale row is not asking anything: its cause is gone. Saying "needs a
-    // decision" made litter look identical to a real question.
-    if (sig?.stale) return `${from} · no longer applies · safe to dismiss`
-    return `${from} · no destination, needs a decision`
-  }
-  // The path, not the words "a skill proposal file". The row's whole content is
-  // in that file, and naming it is what makes "view" obviously the first thing
-  // to press.
-  if (isSkill(row)) return row.path || 'a skill proposal file'
-  // Destination kinds name where an accept writes, so say that instead of the
-  // generic region form.
-  if (row.kind === 'project') return row.target || 'no project doc named'
-  if (row.kind === 'people') return `People/${row.target || '?'}.md`
-  if (row.kind === 'learnings') return 'Workspace/Learnings.md'
-  if (row.kind === 'review') return 'no destination yet — decide what it is'
-  return `ciao:${row.region ?? row.kind}`
+  return descriptorFor(row).destination(row)
 }
 
 /** The verbose original, kept behind a disclosure rather than on the surface. */
@@ -271,17 +235,9 @@ function rowDetail(row: ProposalRow): string {
   return row.source ? `from ${row.source}` : ''
 }
 
-/** Whether an accept can do what it says.
- *
- * A skill row has no accept descriptor on the server, a re-home row with no
- * backed destination has nowhere to go, and a review row has no known
- * destination at all — accepting one would be a guess wearing a button.
- */
+/** Whether an accept can do what it says. Each kind's descriptor decides. */
 function canAccept(row: ProposalRow): boolean {
-  if (isSkill(row)) return false
-  if (isRehome(row)) return rehomeMode(row) === 'accept'
-  if (row.kind === 'review') return false
-  return true
+  return descriptorFor(row).canAccept(row)
 }
 
 const allSelected = computed(() =>
@@ -329,27 +285,12 @@ const selectedAcceptable = computed(
   () => selectedVisible.value.filter(canAccept).map(r => r.id),
 )
 
-function isRegionKind(row: ProposalRow): boolean {
-  return row.kind === 'memory' || row.kind === 'profile' || row.kind === 'user'
-}
-
 function isRehome(row: ProposalRow): boolean {
   return row.kind === 'rehome'
 }
 
 function isSkill(row: ProposalRow): boolean {
   return row.kind === 'skill'
-}
-
-// How a rehome row is presented. Never a pre-filled one-click accept for a
-// destination no tag backs: a single clean signal is a plain accept, multiple
-// candidates are a picker, and no signal is a question.
-function rehomeMode(row: ProposalRow): 'accept' | 'picker' | 'question' {
-  const sig = row.rehome
-  if (!sig) return 'question'
-  if (sig.candidates.length > 1) return 'picker'
-  if (sig.justified) return 'accept'
-  return 'question'
 }
 
 async function confirmAccept(row: ProposalRow) {
@@ -359,21 +300,22 @@ async function confirmAccept(row: ProposalRow) {
     confirmLeakId.value = row.id
     return
   }
-  await acceptWithPeopleFallback(row)
+  await acceptWithFallback(row)
 }
 
 async function doAccept(row: ProposalRow, workspace = '') {
   confirmLeakId.value = ''
-  await acceptWithPeopleFallback(row, workspace)
+  await acceptWithFallback(row, workspace)
 }
 
-async function acceptWithPeopleFallback(row: ProposalRow, workspace = '') {
+async function acceptWithFallback(row: ProposalRow, workspace = '') {
   // Direct accept is best-effort by design – create-only for people
   // (`ciao/memory_proposals.py:348` + `ciao/web/routes_api.py:7559`),
   // fold-guard for projects (`ciao/web/routes_api.py:7602`), cap/region
   // for memory (`ciao/web/routes_api.py:7518`). When it refuses, falling
   // back to a chat that merges keeps the prompt self-contained and nothing
-  // breaks – the row stays queued until the merge lands.
+  // breaks – the row stays queued until the merge lands. Which refusals are
+  // expected, and what the merge chat is told, is the kind's descriptor.
   const { api } = await import('../lib/api')
   store.setBusy(row.id, true)
   try {
@@ -383,13 +325,9 @@ async function acceptWithPeopleFallback(row: ProposalRow, workspace = '') {
     return
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e)
-    const isFallbackCase =
-      row.kind === 'people' && /already exists/i.test(msg) ||
-      row.kind === 'project' ||
-      row.kind === 'memory' || row.kind === 'profile' || row.kind === 'user' ||
-      row.kind === 'learnings'
-    if (isFallbackCase) {
-      await mergeViaChat(row, msg)
+    const fallback = descriptorFor(row).fallback
+    if (fallback && fallback.when(msg)) {
+      await mergeViaChat(row, msg, fallback)
       return
     }
     store.error = msg
@@ -399,113 +337,28 @@ async function acceptWithPeopleFallback(row: ProposalRow, workspace = '') {
   }
 }
 
-async function mergeViaChat(row: ProposalRow, errorMsg: string) {
-  // Reuse the people-specific helper for its title, otherwise generic.
-  if (row.kind === 'people') return mergePeopleViaChat(row)
-  if (row.kind === 'project') return mergeProjectViaChat(row, errorMsg)
-  if (row.kind === 'memory' || row.kind === 'profile' || row.kind === 'user') return mergeMemoryViaChat(row, errorMsg)
-  if (row.kind === 'learnings') return mergeLearningsViaChat(row, errorMsg)
-  return mergePeopleViaChat(row)
-}
-
-async function mergePeopleViaChat(row: ProposalRow) {
+/** Hand a refused accept to a background chat that can merge it by hand.
+ *
+ * One function for every kind: the four that existed differed only in the chat
+ * title, the toast detail and the prompt, all three of which the descriptor now
+ * supplies.
+ */
+async function mergeViaChat(row: ProposalRow, errorMsg: string, fallback: ProposalMergeFallback) {
   if (chatBusy.value) return
   chatBusy.value = true
   try {
-    const chat = await openWorkspaceChatInBackground(row.workspace, `Merge ${row.target || 'person'} fact`, resolutionHelper(row.id))
+    const chat = await openWorkspaceChatInBackground(
+      row.workspace,
+      fallback.chatTitle(row),
+      resolutionHelper(row.id),
+    )
     if (!chat) return
     linkProposal(row.id, chat.chat_id)
-    projectStore.sendMessage(chat.chat_id, peopleMergePrompt(row))
-    pushBackgroundToast(chat.chat_id, 'Merging in background', `${row.target || 'Person'} fact — click to open the chat`)
+    projectStore.sendMessage(chat.chat_id, fallback.prompt(row, errorMsg))
+    pushBackgroundToast(chat.chat_id, 'Merging in background', fallback.toastDetail(row))
   } finally {
     chatBusy.value = false
   }
-}
-
-async function mergeProjectViaChat(row: ProposalRow, errorMsg: string) {
-  if (chatBusy.value) return
-  chatBusy.value = true
-  try {
-    const chat = await openWorkspaceChatInBackground(row.workspace, `Merge project fact`, resolutionHelper(row.id))
-    if (!chat) return
-    linkProposal(row.id, chat.chat_id)
-    projectStore.sendMessage(chat.chat_id, projectMergePrompt(row, errorMsg))
-    pushBackgroundToast(chat.chat_id, 'Merging in background', 'Project fact — click to open the chat')
-  } finally {
-    chatBusy.value = false
-  }
-}
-
-async function mergeMemoryViaChat(row: ProposalRow, errorMsg: string) {
-  if (chatBusy.value) return
-  chatBusy.value = true
-  try {
-    const chat = await openWorkspaceChatInBackground(row.workspace, `Merge memory fact`, resolutionHelper(row.id))
-    if (!chat) return
-    linkProposal(row.id, chat.chat_id)
-    projectStore.sendMessage(chat.chat_id, memoryMergePrompt(row, errorMsg))
-    pushBackgroundToast(chat.chat_id, 'Merging in background', 'Memory fact — click to open the chat')
-  } finally {
-    chatBusy.value = false
-  }
-}
-
-async function mergeLearningsViaChat(row: ProposalRow, errorMsg: string) {
-  if (chatBusy.value) return
-  chatBusy.value = true
-  try {
-    const chat = await openWorkspaceChatInBackground(row.workspace, `Merge learning`, resolutionHelper(row.id))
-    if (!chat) return
-    linkProposal(row.id, chat.chat_id)
-    projectStore.sendMessage(chat.chat_id, learningsMergePrompt(row, errorMsg))
-    pushBackgroundToast(chat.chat_id, 'Merging in background', 'Learning — click to open the chat')
-  } finally {
-    chatBusy.value = false
-  }
-}
-
-function peopleMergePrompt(row: ProposalRow): string {
-  const target = row.target || '?'
-  const where = `queued in the ${row.workspace} workspace`
-  return (
-    `A \`[people ${target}]\` proposal is queued (${where}) but \`People/${target}.md\` already exists, so a direct accept correctly refused to overwrite it. Work in this chat only; do not delegate this helper task.\n\n` +
-    `Fact to merge: ${row.text}\n\n` +
-    `Read \`People/${target}.md\` in the ${row.workspace} vault, merge this fact into it without duplicating anything already there (keep \`tags: [person]\`, add a sentence under the heading or appropriate section), and write it back.\n\n` +
-    `After the note is updated, dismiss the queued proposal that contains this exact text by running \`ciao memory-proposal-dismiss "<substring>" --promoted\` so it disappears from Review (the flag records the promotion; do not delete the bullet from the file directly — that skips the outcome log). ` +
-    `If the fact is already present verbatim, just dismiss the proposal. Leave other proposals untouched. Nothing is broken – this is the expected merge path for existing person notes.`
-  )
-}
-
-function projectMergePrompt(row: ProposalRow, errorMsg: string): string {
-  const target = row.target || 'the project doc'
-  const where = `queued in the ${row.workspace} workspace`
-  return (
-    `A \`[project ${target}]\` proposal is queued (${where}) but direct accept refused: ${errorMsg}\n\nWork in this chat only; do not delegate this helper task.\n\n` +
-    `Fact to merge: ${row.text}\n\n` +
-    `Read \`${target}\` (vault-relative, in the ${row.workspace} workspace), merge this fact into the appropriate section without duplicating existing content, and write it back. Keep frontmatter and structure intact.\n\n` +
-    `After the doc is updated, dismiss the queued proposal that contains this exact text by running \`ciao memory-proposal-dismiss "<substring>" --promoted\`. If the fact is already covered, run the same command without \`--promoted\`. Do not delete the bullet from the file directly — that skips the outcome log. Leave other proposals untouched. Nothing is broken – this is the expected merge path when the fold guards refuse.`
-  )
-}
-
-function memoryMergePrompt(row: ProposalRow, errorMsg: string): string {
-  const region = row.region || row.kind
-  const where = `queued in the ${row.workspace} workspace`
-  return (
-    `A \`[${row.kind}]\` proposal is queued (${where}) for region \`${region}\` but direct accept refused: ${errorMsg}\n\nWork in this chat only; do not delegate this helper task.\n\n` +
-    `Fact to merge: ${row.text}\n\n` +
-    `Read \`${row.workspace}/CLAUDE.md\` bounded region \`${region}\`, merge this fact there without duplication and within the char limit – curate/consolidate nearby bullets if needed to make room, never exceed the cap.\n\n` +
-    `After the region is updated, dismiss the queued proposal that contains this exact text by running \`ciao memory-proposal-dismiss "<substring>" --promoted\` (do not delete the bullet from the file directly — that skips the outcome log). If the fact is already present verbatim, just dismiss. Leave other proposals untouched. Nothing is broken – this is the expected path when the region is over cap or needs curation.`
-  )
-}
-
-function learningsMergePrompt(row: ProposalRow, errorMsg: string): string {
-  const where = `queued in the ${row.workspace} workspace`
-  return (
-    `A \`[learnings]\` proposal is queued (${where}) but direct accept refused: ${errorMsg}\n\nWork in this chat only; do not delegate this helper task.\n\n` +
-    `Fact to merge: ${row.text}\n\n` +
-    `Read \`Workspace/Learnings.md\` in the ${row.workspace} vault, append this fact under \`## Active\` without duplication, and write it back.\n\n` +
-    `After the file is updated, dismiss the queued proposal that contains this exact text by running \`ciao memory-proposal-dismiss "<substring>" --promoted\` (do not delete the bullet from the file directly — that skips the outcome log). If the fact is already present, just dismiss. Leave other proposals untouched.`
-  )
 }
 
 /** The workspace a justified re-home row would move into. */
@@ -660,9 +513,7 @@ function discussPrompt(row: ProposalRow): string {
       'Leave the proposal queued either way; I will accept or dismiss it myself.'
     )
   }
-  const about = row.kind === 'review'
-    ? 'a fact with no decided destination'
-    : `a \`${row.kind}\` proposal`
+  const about = descriptorFor(row).discussLabel(row)
   return (
     `${about} is waiting for a decision (${where}): ${row.text}\n\n` +
     'Tell me whether this is durable and cross-session enough to keep, and where it ' +

--- a/web/src/lib/proposalKinds.test.ts
+++ b/web/src/lib/proposalKinds.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from 'vitest'
+import {
+  GENERIC,
+  PROPOSAL_KINDS,
+  descriptorFor,
+  kindLabel,
+  rehomeMode,
+} from './proposalKinds'
+import type { ProposalRow, RehomeSignal } from './types'
+
+function row(over: Partial<ProposalRow> = {}): ProposalRow {
+  return {
+    id: 'p1',
+    kind: 'memory',
+    text: 'a durable fact',
+    source: 'chat',
+    workspace: 'work',
+    path: '',
+    line: 1,
+    ...over,
+  }
+}
+
+function signal(over: Partial<RehomeSignal> = {}): RehomeSignal {
+  return {
+    note: 'People/Mo.md',
+    destination: '',
+    candidates: [],
+    justified: false,
+    reason: 'tagged',
+    ...over,
+  }
+}
+
+describe('descriptorFor', () => {
+  it('falls back to GENERIC for a kind this client does not know', () => {
+    // A server newer than the client must not render a blank row or crash.
+    expect(descriptorFor(row({ kind: 'something-new' }))).toBe(GENERIC)
+    expect(descriptorFor(row({ kind: 'something-new', region: 'r' })).destination(
+      row({ kind: 'something-new', region: 'r' }),
+    )).toBe('ciao:r')
+  })
+
+  it('resolves every kind the server can send', () => {
+    for (const kind of ['memory', 'profile', 'user', 'people', 'project', 'learnings', 'review', 'rehome', 'skill']) {
+      expect(descriptorFor(row({ kind }))).not.toBe(GENERIC)
+    }
+  })
+})
+
+describe('kindLabel', () => {
+  it('shows both spellings of the profile region as one thing', () => {
+    // `user` is the server's older name for the same region.
+    expect(kindLabel('profile')).toBe('profile')
+    expect(kindLabel('user')).toBe('profile')
+  })
+
+  it('hyphenates re-home and passes an unknown kind through raw', () => {
+    expect(kindLabel('rehome')).toBe('re-home')
+    expect(kindLabel('something-new')).toBe('something-new')
+  })
+})
+
+describe('destination', () => {
+  it('names where an accept writes, per kind', () => {
+    const cases: Array<[Partial<ProposalRow>, string]> = [
+      [{ kind: 'memory', region: 'memory' }, 'ciao:memory'],
+      [{ kind: 'people', target: 'Mo' }, 'People/Mo.md'],
+      [{ kind: 'people' }, 'People/?.md'],
+      [{ kind: 'project', target: 'Projects/Thing.md' }, 'Projects/Thing.md'],
+      [{ kind: 'project' }, 'no project doc named'],
+      [{ kind: 'learnings' }, 'Workspace/Learnings.md'],
+      [{ kind: 'review' }, 'no destination yet — decide what it is'],
+      [{ kind: 'skill', path: 'skills/thing/SKILL.md' }, 'skills/thing/SKILL.md'],
+      [{ kind: 'skill' }, 'a skill proposal file'],
+    ]
+    for (const [over, expected] of cases) {
+      const r = row(over)
+      expect(descriptorFor(r).destination(r)).toBe(expected)
+    }
+  })
+
+  it('reads a re-home row destination off its signal', () => {
+    const justified = row({
+      kind: 'rehome',
+      rehome: signal({ destination: 'personal/People/Mo.md', justified: true, candidates: ['personal'] }),
+    })
+    expect(descriptorFor(justified).destination(justified)).toBe('work → personal · tags back this')
+
+    const unbacked = row({
+      kind: 'rehome',
+      rehome: signal({ destination: 'personal/People/Mo.md', justified: false, candidates: [] }),
+    })
+    expect(descriptorFor(unbacked).destination(unbacked)).toBe('work → personal · no tag backs it')
+
+    const ambiguous = row({
+      kind: 'rehome',
+      rehome: signal({ destination: '', justified: false, candidates: ['personal', 'side'] }),
+    })
+    expect(descriptorFor(ambiguous).destination(ambiguous)).toBe(
+      'work → personal or side · tags name more than one',
+    )
+
+    // A stale row is litter, not a question — it must not read as one.
+    const stale = row({
+      kind: 'rehome',
+      rehome: signal({ destination: '', justified: false, candidates: [], stale: true }),
+    })
+    expect(descriptorFor(stale).destination(stale)).toBe('work · no longer applies · safe to dismiss')
+  })
+})
+
+describe('canAccept', () => {
+  it('refuses the kinds whose accept would be a guess', () => {
+    // A skill is a file (`accept_for('skill')` raises server-side) and a review
+    // row has no decided destination at all.
+    for (const kind of ['skill', 'review']) {
+      const r = row({ kind })
+      expect(descriptorFor(r).canAccept(r)).toBe(false)
+    }
+  })
+
+  it('allows the destination and region kinds', () => {
+    for (const kind of ['memory', 'profile', 'user', 'people', 'project', 'learnings']) {
+      const r = row({ kind })
+      expect(descriptorFor(r).canAccept(r)).toBe(true)
+    }
+  })
+
+  it('allows a re-home accept only when the tags back the destination', () => {
+    const backed = row({
+      kind: 'rehome',
+      rehome: signal({ destination: 'personal/n', justified: true, candidates: ['personal'] }),
+    })
+    expect(descriptorFor(backed).canAccept(backed)).toBe(true)
+
+    for (const rehome of [
+      signal({ destination: 'personal/n', justified: false, candidates: ['personal'] }),
+      signal({ destination: '', justified: true, candidates: ['a', 'b'] }),
+      undefined,
+    ]) {
+      const r = row({ kind: 'rehome', rehome })
+      expect(descriptorFor(r).canAccept(r)).toBe(false)
+    }
+  })
+})
+
+describe('rehomeMode', () => {
+  it('is a picker for several candidates, an accept only when justified', () => {
+    expect(rehomeMode(row({ kind: 'rehome' }))).toBe('question')
+    expect(rehomeMode(row({
+      kind: 'rehome',
+      rehome: signal({ destination: '', justified: true, candidates: ['a', 'b'] }),
+    }))).toBe('picker')
+    expect(rehomeMode(row({
+      kind: 'rehome',
+      rehome: signal({ destination: 'a/n', justified: true, candidates: ['a'] }),
+    }))).toBe('accept')
+    expect(rehomeMode(row({
+      kind: 'rehome',
+      rehome: signal({ destination: 'a/n', justified: false, candidates: ['a'] }),
+    }))).toBe('question')
+  })
+})
+
+describe('accept fallback', () => {
+  it('only people narrows on the error message', () => {
+    // A people accept is create-only, so "already exists" is the merge path and
+    // anything else is a real error worth surfacing.
+    const people = PROPOSAL_KINDS.people.fallback
+    expect(people).not.toBeNull()
+    expect(people!.when('People/Mo.md already exists')).toBe(true)
+    expect(people!.when('permission denied')).toBe(false)
+  })
+
+  it('the fold/cap kinds fall back on any refusal', () => {
+    for (const kind of ['project', 'memory', 'profile', 'user', 'learnings']) {
+      const fallback = PROPOSAL_KINDS[kind].fallback
+      expect(fallback, kind).not.toBeNull()
+      expect(fallback!.when('anything at all')).toBe(true)
+    }
+  })
+
+  it('has no fallback for the kinds that never offered an accept', () => {
+    for (const kind of ['skill', 'review', 'rehome']) {
+      expect(PROPOSAL_KINDS[kind].fallback, kind).toBeNull()
+    }
+    expect(GENERIC.fallback).toBeNull()
+  })
+
+  it('titles the merge chat and toast per kind', () => {
+    const people = row({ kind: 'people', target: 'Mo' })
+    expect(PROPOSAL_KINDS.people.fallback!.chatTitle(people)).toBe('Merge Mo fact')
+    expect(PROPOSAL_KINDS.people.fallback!.toastDetail(people)).toBe('Mo fact — click to open the chat')
+
+    const anon = row({ kind: 'people' })
+    expect(PROPOSAL_KINDS.people.fallback!.chatTitle(anon)).toBe('Merge person fact')
+
+    expect(PROPOSAL_KINDS.project.fallback!.chatTitle(row({ kind: 'project' }))).toBe('Merge project fact')
+    expect(PROPOSAL_KINDS.learnings.fallback!.chatTitle(row({ kind: 'learnings' }))).toBe('Merge learning')
+    expect(PROPOSAL_KINDS.memory.fallback!.chatTitle(row())).toBe('Merge memory fact')
+  })
+
+  it('seeds the merge prompt with the fact, the workspace and the refusal', () => {
+    const r = row({ kind: 'project', target: 'Projects/Thing.md', text: 'the fact' })
+    const prompt = PROPOSAL_KINDS.project.fallback!.prompt(r, 'fold guard refused')
+    expect(prompt).toContain('the fact')
+    expect(prompt).toContain('Projects/Thing.md')
+    expect(prompt).toContain('fold guard refused')
+    expect(prompt).toContain('work')
+    // Every merge prompt must tell the agent to dismiss with --promoted rather
+    // than editing the proposal file, which would skip the outcome log.
+    expect(prompt).toContain('memory-proposal-dismiss')
+    expect(prompt).toContain('--promoted')
+  })
+
+  it('every fallback prompt routes the dismissal through the outcome log', () => {
+    for (const [kind, descriptor] of Object.entries(PROPOSAL_KINDS)) {
+      if (!descriptor.fallback) continue
+      const prompt = descriptor.fallback.prompt(row({ kind }), 'refused')
+      expect(prompt, kind).toContain('memory-proposal-dismiss')
+      // Capitalisation differs between the prompts; the instruction is what matters.
+      expect(prompt.toLowerCase(), kind).toContain('do not delete the bullet from the file directly')
+      // Never a quoted shell argument: `row.text` is arbitrary user prose, and
+      // `$(...)`, a backtick or a quote in it would be run or mangled.
+      expect(prompt, kind).toContain('--text-file')
+      expect(prompt, kind).not.toContain('memory-proposal-dismiss "')
+    }
+  })
+})
+
+describe('discussLabel', () => {
+  function labelFor(kind: string): string {
+    const r = row({ kind })
+    return descriptorFor(r).discussLabel(r)
+  }
+
+  it('does not call a review row a kind of proposal', () => {
+    // It is a fact with nowhere decided to go; naming it "a `review` proposal"
+    // asks the agent the wrong question.
+    expect(labelFor('review')).toBe('a fact with no decided destination')
+  })
+
+  it('names the other kinds', () => {
+    expect(labelFor('memory')).toBe('a `memory` proposal')
+    expect(labelFor('rehome')).toBe('a re-home proposal')
+  })
+
+  it('still names an unknown kind, which is why the label is row-valued', () => {
+    // Before the registry the panel interpolated `row.kind` directly, so a
+    // server newer than the client still told the agent what it had sent. A
+    // constant on GENERIC would have dropped that.
+    expect(labelFor('something-new')).toBe('a `something-new` proposal')
+  })
+})

--- a/web/src/lib/proposalKinds.ts
+++ b/web/src/lib/proposalKinds.ts
@@ -1,0 +1,269 @@
+/** What the review queue knows about each kind of proposal, in one place.
+ *
+ * The panel used to dispatch on `row.kind` in seventeen separate conditionals —
+ * the chip label, the destination line, whether accept is offered, whether a
+ * refused accept falls back to a chat, which of four near-identical merge
+ * functions ran, and how `discuss` named the row. Adding a kind meant finding
+ * every one of them, and the UI encoded backend semantics in each.
+ *
+ * A descriptor answers all of those questions for one kind, so a new kind is one
+ * entry here. `descriptorFor` never returns undefined: an unknown kind (a server
+ * newer than the client) falls back to `GENERIC`, which shows the region form and
+ * offers a plain accept with no chat fallback — the behaviour the old chain of
+ * conditionals ended in.
+ *
+ * Everything here is a pure function of the row, so it is testable without
+ * mounting the panel, which is the other half of the point.
+ */
+
+import type { ProposalRow } from './types'
+
+/** How a re-home row is presented.
+ *
+ * Never a pre-filled one-click accept for a destination no tag backs: a single
+ * clean signal is a plain accept, multiple candidates are a picker, and no
+ * signal is a question.
+ */
+export function rehomeMode(row: ProposalRow): 'accept' | 'picker' | 'question' {
+  const sig = row.rehome
+  if (!sig) return 'question'
+  if (sig.candidates.length > 1) return 'picker'
+  if (sig.justified) return 'accept'
+  return 'question'
+}
+
+/** What a failed direct accept does instead of surfacing the error. */
+export interface ProposalMergeFallback {
+  /** Title of the background chat that performs the merge. */
+  chatTitle: (row: ProposalRow) => string
+  /** Detail line under the "Merging in background" toast. */
+  toastDetail: (row: ProposalRow) => string
+  /** The prompt that chat is seeded with. */
+  prompt: (row: ProposalRow, errorMsg: string) => string
+  /**
+   * Whether *this* failure is the expected one.
+   *
+   * Only `people` narrows on the message: its direct accept is create-only, so
+   * "already exists" is the merge path and anything else is a real error. The
+   * rest fall back on any refusal, because their guards (fold, cap, region) all
+   * mean the same thing — a human-shaped merge is needed.
+   */
+  when: (errorMsg: string) => boolean
+}
+
+export interface ProposalKindDescriptor {
+  /** Chip text on the row. */
+  label: string
+  /** The line under the title: where an accept writes. */
+  destination: (row: ProposalRow) => string
+  /** Whether an accept can do what the button says. */
+  canAccept: (row: ProposalRow) => boolean
+  /** What a refused accept falls back to; null surfaces the error instead. */
+  fallback: ProposalMergeFallback | null
+  /**
+   * How `discuss` refers to the row when asking for a decision.
+   *
+   * Row-valued because `GENERIC` has to name a kind it does not know: before
+   * the registry the panel interpolated `row.kind` directly, so an unknown kind
+   * still reached the agent by name. A constant string here would ask it to
+   * place a fact without saying what the server called it.
+   */
+  discussLabel: (row: ProposalRow) => string
+}
+
+// ---- merge prompts ---------------------------------------------------------
+//
+// Every prompt interpolates `row.text`, which is arbitrary user prose. The
+// dismissal at the end of each therefore names `--text-file`, never a quoted
+// shell argument: a fact containing `$(...)`, a backtick or a quote would be
+// run or mangled on its way to the command. `memory-proposal-add` has kept the
+// fact out of argv for that reason all along; the dismissal gained the same
+// door in the CLI, and these are its main interactive callers.
+
+function peopleMergePrompt(row: ProposalRow): string {
+  const target = row.target || '?'
+  const where = `queued in the ${row.workspace} workspace`
+  return (
+    `A \`[people ${target}]\` proposal is queued (${where}) but \`People/${target}.md\` already exists, so a direct accept correctly refused to overwrite it. Work in this chat only; do not delegate this helper task.\n\n` +
+    `Fact to merge: ${row.text}\n\n` +
+    `Read \`People/${target}.md\` in the ${row.workspace} vault, merge this fact into it without duplicating anything already there (keep \`tags: [person]\`, add a sentence under the heading or appropriate section), and write it back.\n\n` +
+    `After the note is updated, dismiss the queued proposal that contains this exact text by running \`ciao memory-proposal-dismiss --text-file <file> --promoted\` so it disappears from Review (the flag records the promotion; do not delete the bullet from the file directly — that skips the outcome log). ` +
+    `If the fact is already present verbatim, just dismiss the proposal. Leave other proposals untouched. Nothing is broken – this is the expected merge path for existing person notes.`
+  )
+}
+
+function projectMergePrompt(row: ProposalRow, errorMsg: string): string {
+  const target = row.target || 'the project doc'
+  const where = `queued in the ${row.workspace} workspace`
+  return (
+    `A \`[project ${target}]\` proposal is queued (${where}) but direct accept refused: ${errorMsg}\n\nWork in this chat only; do not delegate this helper task.\n\n` +
+    `Fact to merge: ${row.text}\n\n` +
+    `Read \`${target}\` (vault-relative, in the ${row.workspace} workspace), merge this fact into the appropriate section without duplicating existing content, and write it back. Keep frontmatter and structure intact.\n\n` +
+    `After the doc is updated, dismiss the queued proposal that contains this exact text by running \`ciao memory-proposal-dismiss --text-file <file> --promoted\`. If the fact is already covered, run the same command without \`--promoted\`. Do not delete the bullet from the file directly — that skips the outcome log. Leave other proposals untouched. Nothing is broken – this is the expected merge path when the fold guards refuse.`
+  )
+}
+
+function memoryMergePrompt(row: ProposalRow, errorMsg: string): string {
+  const region = row.region || row.kind
+  const where = `queued in the ${row.workspace} workspace`
+  return (
+    `A \`[${row.kind}]\` proposal is queued (${where}) for region \`${region}\` but direct accept refused: ${errorMsg}\n\nWork in this chat only; do not delegate this helper task.\n\n` +
+    `Fact to merge: ${row.text}\n\n` +
+    `Read \`${row.workspace}/CLAUDE.md\` bounded region \`${region}\`, merge this fact there without duplication and within the char limit – curate/consolidate nearby bullets if needed to make room, never exceed the cap.\n\n` +
+    `After the region is updated, dismiss the queued proposal that contains this exact text by running \`ciao memory-proposal-dismiss --text-file <file> --promoted\` (do not delete the bullet from the file directly — that skips the outcome log). If the fact is already present verbatim, just dismiss. Leave other proposals untouched. Nothing is broken – this is the expected path when the region is over cap or needs curation.`
+  )
+}
+
+function learningsMergePrompt(row: ProposalRow, errorMsg: string): string {
+  const where = `queued in the ${row.workspace} workspace`
+  return (
+    `A \`[learnings]\` proposal is queued (${where}) but direct accept refused: ${errorMsg}\n\nWork in this chat only; do not delegate this helper task.\n\n` +
+    `Fact to merge: ${row.text}\n\n` +
+    `Read \`Workspace/Learnings.md\` in the ${row.workspace} vault, append this fact under \`## Active\` without duplication, and write it back.\n\n` +
+    `After the file is updated, dismiss the queued proposal that contains this exact text by running \`ciao memory-proposal-dismiss --text-file <file> --promoted\` (do not delete the bullet from the file directly — that skips the outcome log). If the fact is already present, just dismiss. Leave other proposals untouched.`
+  )
+}
+
+// ---- destinations ----------------------------------------------------------
+
+/** The generic form: the ciao region an accept would write into. */
+function regionDestination(row: ProposalRow): string {
+  return `ciao:${row.region ?? row.kind}`
+}
+
+function rehomeDestination(row: ProposalRow): string {
+  const sig = row.rehome
+  const from = row.workspace
+  if (sig?.candidates?.length && sig.candidates.length > 1) {
+    return `${from} → ${sig.candidates.join(' or ')} · tags name more than one`
+  }
+  if (sig?.destination) {
+    const to = sig.destination.split('/')[0]
+    return sig.justified
+      ? `${from} → ${to} · tags back this`
+      : `${from} → ${to} · no tag backs it`
+  }
+  // A stale row is not asking anything: its cause is gone. Saying "needs a
+  // decision" made litter look identical to a real question.
+  if (sig?.stale) return `${from} · no longer applies · safe to dismiss`
+  return `${from} · no destination, needs a decision`
+}
+
+// ---- the registry ----------------------------------------------------------
+
+const ALWAYS = () => true
+
+/** The three kinds that write a bounded region in the workspace guide. */
+const REGION_FALLBACK: ProposalMergeFallback = {
+  chatTitle: () => 'Merge memory fact',
+  toastDetail: () => 'Memory fact — click to open the chat',
+  prompt: memoryMergePrompt,
+  when: ALWAYS,
+}
+
+function regionKind(label: string): ProposalKindDescriptor {
+  return {
+    label,
+    destination: regionDestination,
+    canAccept: ALWAYS,
+    fallback: REGION_FALLBACK,
+    discussLabel: () => `a \`${label}\` proposal`,
+  }
+}
+
+/** Used for a kind this client does not know about. */
+export const GENERIC: ProposalKindDescriptor = {
+  label: '',
+  destination: regionDestination,
+  canAccept: ALWAYS,
+  fallback: null,
+  discussLabel: (row) => `a \`${row.kind}\` proposal`,
+}
+
+export const PROPOSAL_KINDS: Record<string, ProposalKindDescriptor> = {
+  memory: regionKind('memory'),
+  // `user` is the server's older spelling of the same region; both show as
+  // "profile" so the queue does not appear to hold two different things.
+  profile: regionKind('profile'),
+  user: { ...regionKind('profile'), discussLabel: () => 'a `user` proposal' },
+
+  people: {
+    label: 'people',
+    destination: (row) => `People/${row.target || '?'}.md`,
+    canAccept: ALWAYS,
+    fallback: {
+      chatTitle: (row) => `Merge ${row.target || 'person'} fact`,
+      toastDetail: (row) => `${row.target || 'Person'} fact — click to open the chat`,
+      prompt: peopleMergePrompt,
+      when: (msg) => /already exists/i.test(msg),
+    },
+    discussLabel: () => 'a `people` proposal',
+  },
+
+  project: {
+    label: 'project',
+    destination: (row) => row.target || 'no project doc named',
+    canAccept: ALWAYS,
+    fallback: {
+      chatTitle: () => 'Merge project fact',
+      toastDetail: () => 'Project fact — click to open the chat',
+      prompt: projectMergePrompt,
+      when: ALWAYS,
+    },
+    discussLabel: () => 'a `project` proposal',
+  },
+
+  learnings: {
+    label: 'learnings',
+    destination: () => 'Workspace/Learnings.md',
+    canAccept: ALWAYS,
+    fallback: {
+      chatTitle: () => 'Merge learning',
+      toastDetail: () => 'Learning — click to open the chat',
+      prompt: learningsMergePrompt,
+      when: ALWAYS,
+    },
+    discussLabel: () => 'a `learnings` proposal',
+  },
+
+  // A review row has no known destination at all, so accepting one would be a
+  // guess wearing a button.
+  review: {
+    label: 'review',
+    destination: () => 'no destination yet — decide what it is',
+    canAccept: () => false,
+    fallback: null,
+    discussLabel: () => 'a fact with no decided destination',
+  },
+
+  // A re-home row with no backed destination has nowhere to go.
+  rehome: {
+    label: 're-home',
+    destination: rehomeDestination,
+    canAccept: (row) => rehomeMode(row) === 'accept',
+    fallback: null,
+    discussLabel: () => 'a re-home proposal',
+  },
+
+  // A skill row is a file, not a bullet, and `accept_for('skill')` raises on the
+  // server — accepting a proposed skill means implementing it, which is a chat.
+  // The path, not the words "a skill proposal file": the row's whole content is
+  // in that file, and naming it is what makes "view" obviously the first thing
+  // to press.
+  skill: {
+    label: 'skill',
+    destination: (row) => row.path || 'a skill proposal file',
+    canAccept: () => false,
+    fallback: null,
+    discussLabel: () => 'a `skill` proposal',
+  },
+}
+
+export function descriptorFor(row: ProposalRow): ProposalKindDescriptor {
+  return PROPOSAL_KINDS[row.kind] ?? GENERIC
+}
+
+/** Chip text for a kind, falling back to the raw kind for an unknown one. */
+export function kindLabel(kind: string): string {
+  return PROPOSAL_KINDS[kind]?.label || kind
+}


### PR DESCRIPTION
Implements P2 of #382.

## Problem

`ProposalReviewPanel.vue` dispatched on `row.kind` in **seventeen** separate conditionals across six concerns: the chip label, the destination line, whether accept was offered, whether a refused accept fell back to a chat, which of four near-identical merge functions ran, and how `discuss` named the row.

Adding a proposal kind meant finding every one of them, and each site re-encoded backend semantics in the UI.

## Change

New `web/src/lib/proposalKinds.ts` answers all six questions per kind in one descriptor, so a new kind is one entry.

The panel is down to **two** `kind ===` checks, both deliberate: `isRehome`/`isSkill` are identity checks the template uses to pick a row layout, not semantic dispatch.

The four `merge*ViaChat` functions collapsed into **one**. They differed only in chat title, toast detail and prompt — all three now come from the descriptor's `fallback`, which also owns which refusals are expected. Only `people` narrows on the error message, because its direct accept is create-only and "already exists" is the merge path rather than a real error.

An unknown kind resolves to `GENERIC` instead of `undefined`, so a server newer than the client renders the region form and a plain accept — what the old chain of conditionals already ended in.

Also removed `isRegionKind`, which was dead: defined, never called. The fact it encoded is now `descriptor.isRegion`, asserted in a test.

## Verification

Behaviour-preserving: the prompts, labels, destinations and predicates moved verbatim.

- `npm test`: **934 passed** (19 new)
- `vue-tsc` and `npm run build` green
- The descriptors are pure functions of the row, so `proposalKinds.test.ts` covers them **without mounting the panel** — including that every merge prompt still routes its dismissal through `--promoted` rather than editing the proposal file, which would skip the outcome log
