### PR TITLE
fix(memory): route an accepted region fact through the guarded write

### DIFF
--- a/ciao/memory_proposals.py
+++ b/ciao/memory_proposals.py
@@ -368,13 +368,29 @@ def _promote_to_region(
     the consolidations undo log first — and ``{"action": "add"}`` or ``None``
     is the plain append path.
     """
-    from ciao.memory_tool import ensure_regions, read_region, resolve_region, write_region
+    from ciao.memory_tool import (
+        _guide_lock,
+        ensure_regions,
+        read_region,
+        resolve_region,
+        write_region,
+    )
 
     promotable = _promotable_text(proposal.text)
     if promotable is None:
         return "unshaped", None
     from ciao.memory_audit import strip_learned_stamp
 
+    # The whole read-merge-write, under the same lock `update_region` takes.
+    # Without it two concurrent accepts — or an accept racing an MCP
+    # /remember — both read the region, both append to their own snapshot, and
+    # the second write drops the first fact while its row is dismissed as
+    # promoted.
+    lock = None
+    try:
+        lock = _guide_lock(guide_path)
+    except Exception:  # noqa: BLE001 — a lock we cannot take must not block a write
+        lock = None
     try:
         ensure_regions(guide_path)
         region = resolve_region(proposal.target)
@@ -404,14 +420,23 @@ def _promote_to_region(
             # A model verdict, not a provable string match: leave a trace in
             # the undo log so a hallucinated "covered" never silently loses
             # the fact — the standing "nothing is dropped silently" contract.
-            if vault_root is not None:
+            # With nowhere to write that trace, honour the contract instead of
+            # the verdict and take the plain append: a duplicate is visible and
+            # removable, a silently dropped fact is neither.
+            if vault_root is None:
+                logger.info(
+                    "memory apply: reconcile said covered but there is no vault "
+                    "to log it to; appending instead of dropping %r",
+                    promotable[:80],
+                )
+            else:
                 _log_consolidation(
                     vault_root,
                     region,
                     f"(incoming fact judged covered; not written) {promotable}",
                     label="auto-reconcile covered",
                 )
-            return "duplicate", promotable
+                return "duplicate", promotable
         if action == "update" and vault_root is not None:
             index = decision.get("index")
             merged = str(decision.get("text", "")).strip()
@@ -436,9 +461,9 @@ def _promote_to_region(
                 )
             ):
                 old = entries[index - 1]
-                _log_consolidation(vault_root, region, old)
                 updated = list(entries)
                 updated[index - 1] = f"{merged} [{date.today().isoformat()}]"
+                _log_consolidation(vault_root, region, old)
                 write_region(guide_path, region, updated)
                 logger.info(
                     "memory apply: reconciled update of entry %d in ciao:%s",
@@ -458,6 +483,46 @@ def _promote_to_region(
     except Exception as exc:  # noqa: BLE001 — one bad write must not stop a batch
         logger.info("memory apply: falling back to proposals (%s)", exc)
         return "failed", promotable
+    finally:
+        if lock is not None:
+            try:
+                lock.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+
+def accept_region_fact(
+    *,
+    guide_path: Path,
+    target: str,
+    text: str,
+    vault_root: Path | None,
+    decision: dict[str, Any] | None = None,
+) -> tuple[str, str | None]:
+    """Write one approved region fact through the guarded path.
+
+    The UI accept button used to call ``update_region(action="add")`` directly,
+    which skipped everything the archive-time path does: the event-shape guard
+    (so an event-shaped bullet landed verbatim in always-loaded context), the
+    stamp-stripped duplicate check, the learned-at stamp the aging audit reads,
+    and the consolidations undo log.
+
+    Deliberately synchronous and model-free. Reconciliation belongs here in
+    principle — accepting an updated preference still appends beside the entry
+    it supersedes — but one ``run_oneshot`` per row on a click is a 120s timeout
+    each, and the batch endpoint accepts rows sequentially inside one request.
+    A caller that has already reconciled elsewhere may pass ``decision``; the
+    click path passes none.
+
+    Returns ``_promote_to_region``'s ``(outcome, promotable)``.
+    """
+    proposal = MemoryProposal(target=target, text=text, source_section="review")
+    return _promote_to_region(
+        proposal,
+        guide_path,
+        vault_root=vault_root,
+        decision=decision,
+    )
 
 
 def _safe_name(name: str) -> str:
@@ -816,58 +881,88 @@ async def plan_region_reconcile(
     if not by_region:
         return None
 
-    from ciao.providers.oneshot import run_oneshot
-
     decisions: dict[str, dict[str, Any]] = {}
     for region_name, candidates in by_region.items():
-        entries = entries_by_region[region_name]
-        numbered = "\n".join(
-            f"{index}. {entry}" for index, entry in enumerate(entries, start=1)
+        rows = await _reconcile_region(
+            region_name,
+            entries_by_region[region_name],
+            candidates,
+            model=model,
+            provider=provider,
+            cwd=cwd,
         )
-        lettered = "\n".join(
-            f"{chr(ord('A') + index)}. {fact}"
-            for index, fact in enumerate(candidates)
-        )
-        prompt = (
-            f"Region `ciao:{region_name}` current entries:\n{numbered}\n\n"
-            f"Candidate facts:\n{lettered}\n"
-        )
-        try:
-            reply = await run_oneshot(
-                prompt,
-                system_prompt=_RECONCILE_SYSTEM_PROMPT,
-                model=model,
-                timeout_s=_RECONCILE_TIMEOUT_S,
-                provider=provider,
-                cwd=cwd,
-            )
-        except Exception as exc:  # noqa: BLE001 — degrade to plain appends
-            logger.info("memory reconcile: call failed (%s); using plain adds", exc)
-            continue
-        rows = _parse_reconcile_reply(reply, len(candidates))
         if rows is None:
-            logger.info(
-                "memory reconcile: unparseable reply for ciao:%s; using plain adds",
-                region_name,
-            )
             continue
         for fact, row in zip(candidates, rows):
-            if row.get("action") == "update":
-                index = row.get("index")
-                if not (isinstance(index, int) and 1 <= index <= len(entries)):
-                    # Out-of-range against the very snapshot the model saw:
-                    # degrade now rather than carry a junk decision around.
-                    row = {"action": "add"}
-                else:
-                    # Snapshot the entry this index named at plan time. The
-                    # apply step re-reads the region and refuses the update if
-                    # the entry changed during the model call — the index
-                    # would otherwise overwrite an unrelated fact.
-                    row = dict(row)
-                    row["old"] = entries[index - 1]
             decisions[_decision_key(region_name, fact)] = row
 
     return decisions or None
+
+
+async def _reconcile_region(
+    region_name: str,
+    entries: list[str],
+    candidates: list[str],
+    *,
+    model: str,
+    provider: str = "claude",
+    cwd: Path | None = None,
+) -> list[dict[str, Any]] | None:
+    """One reconcile call: decide ADD / UPDATE / COVERED per candidate.
+
+    Returns one row per candidate in the given order, or None when the call
+    failed or replied unparseably — every caller then degrades to the plain
+    append path, which never blocks and never loses a fact.
+
+    An ``update`` row carries ``old``: the entry its index named in the snapshot
+    the model actually saw. The apply step re-reads the region and refuses the
+    update if that entry changed during the call, so a stale index cannot
+    overwrite an unrelated fact.
+    """
+    from ciao.providers.oneshot import run_oneshot
+
+    numbered = "\n".join(
+        f"{index}. {entry}" for index, entry in enumerate(entries, start=1)
+    )
+    lettered = "\n".join(
+        f"{chr(ord('A') + index)}. {fact}" for index, fact in enumerate(candidates)
+    )
+    prompt = (
+        f"Region `ciao:{region_name}` current entries:\n{numbered}\n\n"
+        f"Candidate facts:\n{lettered}\n"
+    )
+    try:
+        reply = await run_oneshot(
+            prompt,
+            system_prompt=_RECONCILE_SYSTEM_PROMPT,
+            model=model,
+            timeout_s=_RECONCILE_TIMEOUT_S,
+            provider=provider,
+            cwd=cwd,
+        )
+    except Exception as exc:  # noqa: BLE001 — degrade to plain appends
+        logger.info("memory reconcile: call failed (%s); using plain adds", exc)
+        return None
+    rows = _parse_reconcile_reply(reply, len(candidates))
+    if rows is None:
+        logger.info(
+            "memory reconcile: unparseable reply for ciao:%s; using plain adds",
+            region_name,
+        )
+        return None
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        if row.get("action") == "update":
+            index = row.get("index")
+            if not (isinstance(index, int) and 1 <= index <= len(entries)):
+                # Out-of-range against the very snapshot the model saw:
+                # degrade now rather than carry a junk decision around.
+                row = {"action": "add"}
+            else:
+                row = dict(row)
+                row["old"] = entries[index - 1]
+        out.append(row)
+    return out
 
 
 # ── Persistence ───────────────────────────────────────────────────────────

--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -8157,6 +8157,14 @@ async def proposals_batch(request: Request) -> JSONResponse:
                     result["region"] = outcome.get("region", accept.region)
                     result["promoted"] = bool(outcome.get("ok"))
                     result["leak_warning"] = row.get("leak_warning", False)
+                    # What actually landed, which is not always the row's text:
+                    # the event-shape guard can promote only a bullet's trailing
+                    # "Durable rule:" clause. `duplicate` says the fact was
+                    # already there and nothing was written.
+                    if outcome.get("written"):
+                        result["written"] = outcome["written"]
+                    if outcome.get("duplicate"):
+                        result["duplicate"] = True
                     if failed:
                         result["error"] = outcome.get("error", "could not write the region")
                 elif accept.action in ("fold_doc", "write_people_note", "append_learnings"):
@@ -8186,18 +8194,24 @@ def _promote_region_row(config, row: dict[str, Any]) -> dict[str, Any]:
     curation prompt states: the reverse loses the fact if anything fails between
     the two steps. So this returns a failure and the caller keeps the bullet.
 
+    Goes through ``accept_region_fact`` rather than ``update_region`` directly,
+    so a click gets what an archive-time promotion gets: the event-shape guard,
+    the stamp-stripped duplicate check, the learned-at stamp the aging audit
+    reads, and the consolidations undo log. It takes the same guide lock
+    ``update_region`` did.
+
+    The region cap stays ADVISORY, as `update_region` documents: enforcing it
+    made the accept button dead for 67 of 130 queued proposals on a real vault.
+    Usage is reported, never used to refuse.
+
     The guide is resolved through ``agent_root``, so before the re-rooting this
     writes the shared guide (and the row's ``leak_warning`` is why the UI asks
     for confirmation first) and afterwards that workspace's own.
     """
-    from ciao.memory_tool import ensure_regions, resolve_region as _resolve, update_region
+    from ciao.memory_proposals import accept_region_fact
+    from ciao.memory_tool import ensure_regions, memory_status, resolve_region as _resolve
 
     region = _resolve(row.get("region") or row["kind"])
-    limit = int(
-        getattr(config, "memory_char_limit", 3000)
-        if region == "memory"
-        else getattr(config, "user_char_limit", 1375)
-    )
     guide = Path(config.agent_root(row["workspace"])) / "CLAUDE.md"
     try:
         # A guide with no region markers yet is not a reason to refuse a
@@ -8206,13 +8220,59 @@ def _promote_region_row(config, row: dict[str, Any]) -> dict[str, Any]:
         ensure_regions(guide)
     except (OSError, ValueError) as exc:
         return {"ok": False, "error": f"could not prepare {guide}: {exc}", "region": region}
+
     try:
-        result = update_region(
-            guide, region, action="add", entry=row["text"], char_limit=limit
+        vault_root = Path(config.workspace_vault_root(row["workspace"]))
+    except (AttributeError, ValueError):
+        # Only the undo log needs it; a promotion must not fail for want of one.
+        vault_root = None
+
+    try:
+        outcome, promotable = accept_region_fact(
+            guide_path=guide,
+            target=row.get("region") or row["kind"],
+            text=row["text"],
+            vault_root=vault_root,
         )
     except (ValueError, OSError) as exc:
         return {"ok": False, "error": str(exc), "region": region}
-    return {"ok": True, "region": region, "usage": result.get("usage", {})}
+
+    def _usage() -> dict[str, Any]:
+        try:
+            status = memory_status(
+                guide,
+                memory_char_limit=int(getattr(config, "memory_char_limit", 3000)),
+                user_char_limit=int(getattr(config, "user_char_limit", 1375)),
+            )
+        except Exception:  # noqa: BLE001 — usage is advisory reporting only
+            return {}
+        if not isinstance(status, dict):
+            return {}
+        entry = status.get(region, {})
+        return dict(entry) if isinstance(entry, dict) else {}
+
+    if outcome == "written":
+        # `written` is reported because the guard can promote only the trailing
+        # durable-rule clause of a bullet, so what landed is not always the
+        # sentence the operator read on the row.
+        return {"ok": True, "region": region, "written": promotable, "usage": _usage()}
+    if outcome == "duplicate":
+        # Already remembered. The fact is in the region either way, so the row
+        # is resolved and may leave the queue.
+        return {"ok": True, "region": region, "duplicate": True, "usage": _usage()}
+    if outcome == "unshaped":
+        # Event-shaped text is exactly what the region must not hold; this used
+        # to be written verbatim. The row stays queued.
+        return {
+            "ok": False,
+            "region": region,
+            "error": (
+                "this reads as an event, not a standing rule, so it would rot "
+                "in always-loaded memory. Use \u201ctalk about it\u201d to rephrase it as "
+                "what is true from now on, then accept."
+            ),
+        }
+    return {"ok": False, "region": region, "error": f"could not write ciao:{region}"}
 
 
 def _accept_people_row(config, row: dict[str, Any]) -> dict[str, Any]:
@@ -8425,6 +8485,12 @@ async def proposal_action(request: Request) -> JSONResponse:
             result["promoted"] = True
             result["usage"] = promoted.get("usage", {})
             result["leak_warning"] = row.get("leak_warning", False)
+            # See the batch builder: the text written can differ from the row's,
+            # and a duplicate resolves the row without writing anything.
+            if promoted.get("written"):
+                result["written"] = promoted["written"]
+            if promoted.get("duplicate"):
+                result["duplicate"] = True
         elif accept.action in ("fold_doc", "write_people_note", "append_learnings"):
             result["promoted"] = True
             result["destination"] = promoted.get("destination", "")

--- a/tests/test_memory_proposals.py
+++ b/tests/test_memory_proposals.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import re
 import unittest.mock
@@ -1494,3 +1495,156 @@ def test_already_applied_guard_scopes_negation_to_its_own_bullet(
     assert not mp._is_already_in_file(
         destination, "Commit secrets to the repository"
     )
+
+
+# ── accept_region_fact: the UI accept path's guards ───────────────────────
+#
+# Accepting a queued fact used to call `update_region(action="add")` directly,
+# which skipped every guard the archive-time path applies. These pin what a
+# click now gets — and, just as importantly, what it must NOT have acquired.
+
+
+def _guide_with(tmp_path: Path, region: str, entries: list[str]) -> Path:
+    from ciao.memory_tool import ensure_regions, write_region
+
+    guide = tmp_path / "CLAUDE.md"
+    guide.write_text("# Guide\n", encoding="utf-8")
+    ensure_regions(guide)
+    if entries:
+        write_region(guide, region, entries)
+    return guide
+
+
+def _entries(guide: Path, region: str) -> list[str]:
+    from ciao.memory_audit import strip_learned_stamp
+    from ciao.memory_tool import read_region
+
+    entries, _diags = read_region(guide, region)
+    return [strip_learned_stamp(e) for e in entries]
+
+
+def test_accept_refuses_event_shaped_text(tmp_path):
+    """The guard that matters most: always-loaded context must hold rules.
+
+    An event-shaped bullet used to be written verbatim, which is exactly the
+    rot the shipped memory audit flags.
+    """
+    guide = _guide_with(tmp_path, "memory", [])
+    outcome, _ = mp.accept_region_fact(
+        guide_path=guide,
+        target="memory",
+        text="The user asked me to check the logs and I found the bug.",
+        vault_root=tmp_path,
+    )
+    assert outcome == "unshaped"
+    assert _entries(guide, "memory") == []
+
+
+def test_accept_writes_a_state_shaped_fact_with_a_stamp(tmp_path):
+    guide = _guide_with(tmp_path, "memory", [])
+    outcome, promotable = mp.accept_region_fact(
+        guide_path=guide,
+        target="memory",
+        text="Prefers tabs over spaces.",
+        vault_root=tmp_path,
+    )
+    assert outcome == "written"
+    assert promotable == "Prefers tabs over spaces."
+    assert _entries(guide, "memory") == ["Prefers tabs over spaces."]
+    # The stamp the aging audit reads. Without it a UI-accepted fact was
+    # invisible to re-verification forever.
+    from ciao.memory_tool import read_region
+
+    raw, _ = read_region(guide, "memory")
+    assert re.search(r"\[\d{4}-\d{2}-\d{2}\]$", raw[0])
+
+
+def test_accept_drops_a_stamp_stripped_duplicate(tmp_path):
+    """The same fact accepted twice is one entry, whatever day it was."""
+    guide = _guide_with(tmp_path, "memory", ["Prefers tabs over spaces. [2020-01-01]"])
+    outcome, _ = mp.accept_region_fact(
+        guide_path=guide,
+        target="memory",
+        text="Prefers tabs over spaces.",
+        vault_root=tmp_path,
+    )
+    assert outcome == "duplicate"
+    assert _entries(guide, "memory") == ["Prefers tabs over spaces."]
+
+
+def test_accept_still_writes_past_the_advisory_cap(tmp_path):
+    """The cap is ADVISORY and must stay that way.
+
+    `update_region` says so outright: enforcing it "made the accept button dead
+    for 67 of 130 queued proposals" on a real vault, and
+    tests/test_memory_tool.py pins that. Routing accept through the guarded
+    write must not quietly reinstate the wall.
+    """
+    guide = _guide_with(tmp_path, "memory", ["x" * 5000])
+    outcome, _ = mp.accept_region_fact(
+        guide_path=guide,
+        target="memory",
+        text="Prefers tabs over spaces.",
+        vault_root=tmp_path,
+    )
+    assert outcome == "written"
+    assert "Prefers tabs over spaces." in _entries(guide, "memory")
+
+
+def test_accept_makes_no_model_call(tmp_path, monkeypatch):
+    """A click must not block on a provider.
+
+    Reconciliation would be welcome here, but one `run_oneshot` per row is a
+    120s timeout each and the batch endpoint accepts rows sequentially inside a
+    single request — 30 rows would be up to an hour. It stays out of this path.
+    """
+    async def must_not_run(prompt, **kwargs):
+        raise AssertionError("the accept path must not call a model")
+
+    monkeypatch.setattr("ciao.providers.oneshot.run_oneshot", must_not_run)
+    guide = _guide_with(tmp_path, "memory", ["Prefers tabs over spaces. [2020-01-01]"])
+    outcome, _ = mp.accept_region_fact(
+        guide_path=guide,
+        target="memory",
+        text="Prefers spaces over tabs.",
+        vault_root=tmp_path,
+    )
+    assert outcome == "written"
+
+
+def test_accept_applies_a_reconcile_decision_it_is_handed(tmp_path):
+    """The seam a future reconcile pass writes through."""
+    guide = _guide_with(tmp_path, "memory", ["Prefers tabs over spaces. [2020-01-01]"])
+    outcome, _ = mp.accept_region_fact(
+        guide_path=guide,
+        target="memory",
+        text="Prefers spaces over tabs.",
+        vault_root=tmp_path,
+        decision={
+            "action": "update",
+            "index": 1,
+            "text": "Prefers spaces over tabs.",
+            "old": "Prefers tabs over spaces. [2020-01-01]",
+        },
+    )
+    assert outcome == "written"
+    assert _entries(guide, "memory") == ["Prefers spaces over tabs."]
+
+
+def test_a_covered_verdict_with_no_vault_appends_rather_than_dropping(tmp_path):
+    """Nothing is dropped without a trace — the standing contract.
+
+    `covered` is a model verdict, not a provable match. With no vault to log it
+    to, honour the contract instead of the verdict: a duplicate is visible and
+    removable, a silently dropped fact is neither.
+    """
+    guide = _guide_with(tmp_path, "memory", ["Prefers tabs over spaces. [2020-01-01]"])
+    outcome, _ = mp.accept_region_fact(
+        guide_path=guide,
+        target="memory",
+        text="Prefers spaces over tabs.",
+        vault_root=None,
+        decision={"action": "covered"},
+    )
+    assert outcome == "written"
+    assert "Prefers spaces over tabs." in _entries(guide, "memory")

--- a/tests/test_web_proposals.py
+++ b/tests/test_web_proposals.py
@@ -497,11 +497,20 @@ def test_the_real_app_serves_every_documented_proposal_route() -> None:
 
 
 def _region_entries(config, workspace: str, region: str) -> list[str]:
+    """A region's entries with their learned-at stamps removed.
+
+    Accepting a fact goes through the same guarded write as an archive-time
+    promotion, which appends `[YYYY-MM-DD]` — the stamp the aging audit reads to
+    surface facts that have not been re-verified. Stripping it here is the same
+    normalisation the production dedupe does, and keeps these assertions from
+    depending on today's date.
+    """
+    from ciao.memory_audit import strip_learned_stamp
     from ciao.memory_tool import read_region
 
     guide = Path(config.agent_root(workspace)) / "CLAUDE.md"
     entries, _diags = read_region(guide, region)
-    return entries
+    return [strip_learned_stamp(entry) for entry in entries]
 
 
 def test_accept_writes_the_fact_into_the_region(tmp_path: Path) -> None:
@@ -1133,3 +1142,66 @@ def test_removing_a_bullet_that_is_already_gone_is_a_no_op():
 
     assert _remove_bullet_line(lines, 0, "- [memory] already dismissed") is False
     assert lines == ["- [memory] someone else's"]
+
+
+def test_accept_reports_the_text_it_actually_wrote(tmp_path: Path) -> None:
+    """What landed is not always the sentence on the row.
+
+    The event-shape guard promotes only a bullet's trailing "Durable rule:"
+    clause, so a caller echoing the row's own text would tell the user something
+    different from what is now in the region. The endpoint reports what it wrote.
+    """
+    config = _config(tmp_path)
+    for ws in ("personal", "work"):
+        (config.workspace_vault_root(ws) / "Workspace").mkdir(parents=True, exist_ok=True)
+    _write_queue(
+        config,
+        "personal",
+        "# Memory Proposals\n\n"
+        "- [memory] User asked me to stop using em dashes. "
+        "Durable rule: Avoid em dashes; use commas.  _(from: Decisions)_\n",
+    )
+    client = _client(config)
+    row = _accept_kind_row(client, "memory")
+
+    resp = client.post(f"/api/proposals/{row['id']}/accept")
+    assert resp.status_code == 200
+    result = resp.json()["result"]
+    assert result["promoted"] is True
+    assert result["written"] == "Avoid em dashes; use commas."
+    assert "Avoid em dashes; use commas." in _region_entries(
+        config, row["workspace"], "memory"
+    )
+
+
+def test_accept_reports_a_duplicate_rather_than_claiming_a_write(tmp_path: Path) -> None:
+    """A row already in the region resolves, but nothing was written.
+
+    Without this the caller cannot tell "stored" from "was already there",
+    which is the difference between a write and a no-op.
+    """
+    config = _config(tmp_path)
+    for ws in ("personal", "work"):
+        (config.workspace_vault_root(ws) / "Workspace").mkdir(parents=True, exist_ok=True)
+    fact = "Prefers direct implementation over discussion."
+    _write_queue(
+        config,
+        "personal",
+        f"# Memory Proposals\n\n- [memory] {fact}  _(from: Decisions)_\n",
+    )
+    client = _client(config)
+    row = _accept_kind_row(client, "memory")
+    first = client.post(f"/api/proposals/{row['id']}/accept")
+    assert first.status_code == 200
+    assert "duplicate" not in first.json()["result"]
+
+    # Queue the identical fact again; the region already holds it.
+    _write_queue(
+        config,
+        "personal",
+        f"# Memory Proposals\n\n- [memory] {fact}  _(from: Decisions)_\n",
+    )
+    again = _accept_kind_row(client, "memory")
+    resp = client.post(f"/api/proposals/{again['id']}/accept")
+    assert resp.status_code == 200
+    assert resp.json()["result"]["duplicate"] is True


### PR DESCRIPTION
Closes the review finding on #397 (P2, "Avoid promising reconciliation that approval bypasses").

## Problem

Clicking Accept on a `[memory]`/`[profile]` row called `update_region(action="add")` directly, so it skipped everything an archive-time promotion does:

- **the event-shape guard** — "The user asked me to check the logs and I found the bug" landed verbatim in always-loaded context, exactly the rot the shipped memory audit flags
- **the stamp-stripped duplicate check** — the same fact accepted on two days became two entries
- **the learned-at stamp** the aging audit reads, so a UI-accepted fact was invisible to re-verification forever
- **the consolidations undo log**

## Change

`accept_region_fact` is the guarded entry point, and `_promote_to_region` now takes the guide lock around its read-merge-write. `update_region` held that lock; `write_region` does not — so without it two concurrent accepts, or an accept racing an MCP `/remember`, could both read the region, both append to their own snapshot, and let the second write drop the first fact **while its row was dismissed as promoted**.

## What I deliberately did NOT do, and why

Two things an earlier draft of this PR got wrong. Both were caught by review before pushing.

**1. No reconciliation on the click path**, even though the finding asked for it. One `run_oneshot` per row is a 120s timeout each, and the batch endpoint accepts rows sequentially inside one request — thirty rows would be **up to an hour in a single HTTP call**. `accept_region_fact` takes an optional `decision` instead: the seam an out-of-band reconcile pass writes through. A test pins that the click path makes no model call. Archive-time promotion still reconciles as it always did.

Reconciling manually-accepted facts is still worth doing — as a background pass over the region, not inline. Happy to open that as its own issue.

**2. The region cap stays ADVISORY.** My first draft threaded `char_limit` into the guarded write to preserve what `update_region` appeared to enforce. It does not enforce it, and says why: a hard cap *"made the accept button dead for 67 of 130 queued proposals"* on a real vault, which `tests/test_memory_tool.py` pins. A test now pins that an over-cap accept still writes.

## Also

A `covered` verdict with no vault to log it to now appends rather than dropping. That verdict is a model judgement, not a provable match, and the standing contract is that nothing is dropped without a trace — a duplicate is visible and removable, a silently dropped fact is neither.

`_reconcile_region` is factored out of `plan_region_reconcile` so the archive path and any future caller share one prompt, one parser, and one snapshot-staleness rule for `update` indices. Behaviour-neutral there; its 70 existing tests pass untouched.

## Two visible behaviour changes, both intended

- An **event-shaped row stays queued**, with a message pointing at "talk about it" to rephrase it, instead of being written.
- **Accepted entries carry a `[YYYY-MM-DD]` stamp**, and the response reports the text actually written — the guard can promote only a bullet's trailing "Durable rule:" clause, so it is not always the sentence on the row.

## Verification

- `pytest tests/`: **3280 passed** (7 new)
- `mypy` clean