### PR TITLE
refactor(insights): one retry policy, typed outcomes (#382 P3)

### DIFF
--- a/ciao/insights.py
+++ b/ciao/insights.py
@@ -31,6 +31,8 @@ import json
 import logging
 import os
 import re
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -309,6 +311,94 @@ def is_terminal_failure(exc: Exception) -> bool:
     (timeout, subprocess error) stays retriable, which is the safe default.
     """
     return getattr(exc, "transient", None) is False
+
+
+@dataclass(frozen=True)
+class RetryOutcome:
+    """What one guarded model call actually did.
+
+    The three extraction paths used to report a partial failure only through a
+    log line and an empty string, so "the model was never asked because the
+    account is over quota" and "the model answered nothing twice" were
+    indistinguishable to a caller and to a test. ``gave_up`` names the reason
+    instead.
+    """
+
+    output: str
+    error: str
+    #: How many times the call was actually made — 1 when a guard refused the
+    #: retry, 2 when it ran and failed again.
+    attempts: int
+    #: "" when the call succeeded, else one of ``apple-unavailable``,
+    #: ``context-overflow``, ``terminal``, ``failed-twice``.
+    gave_up: str = ""
+
+
+async def call_with_retry(
+    call: Callable[[], Awaitable[str]],
+    *,
+    label: str,
+    model: str = "",
+    check_apple_available: bool = True,
+    check_context_overflow: bool = True,
+) -> RetryOutcome:
+    """Run ``call``; on a transient failure wait 30s and run it once more.
+
+    The one place the insights retry policy lives. It previously existed three
+    times — for the JSONL input, for the rendered-archive input, and inline in
+    the backfill worker — and the copies had drifted: only the JSONL one checked
+    for a context overflow, and only the two named functions checked whether the
+    Apple sidecar was available at all. The drift is now explicit in the two
+    keyword flags rather than implicit in which copy you were reading.
+
+    Three failures are never retried, because an identical second request fails
+    the same way and costs another slow call plus the 30s wait:
+
+    * the Apple sidecar is not available on this machine,
+    * the input still exceeds the model's context window (the payload was
+      already trimmed to the configured budget before the first call),
+    * the provider classified the rejection as non-transient — auth, quota,
+      usage limit, bad model.
+
+    ``label`` prefixes the log lines so a reader can still tell the three paths
+    apart ("Insights model call", "Insights text call", "Text fallback insights
+    call").
+    """
+    try:
+        return RetryOutcome(output=await call(), error="", attempts=1)
+    except Exception as exc:  # noqa: BLE001
+        detail = str(exc).strip() or type(exc).__name__
+        if (
+            check_apple_available
+            and native_sidecar.is_apple_model(model)
+            and not native_sidecar.apple_model_available()
+        ):
+            logger.info("Apple FoundationModels is unavailable; not retrying: %s", exc)
+            return RetryOutcome("", detail, 1, "apple-unavailable")
+        if check_context_overflow and is_context_overflow(exc):
+            logger.error(
+                "%s input still exceeds the model's context window (%s); "
+                "not retrying. Lower CIAO_INSIGHTS_MAX_INPUT_CHARS (currently %d) "
+                "or pick a model with a larger window.",
+                label,
+                exc,
+                _max_input_chars(),
+            )
+            return RetryOutcome("", detail, 1, "context-overflow")
+        if is_terminal_failure(exc):
+            # Quota / auth / bad-model. No traceback: this is an account or
+            # settings condition, not a code fault, and the detail already
+            # says which.
+            logger.error("%s rejected terminally (%s); not retrying", label, exc)
+            return RetryOutcome("", detail, 1, "terminal")
+        logger.info("%s failed (%s); retrying in %ds", label, exc, _RETRY_DELAY_S)
+
+    await asyncio.sleep(_RETRY_DELAY_S)
+    try:
+        return RetryOutcome(output=await call(), error="", attempts=2)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("%s failed twice; skipping", label)
+        return RetryOutcome("", str(exc).strip() or type(exc).__name__, 2, "failed-twice")
 
 
 # Rules shared verbatim by both extraction prompts (JSONL and text mode).
@@ -1025,38 +1115,8 @@ async def _run_model_with_retry(
             payload, model, provider=provider, cwd=cwd, context_block=context_block
         )
 
-    try:
-        return await call(), ""
-    except Exception as exc:  # noqa: BLE001
-        if (
-            native_sidecar.is_apple_model(model)
-            and not native_sidecar.apple_model_available()
-        ):
-            logger.info("Apple FoundationModels is unavailable; not retrying: %s", exc)
-            return "", str(exc).strip() or type(exc).__name__
-        if is_context_overflow(exc):
-            logger.error(
-                "Insights input still exceeds the model's context window (%s); "
-                "not retrying. Lower CIAO_INSIGHTS_MAX_INPUT_CHARS (currently %d) "
-                "or pick a model with a larger window.",
-                exc,
-                _max_input_chars(),
-            )
-            return "", str(exc).strip() or type(exc).__name__
-        if is_terminal_failure(exc):
-            # Quota / auth / bad-model. No traceback: this is an account or
-            # settings condition, not a code fault, and the detail already
-            # says which.
-            logger.error("Insights model call rejected terminally (%s); not retrying", exc)
-            return "", str(exc).strip() or type(exc).__name__
-        logger.info("Insights model call failed (%s); retrying in %ds", exc, _RETRY_DELAY_S)
-
-    await asyncio.sleep(_RETRY_DELAY_S)
-    try:
-        return await call(), ""
-    except Exception as exc:  # noqa: BLE001
-        logger.exception("Insights model call failed twice; skipping")
-        return "", str(exc).strip() or type(exc).__name__
+    outcome = await call_with_retry(call, label="Insights model call", model=model)
+    return outcome.output, outcome.error
 
 
 def _text_user_prompt(body: str, context_block: str = "") -> str:
@@ -1133,26 +1193,21 @@ async def _run_text_model_with_retry(
             body, model, provider=provider, cwd=cwd, context_block=context_block
         )
 
-    try:
-        return await call(), ""
-    except Exception as exc:  # noqa: BLE001
-        if (
-            native_sidecar.is_apple_model(model)
-            and not native_sidecar.apple_model_available()
-        ):
-            logger.info("Apple FoundationModels is unavailable; not retrying: %s", exc)
-            return "", str(exc).strip() or type(exc).__name__
-        if is_terminal_failure(exc):
-            logger.error("Insights text call rejected terminally (%s); not retrying", exc)
-            return "", str(exc).strip() or type(exc).__name__
-        logger.info("Insights text call failed (%s); retrying in %ds", exc, _RETRY_DELAY_S)
-
-    await asyncio.sleep(_RETRY_DELAY_S)
-    try:
-        return await call(), ""
-    except Exception as exc:  # noqa: BLE001
-        logger.exception("Insights text call failed twice; skipping")
-        return "", str(exc).strip() or type(exc).__name__
+    # `check_context_overflow=False` preserves this path's existing behaviour,
+    # which differed from the JSONL one: for a cloud model text mode sends the
+    # whole rendered archive without fitting it to a budget, so an overflow
+    # here is retried rather than refused. (Apple models are the exception —
+    # `_call_text_model` fits the body to the Apple window first, so for those
+    # the retry is as doomed as the JSONL path's would be.) Made explicit so
+    # the asymmetry is a decision on the page instead of a difference between
+    # two copies of the same code.
+    outcome = await call_with_retry(
+        call,
+        label="Insights text call",
+        model=model,
+        check_context_overflow=False,
+    )
+    return outcome.output, outcome.error
 
 
 async def _call_model(
@@ -1507,24 +1562,29 @@ async def backfill_insights_task(
                             provider=text_provider,
                         )
 
-                    output = ""
-                    try:
-                        output = await run_text_extract()
-                    except Exception as exc:
-                        if is_terminal_failure(exc):
-                            logger.error(
-                                "Text fallback insights call rejected terminally (%s); "
-                                "not retrying %s",
-                                exc,
-                                archive_path,
-                            )
-                            return "error"
-                        logger.info("Text fallback insights call failed (%s); retrying in %ds", exc, _RETRY_DELAY_S)
-                        await asyncio.sleep(_RETRY_DELAY_S)
-                        try:
-                            output = await run_text_extract()
-                        except Exception:
-                            logger.exception("Text fallback insights call failed twice; skipping %s", archive_path)
+                    # This path never checked the Apple sidecar or the
+                    # context window, and still does not — the flags say so
+                    # rather than the reader having to notice which copy this
+                    # was. `model` is passed even though the sidecar check is
+                    # off: `run_text_extract` really does call the sidecar for
+                    # an Apple model, so without it flipping the flag would
+                    # look effective and stay inert (`is_apple_model("")` is
+                    # False).
+                    outcome = await call_with_retry(
+                        run_text_extract,
+                        # The path is in the label so a backfill over hundreds
+                        # of archives still says which one failed, as the
+                        # inline version's log lines did.
+                        label=f"Text fallback insights call for {archive_path.name}",
+                        model=effective_model,
+                        check_apple_available=False,
+                        check_context_overflow=False,
+                    )
+                    # No `gave_up` branch: every giving-up reason leaves the
+                    # output empty, which the check below already reports as an
+                    # error. A magic-string comparison here would be a second
+                    # way to say the same thing, able to stop matching silently.
+                    output = outcome.output
 
                     if output and output.strip():
                         _append_section(archive_path, output)

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -1243,3 +1243,206 @@ def test_text_user_prompt_prepends_context():
     assert plain.startswith("Below is a rendered")
     assert augmented.startswith("## Known context")
     assert augmented.endswith(plain)
+
+
+# ── call_with_retry: the one retry policy ────────────────────────────────
+#
+# The policy used to exist three times (JSONL input, rendered-archive input,
+# and inline in the backfill worker) and the copies had drifted. These pin the
+# shared one, including the two flags that preserve the drift on purpose.
+
+
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop the retry wait without patching `asyncio.sleep` process-wide.
+
+    `insights.asyncio` *is* the asyncio module, so setattr'ing `sleep` on it
+    would make every `asyncio.sleep` in the process a no-op for the duration
+    of the test. Zeroing the delay constant is the narrow equivalent.
+    """
+    monkeypatch.setattr(insights, "_RETRY_DELAY_S", 0)
+
+
+class _Terminal(Exception):
+    """A provider rejection the provider already classified as non-transient."""
+
+    transient = False
+
+
+def test_call_with_retry_succeeds_first_time() -> None:
+    calls = 0
+
+    async def call() -> str:
+        nonlocal calls
+        calls += 1
+        return "output"
+
+    outcome = asyncio.run(insights.call_with_retry(call, label="test call"))
+    assert (outcome.output, outcome.error, outcome.attempts) == ("output", "", 1)
+    assert outcome.gave_up == ""
+    assert calls == 1
+
+
+def test_call_with_retry_retries_a_transient_failure_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _no_sleep(monkeypatch)
+    calls = 0
+
+    async def call() -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise asyncio.TimeoutError()
+        return "second try"
+
+    outcome = asyncio.run(insights.call_with_retry(call, label="test call"))
+    assert outcome.output == "second try"
+    assert outcome.attempts == 2
+    assert outcome.gave_up == ""
+    assert calls == 2
+
+
+def test_call_with_retry_gives_up_after_two_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _no_sleep(monkeypatch)
+    calls = 0
+
+    async def call() -> str:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("boom")
+
+    outcome = asyncio.run(insights.call_with_retry(call, label="test call"))
+    assert outcome.gave_up == "failed-twice"
+    assert outcome.attempts == 2
+    assert outcome.error == "boom"
+    assert calls == 2
+
+
+def test_call_with_retry_never_retries_a_terminal_rejection() -> None:
+    """Quota/auth/bad-model fail identically on a second call.
+
+    Re-sending costs another rejected request plus the 30s wait, once per
+    archive across a whole backfill run.
+    """
+    calls = 0
+
+    async def call() -> str:
+        nonlocal calls
+        calls += 1
+        raise _Terminal("over quota")
+
+    outcome = asyncio.run(insights.call_with_retry(call, label="test call"))
+    assert outcome.gave_up == "terminal"
+    assert outcome.attempts == 1
+    assert outcome.error == "over quota"
+    assert calls == 1
+
+
+def test_call_with_retry_never_retries_a_context_overflow() -> None:
+    calls = 0
+
+    async def call() -> str:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("prompt is too long for this model")
+
+    outcome = asyncio.run(insights.call_with_retry(call, label="test call"))
+    assert outcome.gave_up == "context-overflow"
+    assert calls == 1
+
+
+def test_call_with_retry_can_be_told_to_retry_an_overflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The text-mode path's deliberate asymmetry.
+
+    Text mode sends the whole rendered archive without fitting it to a budget,
+    so it retried an overflow before this policy existed and still does. The
+    flag is what keeps that a decision rather than a difference between two
+    copies of the same code.
+    """
+    _no_sleep(monkeypatch)
+    calls = 0
+
+    async def call() -> str:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("prompt is too long for this model")
+
+    outcome = asyncio.run(
+        insights.call_with_retry(call, label="test call", check_context_overflow=False)
+    )
+    assert outcome.gave_up == "failed-twice"
+    assert calls == 2
+
+
+def test_call_with_retry_skips_an_unavailable_apple_sidecar(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(insights.native_sidecar, "is_apple_model", lambda model: True)
+    monkeypatch.setattr(insights.native_sidecar, "apple_model_available", lambda: False)
+    calls = 0
+
+    async def call() -> str:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("sidecar missing")
+
+    outcome = asyncio.run(
+        insights.call_with_retry(call, label="test call", model="apple-on-device")
+    )
+    assert outcome.gave_up == "apple-unavailable"
+    assert calls == 1
+
+
+def test_call_with_retry_can_be_told_not_to_check_the_apple_sidecar(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The backfill worker's deliberate asymmetry: it never made that check."""
+    _no_sleep(monkeypatch)
+    monkeypatch.setattr(insights.native_sidecar, "is_apple_model", lambda model: True)
+    monkeypatch.setattr(insights.native_sidecar, "apple_model_available", lambda: False)
+    calls = 0
+
+    async def call() -> str:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("sidecar missing")
+
+    outcome = asyncio.run(
+        insights.call_with_retry(
+            call,
+            label="test call",
+            model="apple-on-device",
+            check_apple_available=False,
+        )
+    )
+    assert outcome.gave_up == "failed-twice"
+    assert calls == 2
+
+
+def test_retry_outcome_distinguishes_never_asked_from_answered_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reason the outcome is typed at all.
+
+    Both cases used to surface as an empty string plus a log line, so a caller
+    could not tell "the account is over quota, the model was never asked" from
+    "the model answered nothing twice".
+    """
+    _no_sleep(monkeypatch)
+
+    async def refused() -> str:
+        raise _Terminal("over quota")
+
+    async def empty() -> str:
+        return ""
+
+    never_asked = asyncio.run(insights.call_with_retry(refused, label="test call"))
+    answered_nothing = asyncio.run(insights.call_with_retry(empty, label="test call"))
+
+    assert never_asked.output == answered_nothing.output == ""
+    assert never_asked.gave_up == "terminal"
+    assert answered_nothing.gave_up == ""


### PR DESCRIPTION
Implements P3 of #382.

## Problem

The retry-once-after-30s policy existed **three times**:

- `_run_model_with_retry` (JSONL input)
- `_run_text_model_with_retry` — whose docstring said outright that it *"Mirrors `_run_model_with_retry`"*
- a third inline copy in `backfill_insights_task`'s worker

Each repeated its own overflow / terminal / Apple-unavailable branches, and the copies had drifted:

- only the JSONL path checked `is_context_overflow`
- only the two named functions checked whether the Apple sidecar was available
- the inline copy reported nothing but an empty string and a log line

## Change

`call_with_retry` is the one policy. The drift is now explicit in two keyword flags rather than implicit in which copy you happened to be reading. Both asymmetries are **preserved deliberately, not silently fixed** — see the follow-up PR for the one that turned out to be worth changing.

`RetryOutcome` makes partial failure assertable. "The account is over quota, the model was never asked" and "the model answered nothing twice" both used to surface as an empty string; `gave_up` now names which (`apple-unavailable` / `context-overflow` / `terminal` / `failed-twice`), and a test pins that the two are distinguishable.

The backfill path's log lines carried the archive path; that moved into the label, so a backfill over hundreds of archives still says which one failed.

## Deliberately out of scope

`ArchivePostprocessContext` and the pipeline rewrite from the original issue text. `extract_and_append`'s 16 params are all keyword-only with defaults — a readability problem, not a correctness one, and not worth a new context object on its own.

## Verification

- `pytest tests/`: **3282 passed** (9 new)
- `mypy` clean
