### PR TITLE
fix(config): pwa_host default is 0.0.0.0 everywhere

### DIFF
--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -296,7 +296,9 @@ Runtime config for the Ciaobot server itself (PWA, schedules, deploy).
   host's too (that card is proxied). The local token still guards this machine's
   own never-proxied routes, `/api/node/*` and `/api/device/*`.
 - `CIAO_PUSH_CONTACT` (optional): push notification contact string for the Web Push VAPID subject, for example `mailto:you@example.com`. Empty disables Web Push delivery until set (in `.env` or Settings), but the macOS menu-bar companion still posts local alerts from the runtime notification log. Read mutations emit a clear control for matching delivered PWA and macOS notifications.
-- `PWA_PORT` (default `8443`), `PWA_HOST` (default `0.0.0.0`).
+- `PWA_PORT` (default `8443`), `PWA_HOST` (default `0.0.0.0`). The server binds
+  all interfaces so the PWA is reachable over LAN and Tailscale; set
+  `PWA_HOST=127.0.0.1` in `.env` for loopback-only access.
 - `CIAO_RUNTIME_ROOT` (optional): runtime-state directory. `Ciaobot.app` reads
   this from the configured workspace `.env` and resolves a relative value
   against the workspace.

--- a/ciao/config.py
+++ b/ciao/config.py
@@ -475,7 +475,11 @@ class CiaoConfig:
     auto_sync_on_start: bool = False
     auto_vault_index: bool = True
     pwa_port: int = 8443
-    pwa_host: str = "127.0.0.1"
+    # The server binds all interfaces by default so the PWA is reachable over
+    # LAN and Tailscale; the dashboard password + login rate limit are the
+    # access control. Set ``PWA_HOST=127.0.0.1`` in ``.env`` for loopback-only.
+    # This must stay equal to the ``PWA_HOST`` fallback in ``from_env`` below.
+    pwa_host: str = "0.0.0.0"
     gws_default_profile: str = "personal"
     # Per-provider default model for new chats, set from the PWA Settings →
     # Models tab. Empty means the provider's own default applies.
@@ -1396,7 +1400,7 @@ class CiaoConfig:
             auto_vault_index=source.get("CIAO_AUTO_VAULT_INDEX", "true").strip().lower()
             not in {"0", "false", "no", "off"},
             pwa_port=int(source.get("PWA_PORT", "8443")),
-            pwa_host=source.get("PWA_HOST", "0.0.0.0").strip(),
+            pwa_host=(source.get("PWA_HOST") or "0.0.0.0").strip() or "0.0.0.0",
             gws_default_profile=gws_default_profile,
             workspaces=workspaces,
             insights_enabled=source.get("CIAO_INSIGHTS_DISABLED", "").strip().lower()

--- a/tests/test_pwa_host_default.py
+++ b/tests/test_pwa_host_default.py
@@ -1,0 +1,32 @@
+"""Tests for the `pwa_host` default and its `.env` parsing fallback.
+
+Issue #389: the dataclass default said loopback while the `.env` fallback (and
+the actual server bind) said all interfaces. Both must stay equal.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from ciao.config import CiaoConfig
+
+
+def test_pwa_host_default_binds_all_interfaces():
+    assert CiaoConfig.from_env({}).pwa_host == "0.0.0.0"
+
+
+def test_pwa_host_dataclass_default_matches_env_fallback():
+    # CiaoConfig has many required fields; compare the dataclass default via
+    # dataclasses.fields instead of constructing an instance.
+    field = next(
+        f for f in dataclasses.fields(CiaoConfig) if f.name == "pwa_host"
+    )
+    assert field.default == CiaoConfig.from_env({}).pwa_host
+
+
+def test_pwa_host_env_override_is_honoured():
+    assert CiaoConfig.from_env({"PWA_HOST": " 127.0.0.1 "}).pwa_host == "127.0.0.1"
+
+
+def test_pwa_host_empty_env_value_falls_back_to_default():
+    assert CiaoConfig.from_env({"PWA_HOST": ""}).pwa_host == "0.0.0.0"


### PR DESCRIPTION
Closes #389

The real default bind is `0.0.0.0`: a dashboard password is required by default and login is rate-limited (`ciao/web/routes_auth.py`), while Tailscale and LAN access — the documented remote-access paths — both need a non-loopback bind, and `ciao/network_addresses.py:36` already documents `0.0.0.0` as the bind. So the dataclass default now matches the `.env` fallback instead of contradicting it; an empty `PWA_HOST=` line in `.env` also falls back to the default instead of producing an empty bind host. The `.env` parsing fallback value and the setup wizard are unchanged.

## Tests added

`tests/test_pwa_host_default.py`:
- `test_pwa_host_default_binds_all_interfaces` — `from_env({})` yields `0.0.0.0`
- `test_pwa_host_dataclass_default_matches_env_fallback` — the dataclass default equals the `from_env` fallback (pinned via `dataclasses.fields`)
- `test_pwa_host_env_override_is_honoured` — whitespace is stripped from overrides
- `test_pwa_host_empty_env_value_falls_back_to_default` — empty `PWA_HOST=` does not produce an empty bind host

## Verification

```
PYTHONPATH=$PWD python -m pytest tests/test_pwa_host_default.py tests/test_env_vars_documented.py tests/test_config_role.py -q
24 passed

PYTHONPATH=$PWD python -m pytest tests/ -q
3323 passed
```

Docs: `INTEGRATIONS.md` now states the `PWA_HOST` default and the `127.0.0.1` loopback-only option.