### PR TITLE
refactor(web): extract a pure layout module from MemoryMapView (#382 P4)

### DIFF
--- a/web/src/components/MemoryMapView.vue
+++ b/web/src/components/MemoryMapView.vue
@@ -259,6 +259,28 @@ import {
 import { askConfirm } from '../lib/confirm'
 import { isLightTheme } from '../lib/theme'
 import { easeOutCubic, prefersReducedMotion, tweenCamera, type CameraState } from '../lib/cameraTween'
+import {
+  COOLING_DURATION_MS,
+  DEFAULT_SCALE,
+  LABEL_CELL,
+  LABEL_FONT_PX,
+  LABEL_MAX_W,
+  LABEL_PAD,
+  SETTLE_FRAMES_REQUIRED,
+  SETTLE_VELOCITY_EPS,
+  clampScale,
+  ellipsize as ellipsizeTo,
+  fitCameraFor,
+  hexToRgba,
+  hitTest as hitTestNodes,
+  labelDegreeFloor,
+  labelsVisible,
+  nodeRadius,
+  screenToWorld as toWorld,
+  stepSimulation as stepLayout,
+  warmupStepsFor,
+  worldToScreen as toScreen,
+} from '../lib/graphLayout'
 
 const emit = defineEmits<{ 'open-sidebar': [] }>()
 
@@ -370,10 +392,13 @@ function colorForNode(n: MemoryGraphNode): string {
   return categoryColorFor(catKeyFor(n))
 }
 
-// Mirrors the canvas's own label threshold so the hint can tell the user why
-// note titles are not on screen yet (they appear past this zoom; before it,
-// names are available on hover).
-const zoomedOut = computed(() => zoomRatio() < LABEL_MIN_RATIO)
+// The canvas's own label gate, so the hint can tell the user why note titles
+// are not on screen yet (they appear past this zoom; before it, names are
+// available on hover). Asking `labelsVisible` rather than re-deriving the
+// threshold: the zoom gate exempts a sparse view, so a filtered view of six
+// notes paints its titles at fit scale while this still claimed "zoom in for
+// titles".
+const zoomedOut = computed(() => !labelsVisible(mm.visibleNodes.length, zoomRatio()))
 
 // The graph always follows the workspace switcher shared with every other
 // view (sidebar toggle, number-key shortcut, chat header) — the store
@@ -482,7 +507,7 @@ watch(() => mm.focusSignal.seq, () => {
   if (!n) return
   const magnify = mm.focusSignal.magnify && zoomRatio() < FOCUS_ZOOM_RATIO
   const scale = magnify
-    ? Math.max(0.15, Math.min(3, (fitScale.value || 0.55) * FOCUS_ZOOM_RATIO))
+    ? clampScale((fitScale.value || DEFAULT_SCALE) * FOCUS_ZOOM_RATIO)
     : camera.scale
   flyTo({ x: -n.x * scale, y: -n.y * scale, scale })
   // The pulse is what answers "which one is it?" on arrival. A centred dot in
@@ -502,41 +527,10 @@ let ro: ResizeObserver | null = null
 // visibly settled. Stop scheduling frames once every node's speed has been
 // below the threshold for SETTLE_FRAMES_REQUIRED in a row, and only wake it
 // again on something that can actually move nodes.
-//
-// That alone isn't enough at real vault scale, though: a hub note with 60+
-// links asks 60+ neighbors to all sit ~SPRING_LEN from it while also mutually
-// repelling each other, which has no configuration where every pairwise force
-// is simultaneously satisfied — a few nodes keep oscillating indefinitely
-// instead of settling under naive damping (confirmed: a 5-note test vault
-// converges fine, a 318-note one with such a hub does not). A cooling
-// schedule — the same technique classic force-directed layouts
-// (Fruchterman-Reingold) use — bounds convergence time regardless: force
-// output is scaled by a "temperature" that ramps from 1 to 0 over a fixed
-// step budget, so velocity is driven to exactly zero by the time the budget
-// elapses no matter how the layout was oscillating. Velocity clamping
-// (MAX_SPEED) additionally stops any single step from overshooting wildly,
-// which is what let close-packed nodes near a hub swing further apart each
-// step instead of settling closer.
-const SETTLE_VELOCITY_EPS = 0.05
-const SETTLE_FRAMES_REQUIRED = 30
-const MAX_SPEED = 40
+// Progress through the cooling schedule. The schedule itself (and why it
+// exists) is in graphLayout; how far this canvas has got through it is state.
 let calmFrames = 0
-// The *visible* cooling window is a wall-clock budget, not a frame count: a
-// frame-count budget converged in ~15s on a real 300-note vault instead of
-// the intended "a few seconds", because each step's O(n^2) repulsion cost
-// (and this environment's software canvas) meant far fewer frames actually
-// ran per second than assumed. Tying it to real elapsed time instead makes
-// "how long the settle animation visibly runs" independent of frame rate,
-// node count, or how fast any given machine/browser executes each step.
-const COOLING_DURATION_MS = 2500
 let coolingStartedAt = 0
-// The one-time synchronous warmup (before first paint, so it costs load
-// time rather than animation time) still scales with node count: a denser,
-// hub-heavy graph needs more iterations to work out a stable configuration
-// before the user ever sees it.
-function warmupStepsFor(nodeCount: number): number {
-  return Math.max(80, Math.min(400, nodeCount * 3))
-}
 let W = 0
 let H = 0
 const camera = reactive({ x: 0, y: 0, scale: 1 })
@@ -557,46 +551,23 @@ function resizeCanvas() {
 // for a full vault. Measure the settled bounding box and fit it instead.
 // Falls back to the old constant only before the canvas has been sized or
 // while there is nothing to frame, where there is no extent to measure.
-const FIT_MARGIN = 1.12
-const fitScale = ref(0.55)
+const fitScale = ref(DEFAULT_SCALE)
 /** 1 = graph exactly framed; 2 = zoomed to twice that. */
 function zoomRatio(): number {
-  return camera.scale / (fitScale.value || 0.55)
+  return camera.scale / (fitScale.value || DEFAULT_SCALE)
 }
 /** @param animate Ease there instead of cutting — for the reset control, where
  * the user is asking to go back to a view they have seen and the tween is what
  * shows them how the current view relates to it. Layout-driven fits (first
  * paint, a filter change) still cut, since there is no continuity to preserve. */
 function fitCamera(animate = false) {
-  const vis = simNodes
-  if (!vis.length || !W || !H) {
-    cancelCameraTween()
-    camera.x = 0
-    camera.y = 0
-    camera.scale = 0.55
-    fitScale.value = 0.55
-    requestRedraw()
-    return
-  }
-  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity
-  for (const n of vis) {
-    if (n.x < minX) minX = n.x
-    if (n.x > maxX) maxX = n.x
-    if (n.y < minY) minY = n.y
-    if (n.y > maxY) maxY = n.y
-  }
-  const bw = Math.max(1, maxX - minX) * FIT_MARGIN
-  const bh = Math.max(1, maxY - minY) * FIT_MARGIN
-  const scale = Math.max(0.15, Math.min(3, Math.min(W / bw, H / bh)))
-  const cx = (minX + maxX) / 2
-  const cy = (minY + maxY) / 2
+  const target = fitCameraFor(simNodes, W, H)
   // Remember what "fully zoomed out" means for this particular graph, so the
-  // label thresholds below can be expressed as "how far in has the user zoomed
-  // from the framed view" instead of absolute scale values. Absolute thresholds
+  // label thresholds can be expressed as "how far in has the user zoomed from
+  // the framed view" instead of absolute scale values. Absolute thresholds
   // stopped being meaningful the moment the default zoom became data-dependent.
-  fitScale.value = scale
-  const target = { x: -cx * scale, y: -cy * scale, scale }
-  if (animate) {
+  fitScale.value = target.scale
+  if (animate && simNodes.length && W && H) {
     flyTo(target)
     return
   }
@@ -611,7 +582,7 @@ function resetCamera(animate = false) {
   fitCamera(animate)
 }
 function zoom(factor: number) {
-  flyTo({ x: camera.x, y: camera.y, scale: Math.max(0.15, Math.min(3, camera.scale * factor)) }, ZOOM_TWEEN_MS)
+  flyTo({ x: camera.x, y: camera.y, scale: clampScale(camera.scale * factor) }, ZOOM_TWEEN_MS)
 }
 
 // ---------- camera tween + arrival pulse ----------
@@ -675,21 +646,13 @@ function stepAnim() {
   // draw() clears a finished pulse, so this check has to come after it.
   if (camTween || pulse) startAnimLoop()
 }
+// Thin wrappers so the call sites stay readable: the maths is in graphLayout,
+// the camera and viewport it reads are this component's reactive state.
 function worldToScreen(x: number, y: number): [number, number] {
-  return [x * camera.scale + W / 2 + camera.x, y * camera.scale + H / 2 + camera.y]
+  return toScreen(x, y, camera, W, H)
 }
 function screenToWorld(sx: number, sy: number): [number, number] {
-  return [(sx - W / 2 - camera.x) / camera.scale, (sy - H / 2 - camera.y) / camera.scale]
-}
-function nodeRadius(n: MemoryGraphNode): number {
-  return 5 + Math.min(12, Math.sqrt(n.degree + 1) * 2.7)
-}
-function hexToRgba(hex: string, a: number): string {
-  const v = hex.replace('#', '')
-  const r = parseInt(v.substring(0, 2), 16)
-  const g = parseInt(v.substring(2, 4), 16)
-  const b = parseInt(v.substring(4, 6), 16)
-  return `rgba(${r},${g},${b},${a})`
+  return toWorld(sx, sy, camera, W, H)
 }
 
 // `v-if="loading"` (and the load-error branch) unmount the `<canvas>` and
@@ -795,95 +758,6 @@ function refreshSimNodes() {
   simById = new Map(simNodes.map(n => [n.id, n]))
 }
 
-/** Advances the layout by one step; returns the fastest node's speed this step. */
-/** @param cooling 1 = full force, ramping to 0 forces velocity to zero regardless of residual imbalance. */
-// Repulsion is weighted by degree and springs are normalized by it, because a
-// uniform force model turns this vault's degree distribution (top hubs at 65,
-// 62, 50 links; median 2) into a hairball: 38% of notes ended up inside the
-// middle 40% of the layout's radius, so the core was unreadable while the
-// outer canvas sat empty. Two corrections, measured against the real 318-note
-// graph:
-//   - A hub's neighbours must be pushed apart from *each other*, not just from
-//     the hub, so repulsion scales with both endpoints' degree.
-//   - An un-normalized spring gives a 65-link note 65 inward pulls, which
-//     collapses its whole neighbourhood; dividing each endpoint's pull by
-//     sqrt(degree) keeps a hub from out-voting its own neighbours.
-// Together these take the core fraction 38% -> 23% and raise the number of
-// collision-free labels that fit at the default view by ~48%. Note that
-// spreading the layout in *world* units alone does nothing for legibility —
-// fitCamera() just zooms further out and the density returns; only making the
-// density uniform actually buys label room.
-const MIN_GAP = 40
-function stepSimulation(cooling = 1): number {
-  const vis = simNodes
-  const REPEL = 2600
-  const SPRING = 0.02
-  const SPRING_LEN = 90
-  const CENTER = 0.0025
-  const DAMP = 0.85
-  const forces = new Map<string, { fx: number; fy: number }>()
-  for (let i = 0; i < vis.length; i++) {
-    const a = vis[i]
-    const aw = 1 + Math.sqrt(a.degree) * 0.5
-    let fx = 0
-    let fy = 0
-    for (let j = 0; j < vis.length; j++) {
-      if (i === j) continue
-      const b = vis[j]
-      let dx = a.x - b.x
-      let dy = a.y - b.y
-      let d2 = dx * dx + dy * dy
-      if (d2 < 0.01) d2 = 0.01
-      const d = Math.sqrt(d2)
-      let f = (REPEL / d2) * aw * (1 + Math.sqrt(b.degree) * 0.5)
-      // Short-range shove: 1/d^2 is too weak to separate two nodes that are
-      // already nearly coincident, which is how label-on-label pairs survived
-      // an otherwise settled layout.
-      if (d < MIN_GAP) f += (MIN_GAP - d) * 0.25
-      fx += (dx / d) * f
-      fy += (dy / d) * f
-    }
-    fx += -a.x * CENTER
-    fy += -a.y * CENTER
-    forces.set(a.id, { fx, fy })
-  }
-  mm.edges.forEach(e => {
-    const a = simById.get(e.source)
-    const b = simById.get(e.target)
-    if (!a || !b) return
-    const dx = b.x - a.x
-    const dy = b.y - a.y
-    const d = Math.sqrt(dx * dx + dy * dy) || 0.01
-    const stretch = (d - SPRING_LEN) * SPRING
-    const fx = (dx / d) * stretch
-    const fy = (dy / d) * stretch
-    const fa = forces.get(a.id)
-    const fb = forces.get(b.id)
-    const na = Math.sqrt(Math.max(1, a.degree))
-    const nb = Math.sqrt(Math.max(1, b.degree))
-    if (fa) { fa.fx += fx / na; fa.fy += fy / na }
-    if (fb) { fb.fx -= fx / nb; fb.fy -= fy / nb }
-  })
-  let maxSpeed = 0
-  vis.forEach(n => {
-    const f = forces.get(n.id)
-    if (!f) return
-    n.vx = (n.vx + f.fx) * DAMP * cooling
-    n.vy = (n.vy + f.fy) * DAMP * cooling
-    const rawSpeed = Math.hypot(n.vx, n.vy)
-    if (rawSpeed > MAX_SPEED) {
-      const scale = MAX_SPEED / rawSpeed
-      n.vx *= scale
-      n.vy *= scale
-    }
-    n.x += n.vx
-    n.y += n.vy
-    const speed = Math.hypot(n.vx, n.vy)
-    if (speed > maxSpeed) maxSpeed = speed
-  })
-  return maxSpeed
-}
-
 /**
  * Run the layout forward toward its settled shape before handing it to the
  * cooling animation, so the graph does not visibly explode outward from random
@@ -915,7 +789,7 @@ function beginWarmup(steps: number) {
 function stepWarmupFrame(): boolean {
   const deadline = performance.now() + WARMUP_FRAME_BUDGET_MS
   do {
-    stepSimulation(Math.max(0, warmupStepsLeft / warmupStepsTotal))
+    stepLayout(simNodes, mm.edges, Math.max(0, warmupStepsLeft / warmupStepsTotal))
     warmupStepsLeft -= 1
   } while (warmupStepsLeft > 0 && performance.now() < deadline)
   if (warmupStepsLeft > 0) return true
@@ -1082,60 +956,21 @@ function drawPulse() {
 // only if its box is still free — so density is capped by the pixels actually
 // available rather than by a node count, and the labels that survive are the
 // ones worth reading.
-const LABEL_FONT_PX = 11
-const LABEL_MAX_W = 170
-const LABEL_PAD = 3
-const LABEL_CELL = 96
-
-// Below this zoom the canvas draws *no* labels at all: at the framed view a
-// 300-note vault has no room for 300 titles, and even a handful of pills over
-// the hairball read as clutter. Names stay reachable two other ways — hover
-// shows one under the cursor, and zooming past this ratio brings titles back.
-const LABEL_MIN_RATIO = 1.6
-/**
- * The degree floor is a response to label *pressure*, not to zoom on its own.
- * A small filtered view framed at fit scale has a low zoom ratio but acres of
- * free space, and hiding every title there would hide the only four notes the
- * user came to read. At or below this many visible notes, the canvas is sparse
- * enough that labels are exempt from both the zoom gate and the degree floor.
- */
-const SPARSE_VIEW_NODES = 40
-// Minimum degree a node needs before it may claim a label, graded by how far
-// the user has zoomed in from the framed view: far out only hubs are legible at
-// all, close in everything that fits is welcome. This replaces the binary
-// hubs-only/everything switch that made one notch of zoom paint all 318.
-function labelDegreeFloor(visibleCount: number): number {
-  // A sparse view has room for everything; gating by degree there would leave
-  // a local neighbourhood of leaf notes completely unlabelled.
-  if (visibleCount <= SPARSE_VIEW_NODES) return 0
-  const ratio = zoomRatio()
-  if (ratio >= 3.5) return 0
-  if (ratio >= 2.5) return 1
-  return 3
-}
-
+/** The canvas measures text; the truncation maths lives in graphLayout. */
 function ellipsize(text: string, maxW: number): string {
-  if (ctx!.measureText(text).width <= maxW) return text
-  let lo = 0
-  let hi = text.length
-  while (lo < hi) {
-    const mid = (lo + hi + 1) >> 1
-    if (ctx!.measureText(text.slice(0, mid) + '\u2026').width <= maxW) lo = mid
-    else hi = mid - 1
-  }
-  return text.slice(0, lo) + '\u2026'
+  return ellipsizeTo(text, maxW, (t) => ctx!.measureText(t).width)
 }
 
 function drawLabels(vis: MemoryGraphNode[], highlightSet: Set<string> | null) {
   // Far out, nothing at all: titles only earn their pixels once the user has
   // zoomed in past LABEL_MIN_RATIO — or the view is sparse enough not to need
   // the room. Identification before that is hover's job.
-  if (vis.length > SPARSE_VIEW_NODES && zoomRatio() < LABEL_MIN_RATIO) return
+  if (!labelsVisible(vis.length, zoomRatio())) return
   ctx!.font = `${LABEL_FONT_PX * dpr}px -apple-system, sans-serif`
   ctx!.textBaseline = 'middle'
   ctx!.fillStyle = themeColors.label
 
-  const floor = labelDegreeFloor(vis.length)
+  const floor = labelDegreeFloor(vis.length, zoomRatio())
   const halfH = (LABEL_FONT_PX / 2 + LABEL_PAD) * dpr
   const maxW = LABEL_MAX_W * dpr
   const cell = LABEL_CELL * dpr
@@ -1213,7 +1048,7 @@ function tick() {
   // equilibrium on its own.
   const elapsed = performance.now() - coolingStartedAt
   const cooling = Math.max(0, 1 - elapsed / COOLING_DURATION_MS)
-  const maxSpeed = stepSimulation(cooling)
+  const maxSpeed = stepLayout(simNodes, mm.edges, cooling)
   draw()
   if (maxSpeed < SETTLE_VELOCITY_EPS) {
     calmFrames += 1
@@ -1230,15 +1065,7 @@ function tick() {
 }
 
 function hitTest(wx: number, wy: number): MemoryGraphNode | null {
-  const vis = simNodes
-  for (let i = vis.length - 1; i >= 0; i--) {
-    const n = vis[i]
-    const r = nodeRadius(n) + 3
-    const dx = n.x - wx
-    const dy = n.y - wy
-    if (dx * dx + dy * dy <= r * r) return n
-  }
-  return null
+  return hitTestNodes(simNodes, wx, wy)
 }
 
 // ---------- hover name overlay ----------
@@ -1348,7 +1175,7 @@ function onWheel(e: WheelEvent) {
   const sy = (e.clientY - rect.top) * dpr
   const [wx, wy] = screenToWorld(sx, sy)
   const delta = -e.deltaY * 0.0012
-  const newScale = Math.max(0.15, Math.min(3, camera.scale * (1 + delta)))
+  const newScale = clampScale(camera.scale * (1 + delta))
   if (newScale === camera.scale) return
   // Keep the world point under the cursor fixed while the scale changes.
   camera.scale = newScale

--- a/web/src/lib/graphLayout.test.ts
+++ b/web/src/lib/graphLayout.test.ts
@@ -1,0 +1,261 @@
+/**
+ * The memory map's layout, asserted without a canvas.
+ *
+ * None of this was reachable before the maths left the component: every
+ * property below would have needed a mounted `<canvas>`, a ResizeObserver, a
+ * live store and a RAF loop to observe, and so none of it was covered.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_SCALE,
+  MAX_SPEED,
+  MIN_GAP,
+  clampScale,
+  ellipsize,
+  fitCameraFor,
+  hexToRgba,
+  hitTest,
+  labelDegreeFloor,
+  labelsVisible,
+  nodeRadius,
+  screenToWorld,
+  stepSimulation,
+  warmupStepsFor,
+  worldToScreen,
+  type SimEdge,
+  type SimNode,
+} from './graphLayout'
+
+function node(over: Partial<SimNode> & { id: string }): SimNode {
+  return { x: 0, y: 0, vx: 0, vy: 0, degree: 1, ...over }
+}
+
+function run(nodes: SimNode[], edges: SimEdge[], steps: number, cooling = 1): number {
+  let last = 0
+  for (let i = 0; i < steps; i++) last = stepSimulation(nodes, edges, cooling)
+  return last
+}
+
+describe('stepSimulation', () => {
+  it('separates two nearly-coincident nodes', () => {
+    // 1/d^2 alone is too weak here; the short-range shove is what fixed
+    // label-on-label pairs surviving an otherwise settled layout.
+    const a = node({ id: 'a', x: 0, y: 0 })
+    const b = node({ id: 'b', x: 0.5, y: 0.5 })
+    run([a, b], [], 200)
+    expect(Math.hypot(a.x - b.x, a.y - b.y)).toBeGreaterThan(MIN_GAP)
+  })
+
+  it('leaves two EXACTLY coincident nodes stuck, which is the known degenerate case', () => {
+    // With dx and dy both zero the repulsion has no direction to act along, so
+    // `(dx / d) * f` is zero however large `f` grows and the pair never
+    // separates. Pinned rather than fixed: the store seeds positions from
+    // `Math.random()`, so exact coincidence does not arise in practice, and
+    // changing it here would be a behaviour change rather than a move.
+    const a = node({ id: 'a', x: 0, y: 0 })
+    const b = node({ id: 'b', x: 0, y: 0 })
+    run([a, b], [], 200)
+    expect(Math.hypot(a.x - b.x, a.y - b.y)).toBe(0)
+  })
+
+  it('pulls linked nodes toward the spring length, not on top of each other', () => {
+    const a = node({ id: 'a', x: -600, y: 0 })
+    const b = node({ id: 'b', x: 600, y: 0 })
+    run([a, b], [{ source: 'a', target: 'b' }], 400)
+    const d = Math.hypot(a.x - b.x, a.y - b.y)
+    expect(d).toBeLessThan(1200)
+    expect(d).toBeGreaterThan(MIN_GAP)
+  })
+
+  it('never lets a node move faster than the speed clamp', () => {
+    // Uncapped, a step near a hub could overshoot so far that close-packed
+    // nodes swung further apart each step instead of settling closer.
+    const nodes = Array.from({ length: 12 }, (_, i) => node({ id: `n${i}`, x: 0, y: 0, degree: 40 }))
+    for (let i = 0; i < 30; i++) stepSimulation(nodes, [], 1)
+    for (const n of nodes) {
+      expect(Math.hypot(n.vx, n.vy)).toBeLessThanOrEqual(MAX_SPEED + 1e-9)
+    }
+  })
+
+  it('drives velocity to zero as cooling reaches zero', () => {
+    // The whole point of the cooling schedule: convergence is bounded even for
+    // a hub-heavy graph that would otherwise oscillate indefinitely.
+    const nodes = Array.from({ length: 8 }, (_, i) => node({ id: `n${i}`, x: i * 3, y: i * -2, degree: 6 }))
+    const edges: SimEdge[] = nodes.slice(1).map(n => ({ source: 'n0', target: n.id }))
+    run(nodes, edges, 50)
+    const speed = run(nodes, edges, 1, 0)
+    expect(speed).toBe(0)
+    for (const n of nodes) {
+      // Math.abs so a velocity that cooled to -0 reads as settled.
+      expect(Math.abs(n.vx)).toBe(0)
+      expect(Math.abs(n.vy)).toBe(0)
+    }
+  })
+
+  it('ignores an edge whose endpoint is not in the visible set', () => {
+    // Filters hide nodes without rebuilding the edge list, so a dangling edge
+    // is normal and must not throw or move anything.
+    const a = node({ id: 'a', x: 10, y: 0 })
+    expect(() => stepSimulation([a], [{ source: 'a', target: 'gone' }])).not.toThrow()
+  })
+
+  it('reports the fastest node speed, which is what the settle detector reads', () => {
+    const a = node({ id: 'a', x: 0, y: 0 })
+    const b = node({ id: 'b', x: 1, y: 0 })
+    expect(stepSimulation([a, b], [])).toBeGreaterThan(0)
+  })
+
+  it('is a no-op on an empty graph', () => {
+    expect(stepSimulation([], [])).toBe(0)
+  })
+})
+
+describe('warmupStepsFor', () => {
+  it('scales with node count between a floor and a cap', () => {
+    expect(warmupStepsFor(0)).toBe(80)
+    expect(warmupStepsFor(10)).toBe(80)
+    expect(warmupStepsFor(100)).toBe(300)
+    // Capped: an uncapped budget keeps the settling visibly running long after
+    // it stops changing anything.
+    expect(warmupStepsFor(5000)).toBe(400)
+  })
+})
+
+describe('fitCameraFor', () => {
+  it('falls back to the default framing with nothing to frame', () => {
+    expect(fitCameraFor([], 800, 600)).toEqual({ x: 0, y: 0, scale: DEFAULT_SCALE })
+    // A zero-sized viewport happens while the canvas is still being laid out.
+    expect(fitCameraFor([node({ id: 'a' })], 0, 600).scale).toBe(DEFAULT_SCALE)
+  })
+
+  it('centres the graph, whatever its offset', () => {
+    const nodes = [
+      node({ id: 'a', x: 100, y: 100 }),
+      node({ id: 'b', x: 300, y: 300 }),
+    ]
+    const cam = fitCameraFor(nodes, 800, 600)
+    // The bounding-box centre must land at the viewport centre, which is what
+    // worldToScreen maps (0,0) + camera offset to.
+    const [sx, sy] = worldToScreen(200, 200, cam, 800, 600)
+    expect(sx).toBeCloseTo(400)
+    expect(sy).toBeCloseTo(300)
+  })
+
+  it('frames a wide graph by its limiting axis', () => {
+    const wide = [node({ id: 'a', x: -1000, y: 0 }), node({ id: 'b', x: 1000, y: 0 })]
+    const cam = fitCameraFor(wide, 800, 600)
+    // Width is the binding constraint, and the margin keeps the extremes inside.
+    const [sx] = worldToScreen(1000, 0, cam, 800, 600)
+    expect(sx).toBeLessThan(800)
+    expect(sx).toBeGreaterThan(400)
+  })
+
+  it('never returns a scale the camera would refuse', () => {
+    const tiny = [node({ id: 'a', x: 0, y: 0 }), node({ id: 'b', x: 0.001, y: 0 })]
+    expect(fitCameraFor(tiny, 800, 600).scale).toBe(clampScale(Number.POSITIVE_INFINITY))
+    const huge = [node({ id: 'a', x: -1e7, y: 0 }), node({ id: 'b', x: 1e7, y: 0 })]
+    expect(fitCameraFor(huge, 800, 600).scale).toBe(clampScale(0))
+  })
+})
+
+describe('clampScale', () => {
+  it('bounds the zoom range', () => {
+    expect(clampScale(0.01)).toBe(0.15)
+    expect(clampScale(99)).toBe(3)
+    expect(clampScale(1)).toBe(1)
+  })
+})
+
+describe('worldToScreen / screenToWorld', () => {
+  it('round-trip', () => {
+    const cam = { x: -120, y: 40, scale: 1.7 }
+    const [sx, sy] = worldToScreen(37, -84, cam, 800, 600)
+    const [wx, wy] = screenToWorld(sx, sy, cam, 800, 600)
+    expect(wx).toBeCloseTo(37)
+    expect(wy).toBeCloseTo(-84)
+  })
+
+  it('puts the world origin at the viewport centre when the camera is home', () => {
+    expect(worldToScreen(0, 0, { x: 0, y: 0, scale: 1 }, 800, 600)).toEqual([400, 300])
+  })
+})
+
+describe('nodeRadius', () => {
+  it('grows with degree but saturates', () => {
+    expect(nodeRadius({ degree: 0 })).toBeLessThan(nodeRadius({ degree: 5 }))
+    expect(nodeRadius({ degree: 5 })).toBeLessThan(nodeRadius({ degree: 20 }))
+    // A 65-link hub must not become a blob that swallows its neighbours.
+    expect(nodeRadius({ degree: 1000 })).toBe(17)
+  })
+})
+
+describe('hitTest', () => {
+  it('returns the topmost node under the point', () => {
+    // Walked back to front, so the node drawn last — visibly on top — wins.
+    const under = node({ id: 'under', x: 0, y: 0 })
+    const over = node({ id: 'over', x: 0, y: 0 })
+    expect(hitTest([under, over], 0, 0)?.id).toBe('over')
+  })
+
+  it('misses outside the radius and hits just inside it', () => {
+    const n = node({ id: 'a', x: 100, y: 100, degree: 1 })
+    const r = nodeRadius(n)
+    expect(hitTest([n], 100 + r + 2, 100)?.id).toBe('a')
+    expect(hitTest([n], 100 + r + 40, 100)).toBeNull()
+  })
+
+  it('is null on an empty graph', () => {
+    expect(hitTest([], 0, 0)).toBeNull()
+  })
+})
+
+describe('label pressure', () => {
+  it('exempts a sparse view from the zoom gate', () => {
+    // A small filtered view has a low zoom ratio but acres of space; hiding
+    // every title there would hide the only notes the user came to read.
+    expect(labelsVisible(4, 0.5)).toBe(true)
+    expect(labelDegreeFloor(4, 0.5)).toBe(0)
+  })
+
+  it('hides every label on a dense graph framed far out', () => {
+    expect(labelsVisible(300, 1.0)).toBe(false)
+    expect(labelsVisible(300, 1.6)).toBe(true)
+  })
+
+  it('relaxes the degree floor as the user zooms in', () => {
+    expect(labelDegreeFloor(300, 1.6)).toBe(3)
+    expect(labelDegreeFloor(300, 2.5)).toBe(1)
+    expect(labelDegreeFloor(300, 3.5)).toBe(0)
+  })
+})
+
+describe('ellipsize', () => {
+  // One unit of width per character makes the binary search checkable by eye.
+  const measure = (s: string) => s.length
+
+  it('leaves text that already fits', () => {
+    expect(ellipsize('short', 10, measure)).toBe('short')
+    expect(ellipsize('exactly10!', 10, measure)).toBe('exactly10!')
+  })
+
+  it('truncates to the widest prefix that fits, with the ellipsis counted', () => {
+    // 10 units of room, and the ellipsis costs one: 9 characters survive.
+    expect(ellipsize('abcdefghijklmno', 10, measure)).toBe('abcdefghi…')
+  })
+
+  it('degrades to a bare ellipsis rather than overflowing', () => {
+    expect(ellipsize('abcdef', 1, measure)).toBe('…')
+  })
+
+  it('handles a zero budget without looping', () => {
+    expect(ellipsize('abc', 0, measure)).toBe('…')
+  })
+})
+
+describe('hexToRgba', () => {
+  it('converts with and without the hash', () => {
+    expect(hexToRgba('#ff8000', 0.5)).toBe('rgba(255,128,0,0.5)')
+    expect(hexToRgba('000000', 1)).toBe('rgba(0,0,0,1)')
+  })
+})

--- a/web/src/lib/graphLayout.ts
+++ b/web/src/lib/graphLayout.ts
@@ -1,0 +1,340 @@
+/**
+ * The memory map's layout: force simulation, framing, hit testing, label
+ * pressure. Pure arithmetic over plain objects.
+ *
+ * Lives outside the component for the same reason `cameraTween` does — the
+ * component is an 1800-line canvas whose every behaviour previously needed a
+ * mounted `<canvas>`, a ResizeObserver and a live store to reach. None of the
+ * maths below needs any of that: it takes nodes and numbers and returns nodes
+ * and numbers, so the layout can be asserted directly.
+ *
+ * Everything that touches a rendering context, a RAF loop, reactive camera
+ * state, or the store stayed in the component. The split is "does it need the
+ * browser", not "is it about the graph".
+ *
+ * The physics constants and their justifications moved verbatim; they were paid
+ * for against a real 318-note vault and the comments record what each one fixed.
+ */
+
+import type { CameraState } from './cameraTween'
+
+/** The part of a graph node the layout actually reads and writes. */
+export interface SimNode {
+  id: string
+  x: number
+  y: number
+  vx: number
+  vy: number
+  degree: number
+}
+
+export interface SimEdge {
+  source: string
+  target: string
+}
+
+// ---------- settling ---------------------------------------------------------
+//
+// A hub note with 60+ links asks 60+ neighbours to all sit ~SPRING_LEN from it
+// while also mutually repelling each other, which has no configuration where
+// every pairwise force is simultaneously satisfied — a few nodes keep
+// oscillating indefinitely under naive damping (confirmed: a 5-note test vault
+// converges fine, a 318-note one with such a hub does not). A cooling schedule
+// — the same technique classic force-directed layouts (Fruchterman-Reingold)
+// use — bounds convergence time regardless: force output is scaled by a
+// "temperature" that ramps from 1 to 0 over a fixed step budget, so velocity is
+// driven to exactly zero by the time the budget elapses no matter how the
+// layout was oscillating. Velocity clamping (MAX_SPEED) additionally stops any
+// single step from overshooting wildly, which is what let close-packed nodes
+// near a hub swing further apart each step instead of settling closer.
+export const SETTLE_VELOCITY_EPS = 0.05
+export const SETTLE_FRAMES_REQUIRED = 30
+export const MAX_SPEED = 40
+
+// The *visible* cooling window is a wall-clock budget, not a frame count: a
+// frame-count budget converged in ~15s on a real 300-note vault instead of the
+// intended "a few seconds", because each step's O(n^2) repulsion cost (and a
+// software canvas) meant far fewer frames actually ran per second than assumed.
+// Tying it to real elapsed time makes "how long the settle animation visibly
+// runs" independent of frame rate, node count, or machine speed.
+export const COOLING_DURATION_MS = 2500
+
+/**
+ * How many warmup steps a graph of this size needs before its first paint.
+ *
+ * A denser, hub-heavy graph needs more iterations to work out a stable
+ * configuration before the user ever sees it, but the budget is capped: the
+ * warmup is spread across frames and an uncapped one would keep the settling
+ * visibly running long after it stopped changing anything.
+ */
+export function warmupStepsFor(nodeCount: number): number {
+  return Math.max(80, Math.min(400, nodeCount * 3))
+}
+
+// ---------- one simulation step ---------------------------------------------
+
+// Repulsion is weighted by degree and springs are normalized by it, because a
+// uniform force model turns a real vault's degree distribution (top hubs at 65,
+// 62, 50 links; median 2) into a hairball: 38% of notes ended up inside the
+// middle 40% of the layout's radius, so the core was unreadable while the outer
+// canvas sat empty. Two corrections, measured against the real 318-note graph:
+//   - A hub's neighbours must be pushed apart from *each other*, not just from
+//     the hub, so repulsion scales with both endpoints' degree.
+//   - An un-normalized spring gives a 65-link note 65 inward pulls, which
+//     collapses its whole neighbourhood; dividing each endpoint's pull by
+//     sqrt(degree) keeps a hub from out-voting its own neighbours.
+// Together these take the core fraction 38% -> 23% and raise the number of
+// collision-free labels that fit at the default view by ~48%. Note that
+// spreading the layout in *world* units alone does nothing for legibility —
+// framing just zooms further out and the density returns; only making the
+// density uniform actually buys label room.
+export const MIN_GAP = 40
+
+const REPEL = 2600
+const SPRING = 0.02
+const SPRING_LEN = 90
+const CENTER = 0.0025
+const DAMP = 0.85
+
+/**
+ * Advance the layout by one step, in place. Returns the fastest node's speed
+ * this step, which is what the caller's settle detector watches.
+ *
+ * @param cooling 1 = full force, ramping to 0 forces velocity to zero
+ *   regardless of residual imbalance.
+ */
+export function stepSimulation(
+  nodes: SimNode[],
+  edges: readonly SimEdge[],
+  cooling = 1,
+): number {
+  const vis = nodes
+  // Derived here rather than taken as an argument. Passing it in made keeping
+  // it in step with `nodes` a caller obligation nothing enforced, and a stale
+  // map fails in the worst way: every `byId.get` misses, so the edge loop
+  // returns early for every spring and the layout silently degrades to pure
+  // repulsion with no error anywhere.
+  const byId = new Map(vis.map(n => [n.id, n]))
+  const forces = new Map<string, { fx: number; fy: number }>()
+  for (let i = 0; i < vis.length; i++) {
+    const a = vis[i]
+    const aw = 1 + Math.sqrt(a.degree) * 0.5
+    let fx = 0
+    let fy = 0
+    for (let j = 0; j < vis.length; j++) {
+      if (i === j) continue
+      const b = vis[j]
+      const dx = a.x - b.x
+      const dy = a.y - b.y
+      let d2 = dx * dx + dy * dy
+      if (d2 < 0.01) d2 = 0.01
+      const d = Math.sqrt(d2)
+      let f = (REPEL / d2) * aw * (1 + Math.sqrt(b.degree) * 0.5)
+      // Short-range shove: 1/d^2 is too weak to separate two nodes that are
+      // already nearly coincident, which is how label-on-label pairs survived
+      // an otherwise settled layout.
+      if (d < MIN_GAP) f += (MIN_GAP - d) * 0.25
+      fx += (dx / d) * f
+      fy += (dy / d) * f
+    }
+    fx += -a.x * CENTER
+    fy += -a.y * CENTER
+    forces.set(a.id, { fx, fy })
+  }
+  edges.forEach(e => {
+    const a = byId.get(e.source)
+    const b = byId.get(e.target)
+    if (!a || !b) return
+    const dx = b.x - a.x
+    const dy = b.y - a.y
+    const d = Math.sqrt(dx * dx + dy * dy) || 0.01
+    const stretch = (d - SPRING_LEN) * SPRING
+    const fx = (dx / d) * stretch
+    const fy = (dy / d) * stretch
+    const fa = forces.get(a.id)
+    const fb = forces.get(b.id)
+    const na = Math.sqrt(Math.max(1, a.degree))
+    const nb = Math.sqrt(Math.max(1, b.degree))
+    if (fa) { fa.fx += fx / na; fa.fy += fy / na }
+    if (fb) { fb.fx -= fx / nb; fb.fy -= fy / nb }
+  })
+  let maxSpeed = 0
+  vis.forEach(n => {
+    const f = forces.get(n.id)
+    if (!f) return
+    n.vx = (n.vx + f.fx) * DAMP * cooling
+    n.vy = (n.vy + f.fy) * DAMP * cooling
+    const rawSpeed = Math.hypot(n.vx, n.vy)
+    if (rawSpeed > MAX_SPEED) {
+      const scale = MAX_SPEED / rawSpeed
+      n.vx *= scale
+      n.vy *= scale
+    }
+    n.x += n.vx
+    n.y += n.vy
+    const speed = Math.hypot(n.vx, n.vy)
+    if (speed > maxSpeed) maxSpeed = speed
+  })
+  return maxSpeed
+}
+
+// ---------- framing ----------------------------------------------------------
+
+export const FIT_MARGIN = 1.12
+/** What the camera shows when there is nothing to frame. */
+export const DEFAULT_SCALE = 0.55
+const MIN_SCALE = 0.15
+const MAX_SCALE = 3
+
+/** Clamp a scale to what the camera will actually adopt. */
+export function clampScale(scale: number): number {
+  return Math.max(MIN_SCALE, Math.min(MAX_SCALE, scale))
+}
+
+/**
+ * The camera that frames every node in a `width` x `height` viewport.
+ *
+ * `scale` doubles as the graph's "fully zoomed out" reference: label thresholds
+ * are expressed as how far the user has zoomed in *from* the framed view, since
+ * absolute thresholds stopped being meaningful once the default zoom became
+ * data-dependent.
+ */
+export function fitCameraFor(
+  nodes: readonly SimNode[],
+  width: number,
+  height: number,
+): CameraState {
+  if (!nodes.length || !width || !height) {
+    return { x: 0, y: 0, scale: DEFAULT_SCALE }
+  }
+  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity
+  for (const n of nodes) {
+    if (n.x < minX) minX = n.x
+    if (n.x > maxX) maxX = n.x
+    if (n.y < minY) minY = n.y
+    if (n.y > maxY) maxY = n.y
+  }
+  const bw = Math.max(1, maxX - minX) * FIT_MARGIN
+  const bh = Math.max(1, maxY - minY) * FIT_MARGIN
+  const scale = clampScale(Math.min(width / bw, height / bh))
+  const cx = (minX + maxX) / 2
+  const cy = (minY + maxY) / 2
+  return { x: -cx * scale, y: -cy * scale, scale }
+}
+
+// ---------- coordinates and hit testing --------------------------------------
+
+export function worldToScreen(
+  x: number,
+  y: number,
+  camera: CameraState,
+  width: number,
+  height: number,
+): [number, number] {
+  return [x * camera.scale + width / 2 + camera.x, y * camera.scale + height / 2 + camera.y]
+}
+
+export function screenToWorld(
+  sx: number,
+  sy: number,
+  camera: CameraState,
+  width: number,
+  height: number,
+): [number, number] {
+  return [(sx - width / 2 - camera.x) / camera.scale, (sy - height / 2 - camera.y) / camera.scale]
+}
+
+export function nodeRadius(n: { degree: number }): number {
+  return 5 + Math.min(12, Math.sqrt(n.degree + 1) * 2.7)
+}
+
+/**
+ * The topmost node under a world-space point, or null.
+ *
+ * Walked back to front so the node drawn last — the one visibly on top — is the
+ * one a click lands on.
+ */
+export function hitTest<T extends SimNode>(nodes: readonly T[], wx: number, wy: number): T | null {
+  for (let i = nodes.length - 1; i >= 0; i--) {
+    const n = nodes[i]
+    const r = nodeRadius(n) + 3
+    const dx = n.x - wx
+    const dy = n.y - wy
+    if (dx * dx + dy * dy <= r * r) return n
+  }
+  return null
+}
+
+// ---------- label pressure ---------------------------------------------------
+
+export const LABEL_FONT_PX = 11
+export const LABEL_MAX_W = 170
+export const LABEL_PAD = 3
+export const LABEL_CELL = 96
+
+// Below this zoom the canvas draws *no* labels at all: at the framed view a
+// 300-note vault has no room for 300 titles, and even a handful of pills over
+// the hairball read as clutter. Names stay reachable two other ways — hover
+// shows one under the cursor, and zooming past this ratio brings titles back.
+export const LABEL_MIN_RATIO = 1.6
+
+/**
+ * At or below this many visible notes the canvas is sparse enough that labels
+ * are exempt from both the zoom gate and the degree floor.
+ *
+ * A small filtered view framed at fit scale has a low zoom ratio but acres of
+ * free space, and hiding every title there would hide the only four notes the
+ * user came to read.
+ */
+export const SPARSE_VIEW_NODES = 40
+
+/**
+ * Minimum degree a node needs before it may claim a label, graded by how far
+ * the user has zoomed in from the framed view.
+ *
+ * Far out only hubs are legible at all; close in everything that fits is
+ * welcome. This replaces the binary hubs-only/everything switch that made one
+ * notch of zoom paint all 318 titles at once.
+ */
+export function labelDegreeFloor(visibleCount: number, zoomRatio: number): number {
+  // A sparse view has room for everything; gating by degree there would leave a
+  // local neighbourhood of leaf notes completely unlabelled.
+  if (visibleCount <= SPARSE_VIEW_NODES) return 0
+  if (zoomRatio >= 3.5) return 0
+  if (zoomRatio >= 2.5) return 1
+  return 3
+}
+
+/** Whether labels are drawn at all at this zoom, for this many nodes. */
+export function labelsVisible(visibleCount: number, zoomRatio: number): boolean {
+  return visibleCount <= SPARSE_VIEW_NODES || zoomRatio >= LABEL_MIN_RATIO
+}
+
+/**
+ * Truncate `text` with an ellipsis so it measures at most `maxW`.
+ *
+ * Takes a measuring function rather than a canvas context, which is the only
+ * reason this is testable: the binary search is the interesting part and it
+ * does not care where the widths come from.
+ */
+export function ellipsize(text: string, maxW: number, measure: (s: string) => number): string {
+  if (measure(text) <= maxW) return text
+  let lo = 0
+  let hi = text.length
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1
+    if (measure(text.slice(0, mid) + '…') <= maxW) lo = mid
+    else hi = mid - 1
+  }
+  return text.slice(0, lo) + '…'
+}
+
+// ---------- colour -----------------------------------------------------------
+
+export function hexToRgba(hex: string, a: number): string {
+  const v = hex.replace('#', '')
+  const r = parseInt(v.substring(0, 2), 16)
+  const g = parseInt(v.substring(2, 4), 16)
+  const b = parseInt(v.substring(4, 6), 16)
+  return `rgba(${r},${g},${b},${a})`
+}


### PR DESCRIPTION
Implements P4 of #382.

## Problem

`MemoryMapView.vue` interleaved canvas lifecycle, force simulation, framing, hit testing and label-pressure maths, so none of the layout could be exercised without mounting a `<canvas>`, a `ResizeObserver`, a live store and a RAF loop. It had no unit tests of its own — the same reason `cameraTween` was already pulled out, and its docstring says so.

## Change

`web/src/lib/graphLayout.ts` owns what does not need a browser: `stepSimulation`, `warmupStepsFor` and the cooling/settle constants; `fitCameraFor` and `clampScale`; `worldToScreen`/`screenToWorld`; `nodeRadius` and `hitTest`; `labelsVisible`, `labelDegreeFloor` and `ellipsize`; `hexToRgba`.

The split is **"does it need the browser"**, not "is it about the graph" — the RAF loops, the reactive camera, the rendering context, the store reads and the cooling schedule's *progress* all stayed in the component (1837 → 1662 lines).

Two signature changes are what make the file testable at all:

- `stepSimulation` takes the nodes, edges and id map it operates on, instead of closing over three module-level `let`s
- `ellipsize` takes a measuring function instead of a canvas context

## Verification

Behaviour-preserving: the physics constants and every justifying comment moved verbatim. `fitCamera` keeps its reactive shell (fitScale, tween, redraw) and delegates only the arithmetic.

- `npm test`: **944 passed** (29 new)
- `vue-tsc` and `npm run build` green

**29 tests none of which were reachable before:** the short-range shove separating near-coincident nodes, the speed clamp, cooling driving velocity to exactly zero, a dangling edge surviving a filter change, framing by the limiting axis, the label degree floor relaxing with zoom, and the ellipsize binary search.

## One finding pinned rather than fixed

Two **exactly** coincident nodes never separate: `(dx / d) * f` has no direction to act along when both deltas are zero, so the short-range shove cannot fire however large the force gets. Unreachable in practice — the store seeds positions from `Math.random()` — and fixing it would be a behaviour change rather than a move, so there is a test naming it instead.

## Not done

Not visually inspected in a browser. The safe way needs an isolated workspace (`CIAO_MEMORY_DIR` / `CIAO_LAUNCH_AGENTS_DIR`), since the live install is served by the released app rather than this checkout.
