### PR TITLE
fix(web): stop the projects store leaking timers and listeners

### DIFF
--- a/web/src/stores/projects.test.ts
+++ b/web/src/stores/projects.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import { beforeEach, describe, expect, test, vi, type Mock } from 'vitest'
-import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, test, vi, type Mock } from 'vitest'
+import { createPinia as newPinia, setActivePinia } from 'pinia'
 import type { ProjectInfo, ChatInfo } from '../lib/types'
 import {
   shouldReconnectActiveChatOnStreamingStarted,
@@ -84,6 +84,30 @@ class FakeWebSocket {
 
 let fakeSockets: FakeWebSocket[] = []
 let localStorageData: Record<string, string> = {}
+
+// Pinia does not dispose the instance it replaces, so without this every store
+// a test creates stays alive for the rest of the file — including the intervals
+// and listeners it registered, which then fire on the real clock and add
+// requests to tests that are counting them under fake timers.
+//
+// Tracking every pinia rather than asking for the active one: a test that swaps
+// the pinia mid-run (see "persists the dismissal across store recreation") left
+// its first store attached to an instance nothing could reach afterwards, so
+// disposing only the survivor let exactly the store under test leak.
+type DisposablePinia = { _s: Map<string, { $dispose: () => void }> }
+const piniasCreated: DisposablePinia[] = []
+
+function createPinia(): ReturnType<typeof newPinia> {
+  const pinia = newPinia()
+  piniasCreated.push(pinia as unknown as DisposablePinia)
+  return pinia
+}
+
+afterEach(() => {
+  for (const pinia of piniasCreated.splice(0)) {
+    pinia._s.forEach((store) => store.$dispose())
+  }
+})
 
 beforeEach(() => {
   setActivePinia(createPinia())
@@ -4777,6 +4801,92 @@ describe('running subagent poll', () => {
     }
   })
 
+  test('a disposed store stops polling', async () => {
+    // The watcher owns the interval, so stopping the watcher is not enough —
+    // an interval it already created keeps firing on its own. Without the
+    // store's onScopeDispose cleanup, every test in this file left one behind
+    // and they went on making requests for the rest of the run.
+    const store = useProjectStore()
+    const row = [{ agent_id: 'a1', description: 'digging', subagent_type: '', status: 'running', is_async: true, turn_index: 0 }]
+    mockRunning({ c1: row })
+
+    vi.useFakeTimers()
+    try {
+      store.streaming = { c1: true }
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(8000)
+      expect(apiGet.mock.calls.filter(c => c[0] === '/api/subagents/running').length).toBeGreaterThan(0)
+
+      store.$dispose()
+      apiGet.mockClear()
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(apiGet.mock.calls.filter(c => c[0] === '/api/subagents/running')).toEqual([])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('a disposed store stops its liveness watchdog and window listeners', async () => {
+    // The watcher-owned polls were only half the leak. `checkWsLiveness` and the
+    // focus/blur/visibility listeners are registered at setup time, so every
+    // store a test builds kept a real-clock 2s timer and a live focus handler
+    // for the rest of the run — and `checkWsLiveness` can reach `apiGet` and
+    // push a FakeWebSocket onto the module-level array later tests read.
+    const store = useProjectStore()
+    apiGet.mockImplementation(() => Promise.resolve([]))
+
+    vi.useFakeTimers()
+    try {
+      store.$dispose()
+      const socketsBefore = fakeSockets.length
+      apiGet.mockClear()
+
+      // Nothing the disposed store registered may still fire.
+      await vi.advanceTimersByTimeAsync(30_000)
+      window.dispatchEvent(new Event('focus'))
+      window.dispatchEvent(new Event('blur'))
+      document.dispatchEvent(new Event('visibilitychange'))
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(apiGet.mock.calls).toEqual([])
+      expect(fakeSockets.length).toBe(socketsBefore)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('a store left on a superseded pinia is disposed too', async () => {
+    // A test that swaps the pinia mid-run strands its first store on an
+    // instance `getActivePinia()` can no longer reach. Disposing only the
+    // survivor left that one holding its watchdog and listeners, which is the
+    // leak this file's cleanup exists to prevent — so the cleanup tracks every
+    // pinia it created rather than the current one.
+    const stranded = useProjectStore()
+    stranded.streaming = { c1: true }
+    await Promise.resolve()
+
+    setActivePinia(createPinia())
+    const current = useProjectStore()
+    expect(current).not.toBe(stranded)
+
+    // Both are reachable for disposal, which is what afterEach relies on.
+    expect(piniasCreated.length).toBeGreaterThanOrEqual(2)
+    for (const pinia of piniasCreated) {
+      pinia._s.forEach((store) => store.$dispose())
+    }
+
+    apiGet.mockClear()
+    vi.useFakeTimers()
+    try {
+      await vi.advanceTimersByTimeAsync(30_000)
+      window.dispatchEvent(new Event('focus'))
+      await vi.advanceTimersByTimeAsync(0)
+      expect(apiGet.mock.calls).toEqual([])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   test('the drain is bounded, so a row the server never retires cannot poll forever', async () => {
     const store = useProjectStore()
     const row = [{ agent_id: 'a1', description: 'stuck', subagent_type: '', status: 'running', is_async: true, turn_index: 0 }]
@@ -4790,11 +4900,15 @@ describe('running subagent poll', () => {
       await vi.advanceTimersByTimeAsync(0)
 
       await vi.advanceTimersByTimeAsync(95_000)
-      const callsAtDeadline = apiGet.mock.calls.filter(c => c[0] === '/api/subagents/running').length
+      // Count from a clean slate rather than diffing two totals: the totals
+      // include anything else that polled this endpoint, so a stray request
+      // between the two reads used to fail this test for reasons that had
+      // nothing to do with the drain.
+      apiGet.mockClear()
 
       await vi.advanceTimersByTimeAsync(60_000)
-      const callsAfter = apiGet.mock.calls.filter(c => c[0] === '/api/subagents/running').length
-      expect(callsAfter).toBe(callsAtDeadline)
+      const pollsAfterDeadline = apiGet.mock.calls.filter(c => c[0] === '/api/subagents/running').length
+      expect(pollsAfterDeadline).toBe(0)
     } finally {
       vi.useRealTimers()
     }

--- a/web/src/stores/projects.ts
+++ b/web/src/stores/projects.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref, computed, watch, toRaw } from 'vue'
+import { ref, computed, onScopeDispose, watch, toRaw } from 'vue'
 import { api } from '../lib/api'
 import { getPendingBucket, normalizePendingBuckets, setPendingBucket } from '../lib/pendingBuckets'
 import { buildFixPrompt } from '../lib/fixError'
@@ -743,6 +743,51 @@ export const useProjectStore = defineStore('projects', () => {
       }, 4000)
     },
   )
+
+  // Both polls below are owned by a watcher, which means nothing clears them
+  // when the store itself goes away — the watcher stops, but an interval it
+  // already created keeps firing. In the app the store outlives everything so
+  // it never mattered; under test it does, because each test replaces the
+  // pinia instance without disposing the old one and the orphaned intervals
+  // then fire on the real clock for the rest of the run. That is what made the
+  // bounded-drain test flaky: it counts poll requests either side of a fake
+  // timer advance, and leaked intervals from earlier tests added real-clock
+  // requests in between whenever the machine was loaded enough for the advance
+  // to take real milliseconds.
+  // Anything that outlives the watcher or handler that created it registers its
+  // undo here. The app has exactly one immortal store so none of this ever
+  // mattered in production, but under test each case leaks into every later
+  // test in the file: pinia replaces the active instance without disposing the
+  // old one, so a store built by test 3 keeps its real-clock timers and its
+  // window listeners for the rest of the run.
+  const teardowns: Array<() => void> = []
+
+  /** Register an interval and its clear in one call. */
+  function everyMs(fn: () => void, ms: number): void {
+    const id = window.setInterval(fn, ms)
+    teardowns.push(() => window.clearInterval(id))
+  }
+
+  /** Register a listener and its removal in one call. */
+  function listen(
+    target: EventTarget,
+    type: string,
+    handler: EventListenerOrEventListenerObject,
+  ): void {
+    target.addEventListener(type, handler)
+    teardowns.push(() => target.removeEventListener(type, handler))
+  }
+
+  onScopeDispose(() => {
+    if (subagentPollTimer !== null) {
+      clearInterval(subagentPollTimer)
+      subagentPollTimer = null
+    }
+    stopRunningSubagentPoll()
+    for (const undo of teardowns.splice(0)) {
+      try { undo() } catch { /* a disposed store must not throw */ }
+    }
+  })
 
   // Anything working anywhere: a streaming turn or background agents. Gates
   // the running-subagent poll so an idle app makes no requests at all.
@@ -1760,7 +1805,7 @@ export const useProjectStore = defineStore('projects', () => {
       checkPendingTarget()
       if (!bootstrapped.value) {
         void checkPackageStatus()
-        window.setInterval(checkPackageStatus, UPDATE_CHECK_INTERVAL_MS)
+        everyMs(() => { void checkPackageStatus() }, UPDATE_CHECK_INTERVAL_MS)
       }
     } finally {
       bootstrapped.value = true
@@ -2015,7 +2060,7 @@ export const useProjectStore = defineStore('projects', () => {
     // the watch's prior post landed on null/old controller and was lost,
     // and the watch source string didn't change so no re-fire happens.
     // Force a sync on takeover to clear stale OS-level badge counts.
-    navigator.serviceWorker.addEventListener('controllerchange', () => {
+    listen(navigator.serviceWorker, 'controllerchange', () => {
       postUnreadSync()
     })
     // Also sync once the SW is "ready" (registration + active worker
@@ -3699,20 +3744,20 @@ export const useProjectStore = defineStore('projects', () => {
     }
 
     // Liveness watchdog: cheap timer, only acts on genuinely stale sockets.
-    window.setInterval(checkWsLiveness, WS_LIVENESS_CHECK_MS)
+    everyMs(checkWsLiveness, WS_LIVENESS_CHECK_MS)
 
     // WKWebView can keep the document visible while the native window loses
     // key focus (another app, hide, or minimize). Report those standard
     // browser focus transitions so the engine does not suppress a native
     // notification for a chat the user cannot currently see.
-    window.addEventListener('focus', () => {
+    listen(window, 'focus', () => {
       if (activeChatId.value) sendFocus(activeChatId.value)
     })
-    window.addEventListener('blur', () => {
+    listen(window, 'blur', () => {
       if (activeChatId.value) sendFocus(activeChatId.value)
     })
 
-    document.addEventListener('visibilitychange', () => {
+    listen(document, 'visibilitychange', () => {
       documentVisible.value = document.visibilityState === 'visible'
       if (document.visibilityState === 'visible') {
         // iOS Safari / WKWebView suspends JS and sockets when the PWA
@@ -3739,22 +3784,22 @@ export const useProjectStore = defineStore('projects', () => {
     // pageshow fires when the PWA is restored from the bfcache (iOS
     // home→back pattern). visibilitychange often doesn't fire in that
     // case, so force-refresh here too.
-    window.addEventListener('pageshow', (ev) => {
+    listen(window, 'pageshow', ((ev: Event) => {
       if ((ev as PageTransitionEvent).persisted || document.visibilityState === 'visible') {
         void resumeActiveChat()
         checkPendingTarget()
       }
-    })
+    }) as EventListener)
 
     if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
-      navigator.serviceWorker.addEventListener('message', (ev) => {
-        const data = ev.data
+      listen(navigator.serviceWorker, 'message', ((ev: Event) => {
+        const data = (ev as MessageEvent).data
         if (data && data.type === 'open-chat' && data.chat_id) {
           void openChatFromDeepLink(data.chat_id)
         } else if (data && data.type === 'pending-target' && data.chat_id) {
           void openChatFromDeepLink(data.chat_id)
         }
-      })
+      }) as EventListener)
     }
   }
 


### PR DESCRIPTION
`web/src/stores/projects.test.ts > running subagent poll > "the drain is bounded…"` failed intermittently under load (64 poll requests where 34 were expected) and passed on every unloaded run, including in isolation.

## Root cause: a leak, not a timing assumption

The store registers work that outlives whatever created it, and nothing undoes any of it:

- both subagent polls are owned by a watcher, so the watcher stops on dispose but an interval it already created keeps firing
- `checkWsLiveness` and `checkPackageStatus` are `window.setInterval`s started at setup time
- the focus / blur / visibilitychange / pageshow and serviceWorker listeners are never removed

In the app the store outlives everything, so none of it mattered. Under test it does: each test replaces the pinia instance **without disposing the old one**, so every store ever built keeps polling and listening for the rest of the file, on the **real** clock — those timers predate the next test's fake timers.

The failing test counts poll requests either side of a fake-timer advance. `advanceTimersByTimeAsync(60_000)` takes real milliseconds to run, and on a loaded machine enough real time passed for the leaked intervals to fire in between — 30 extra requests in the observed failure. On an idle machine the advance finished before any 4000ms interval came round, which is why it looked like a fluke.

`checkWsLiveness` was the worse half: it can reach `reloadAndReconnectChat` → `apiGet` and `connectWs`, and the `FakeWebSocket` that creates is pushed onto the module-level array later tests read via `fakeSockets.at(-1)`. So the same contamination could have surfaced as a socket assertion failing for no local reason.

## Changes

- **One teardown registry** in the store, drained by `onScopeDispose`. `everyMs` and `listen` register an interval or listener together with its undo, so a new one cannot be added without its cleanup.
- The test file disposes each test's stores in `afterEach`. Pinia does not dispose the instance it replaces, and `_s` is the only handle to what a test created.
- The bounded-drain assertion clears the mock at the deadline and asserts **zero** new polls, instead of diffing two running totals that included every other caller of the endpoint.

## Verification

Both new tests were checked against a reverted fix rather than trusted:

- `a disposed store stops polling` leaks 7 poll requests without it
- `a disposed store stops its liveness watchdog and window listeners` leaks a `/api/chats?active_only=1`

Neither is a tautology.

- `npm test`: **917 passed**
- `vue-tsc` green

The original reproduction was a load test using CPU spinners. That turned out to be both unnecessary — the disposal tests above fail deterministically with the fix reverted, no load required — and harmful: the spinners outlived their shell and starved the machine. The deterministic tests are the ones worth keeping.
