### PR TITLE
fix(insights): refuse a context overflow on the paths that cannot shrink

### DIFF
--- a/ciao/insights.py
+++ b/ciao/insights.py
@@ -341,6 +341,7 @@ async def call_with_retry(
     model: str = "",
     check_apple_available: bool = True,
     check_context_overflow: bool = True,
+    budget_applies: bool = True,
 ) -> RetryOutcome:
     """Run ``call``; on a transient failure wait 30s and run it once more.
 
@@ -376,14 +377,27 @@ async def call_with_retry(
             logger.info("Apple FoundationModels is unavailable; not retrying: %s", exc)
             return RetryOutcome("", detail, 1, "apple-unavailable")
         if check_context_overflow and is_context_overflow(exc):
-            logger.error(
-                "%s input still exceeds the model's context window (%s); "
-                "not retrying. Lower CIAO_INSIGHTS_MAX_INPUT_CHARS (currently %d) "
-                "or pick a model with a larger window.",
-                label,
-                exc,
-                _max_input_chars(),
-            )
+            # Only the JSONL path fits its payload to CIAO_INSIGHTS_MAX_INPUT_CHARS,
+            # so naming that variable on a text-mode overflow sends the operator
+            # to a setting that does nothing for it. Both messages end at the
+            # remedy that always applies.
+            if budget_applies:
+                logger.error(
+                    "%s input still exceeds the model's context window (%s); "
+                    "not retrying. Lower CIAO_INSIGHTS_MAX_INPUT_CHARS "
+                    "(currently %d) or pick a model with a larger window.",
+                    label,
+                    exc,
+                    _max_input_chars(),
+                )
+            else:
+                logger.error(
+                    "%s input still exceeds the model's context window (%s); "
+                    "not retrying. This path sends the rendered archive whole, "
+                    "so pick a model with a larger window.",
+                    label,
+                    exc,
+                )
             return RetryOutcome("", detail, 1, "context-overflow")
         if is_terminal_failure(exc):
             # Quota / auth / bad-model. No traceback: this is an account or
@@ -1193,19 +1207,24 @@ async def _run_text_model_with_retry(
             body, model, provider=provider, cwd=cwd, context_block=context_block
         )
 
-    # `check_context_overflow=False` preserves this path's existing behaviour,
-    # which differed from the JSONL one: for a cloud model text mode sends the
-    # whole rendered archive without fitting it to a budget, so an overflow
-    # here is retried rather than refused. (Apple models are the exception —
-    # `_call_text_model` fits the body to the Apple window first, so for those
-    # the retry is as doomed as the JSONL path's would be.) Made explicit so
-    # the asymmetry is a decision on the page instead of a difference between
-    # two copies of the same code.
+    # An overflow is refused here for the same reason it is on the JSONL path:
+    # the payload does not change between attempts, so the retry buys a second
+    # slow call (the timeout budget is 600s) plus the 30s wait to reach the
+    # identical rejection. This path used to retry it, which was an accident of
+    # the policy existing in two copies rather than a decision.
+    #
+    # No fitting step, though, unlike the JSONL path — and measurement says it
+    # does not need one. Text mode's input is the *rendered* archive, which is
+    # the stripped rendering (no tool_use, tool_result or thinking blocks); the
+    # 320k-char budget exists for raw JSONL, observed at 131k-262k tokens
+    # against a 126k-token window. Across 1568 real archives the rendered form
+    # runs ~2.6k tokens at the median and ~23k at p99, with exactly one
+    # outlier (134k tokens) able to overflow a 126k-token model at all. Apple
+    # on-device is the one budget that genuinely bites here (8k chars, over half
+    # of all archives), and `_call_text_model` already fits for it. Truncating
+    # the rest would be a general mechanism for a single archive.
     outcome = await call_with_retry(
-        call,
-        label="Insights text call",
-        model=model,
-        check_context_overflow=False,
+        call, label="Insights text call", model=model, budget_applies=False
     )
     return outcome.output, outcome.error
 
@@ -1578,7 +1597,7 @@ async def backfill_insights_task(
                         label=f"Text fallback insights call for {archive_path.name}",
                         model=effective_model,
                         check_apple_available=False,
-                        check_context_overflow=False,
+                        budget_applies=False,
                     )
                     # No `gave_up` branch: every giving-up reason leaves the
                     # output empty, which the check below already reports as an

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -1356,12 +1356,11 @@ def test_call_with_retry_never_retries_a_context_overflow() -> None:
 def test_call_with_retry_can_be_told_to_retry_an_overflow(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The text-mode path's deliberate asymmetry.
+    """The flag still exists for a caller that wants the old behaviour.
 
-    Text mode sends the whole rendered archive without fitting it to a budget,
-    so it retried an overflow before this policy existed and still does. The
-    flag is what keeps that a decision rather than a difference between two
-    copies of the same code.
+    No production path sets it today — text mode used to, by accident of the
+    policy existing in three copies, and now refuses an overflow like the JSONL
+    path does.
     """
     _no_sleep(monkeypatch)
     calls = 0
@@ -1446,3 +1445,117 @@ def test_retry_outcome_distinguishes_never_asked_from_answered_nothing(
     assert never_asked.output == answered_nothing.output == ""
     assert never_asked.gave_up == "terminal"
     assert answered_nothing.gave_up == ""
+
+def test_text_mode_does_not_retry_a_context_overflow(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An oversized archive fails once, not twice.
+
+    Text mode sends the rendered archive unchanged, so a second identical
+    request is rejected identically — at 600s of timeout budget plus the 30s
+    wait, that is ten minutes to learn nothing. It used to retry: the policy
+    existed in three copies and only the JSONL one made this check.
+    """
+    archive = tmp_path / "archive.md"
+    archive.write_text("## Turn 1\n\nhello\n", encoding="utf-8")
+    calls = 0
+
+    async def overflowing(*args: object, **kwargs: object) -> str:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("prompt is too long for this model")
+
+    monkeypatch.setattr(insights, "_call_text_model", overflowing)
+
+    # Zeroed rather than patched, so a regression that reintroduces the retry
+    # fails the call count instead of hanging for 30s.
+    _no_sleep(monkeypatch)
+
+    out, err = asyncio.run(
+        insights._run_text_model_with_retry(archive_path=archive, model="some-model")
+    )
+    assert out == ""
+    assert "too long" in err
+    assert calls == 1
+
+
+def test_text_mode_still_retries_a_transient_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Refusing an overflow must not have turned off retrying in general."""
+    archive = tmp_path / "archive.md"
+    archive.write_text("## Turn 1\n\nhello\n", encoding="utf-8")
+    calls = 0
+
+    async def flaky(*args: object, **kwargs: object) -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise asyncio.TimeoutError()
+        return "## Decisions\n- shipped it"
+
+    monkeypatch.setattr(insights, "_call_text_model", flaky)
+    _no_sleep(monkeypatch)
+
+    out, err = asyncio.run(
+        insights._run_text_model_with_retry(archive_path=archive, model="some-model")
+    )
+    assert err == ""
+    assert "shipped it" in out
+    assert calls == 2
+
+
+def test_backfill_does_not_retry_a_context_overflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The backfill worker refuses an overflow too.
+
+    It sends the rendered archive whole, exactly as text mode does, so a second
+    identical request is rejected identically. This path runs over every archive
+    missing insights, and each doomed retry holds a worker slot for two full
+    600s timeout budgets plus the 30s wait.
+    """
+    _no_sleep(monkeypatch)
+    calls = 0
+
+    async def overflowing() -> str:
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("prompt is too long for this model")
+
+    outcome = asyncio.run(
+        insights.call_with_retry(
+            overflowing,
+            label="Text fallback insights call",
+            check_apple_available=False,
+            budget_applies=False,
+        )
+    )
+    assert outcome.gave_up == "context-overflow"
+    assert calls == 1
+
+
+def test_overflow_log_only_names_the_budget_that_applies(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A text-mode overflow must not send the operator to an inert setting.
+
+    Only the JSONL path fits its payload to CIAO_INSIGHTS_MAX_INPUT_CHARS.
+    Naming that variable on a path that ignores it is advice that cannot work.
+    """
+    async def overflowing() -> str:
+        raise RuntimeError("prompt is too long for this model")
+
+    with caplog.at_level("ERROR"):
+        asyncio.run(insights.call_with_retry(overflowing, label="Insights model call"))
+    assert "CIAO_INSIGHTS_MAX_INPUT_CHARS" in caplog.text
+
+    caplog.clear()
+    with caplog.at_level("ERROR"):
+        asyncio.run(
+            insights.call_with_retry(
+                overflowing, label="Insights text call", budget_applies=False
+            )
+        )
+    assert "CIAO_INSIGHTS_MAX_INPUT_CHARS" not in caplog.text
+    assert "larger window" in caplog.text


### PR DESCRIPTION
**Stacked on #393 — merge that first.** This PR targets `refactor/insights-retry-policy` because it needs `call_with_retry` from it; GitHub will retarget it to `develop` automatically once #393 lands.

## Problem

Text-mode extraction and the backfill worker retried an oversized-input rejection. Neither fits its payload, so the second attempt sends the identical bytes and is rejected identically: **two full 600s timeout budgets plus the 30s wait** to learn nothing. The backfill path runs over every archive missing insights, so each affected archive holds a worker slot ~20 minutes.

The JSONL path always refused this. The other two did not, and that was an accident of the policy existing in three copies rather than a decision.

## Why NOT a fitting step

The first plan was to fit the text payload the way the JSONL path fits its own. Measured against the 1568 archives in a real workspace first:

```
median    9,101 chars  (~2,600 tokens)
p90      29,310 chars  (~8,374 tokens)
p99      81,448 chars  (~23,271 tokens)
max     469,810 chars  (~134,231 tokens)   <- one archive
```

The 320k-char budget exists for the **JSONL** path, sized against raw JSONL observed at 131k–262k tokens versus a 126k-token window (`insights.py` records that measurement). Text mode's input is the **rendered** archive — the stripped form with no `tool_use`, `tool_result` or thinking blocks, which is the whole reason this module exists — so it runs 5–20x smaller.

Exactly **one archive in 1568** could overflow a 126k-token model, and only if the operator points insights at a DeepSeek-class model rather than the `sonnet` default (200k+).

Apple on-device is the one budget that genuinely bites — 8k chars, **53% of archives** — and `_call_text_model` already fits for it.

So truncation would be a general mechanism, plus a policy decision about whether to drop an archive's head or its tail, for a 0.06% case. Refusing fast is the whole fix.

## The `budget_applies` flag

The log line mattered enough to need it. The shared overflow message told the operator to lower `CIAO_INSIGHTS_MAX_INPUT_CHARS`, and the two text paths never consult that setting — so on exactly the paths where an overflow is now terminal, the advice could not work. They now say to pick a model with a larger window, which is the remedy that always applies.

## Verification

- `pytest tests/`: **3286 passed** (4 new)
- `mypy` clean

New tests: an overflow fails once with no sleep on both text paths; a transient failure still retries; and the overflow log names `CIAO_INSIGHTS_MAX_INPUT_CHARS` only on the path that honours it.
