### PR TITLE
fix: resolve session blobs against the chat's own agent root

### DIFF
--- a/ciao/control_plane.py
+++ b/ciao/control_plane.py
@@ -1281,7 +1281,12 @@ class CiaoControlPlane:
             created_at=now,
             model=str(values.get("model") or ""),
             provider=str(values.get("provider") or ""),
-            mode=str(values.get("mode") or "auto"),  # type: ignore[arg-type]
+            # "" means inherit, exactly as an empty model/provider does: the
+            # permission mode is resolved from the operator's per-provider pin
+            # at dispatch. The MCP schedule tool exposes no `mode` at all, so
+            # the old "auto" default was an unconditional override that made the
+            # dispatcher's inheritance dead for every model-created routine.
+            mode=str(values.get("mode") or ""),
             timezone_name=str(values.get("timezone") or values.get("timezone_name") or "UTC"),
             days_of_week=list(values.get("days_of_week") or []),
             frequency=frequency,
@@ -1604,7 +1609,7 @@ class CiaoControlPlane:
             # Empty model/mode is what makes each run inherit the target chat's
             # own settings, which is how loops always behaved.
             model="",
-            mode="auto",
+            mode="",
             chat_id=0,
             frequency=INTERVAL_FREQUENCY,
             interval_minutes=minutes,

--- a/ciao/insights.py
+++ b/ciao/insights.py
@@ -31,7 +31,7 @@ import json
 import logging
 import os
 import re
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -1420,12 +1420,18 @@ async def backfill_insights_task(
     workspace: str = "",
     model_override: str = "",
     agent_root: Path | None = None,
+    chat_workspaces: Mapping[str, str] | None = None,
 ) -> dict[str, int]:
     """Scan archived transcripts and return counts for the completed run.
 
     *model_override* runs this pass with an explicit model instead of the
     configured one, without changing the stored setting — the retry path when
     the configured insights model keeps failing.
+
+    *chat_workspaces* maps chat id to workspace, and is required to scope a
+    run with *workspace*: an archive's path names the chat that wrote it, not
+    the workspace it ran in, so the mapping has to come from the chat registry.
+    A *workspace* given without one filters nothing and says so.
 
     *agent_root* pins the run to one workspace's agent root. Callers that
     supply nothing get every agent root in the install searched for each
@@ -1453,6 +1459,15 @@ async def backfill_insights_task(
             search_roots = [config.workspace_root]
     project_dirs = [(r, _claude_projects_dir(r)) for r in search_roots]
 
+    by_chat = dict(chat_workspaces or {})
+    if workspace and not by_chat:
+        logger.warning(
+            "Backfill asked for workspace %r without a chat->workspace map; "
+            "scanning every archive instead",
+            workspace,
+        )
+        workspace = ""
+
     def _discover() -> tuple[list[tuple[Path, str, Path | None]], int, int]:
         """Walk the archive tree and decide what needs backfilling.
 
@@ -1474,7 +1489,7 @@ async def backfill_insights_task(
             # Cheap filters first. _has_insights_section reads the whole file,
             # so a workspace-scoped run must not pay for every archive in the
             # vault before discarding it.
-            if workspace and md.parent.parent.name != workspace:
+            if workspace and by_chat.get(md.parent.parent.name, "") != workspace:
                 continue
 
             match = SESSION_ID_RE.search(md.name)

--- a/ciao/insights.py
+++ b/ciao/insights.py
@@ -1299,10 +1299,7 @@ UUID_RE = re.compile(
 # reads the id out of the name and skips a file it cannot find one in — so an
 # opencode transcript that missed insights at archive time could never be
 # recovered, even though its text-mode path needs nothing but the markdown.
-SESSION_ID_RE = re.compile(
-    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-    r"|ses_[A-Za-z0-9]+"
-)
+SESSION_ID_RE = re.compile(rf"{UUID_RE.pattern}|ses_[A-Za-z0-9]+")
 
 
 def _empty_backfill_stats() -> dict[str, int]:
@@ -1455,8 +1452,12 @@ async def backfill_insights_task(
         search_roots = [Path(agent_root)]
     else:
         search_roots = [root for root, _name in config.agent_root_targets()]
-        if not search_roots:
-            search_roots = [config.workspace_root]
+        # The install root is not one of those targets after the re-rooting,
+        # but a blob written before the migration is still keyed by it — so
+        # keep it as a last candidate rather than demoting those archives to
+        # the text-mode path that this function previously handled in full.
+        if config.workspace_root not in search_roots:
+            search_roots.append(config.workspace_root)
     project_dirs = [(r, _claude_projects_dir(r)) for r in search_roots]
 
     by_chat = dict(chat_workspaces or {})

--- a/ciao/insights.py
+++ b/ciao/insights.py
@@ -1293,6 +1293,17 @@ UUID_RE = re.compile(
     r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
 )
 
+# Archive filenames end in the session id, whose shape is the provider's: a
+# UUID from the Claude SDK, `ses_<base62>` from opencode. Matching only the
+# UUID made every opencode archive undiscoverable to backfill — `_discover`
+# reads the id out of the name and skips a file it cannot find one in — so an
+# opencode transcript that missed insights at archive time could never be
+# recovered, even though its text-mode path needs nothing but the markdown.
+SESSION_ID_RE = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    r"|ses_[A-Za-z0-9]+"
+)
+
 
 def _empty_backfill_stats() -> dict[str, int]:
     return {
@@ -1416,9 +1427,10 @@ async def backfill_insights_task(
     configured one, without changing the stored setting — the retry path when
     the configured insights model keeps failing.
 
-    *agent_root* is the per-workspace agent root whose session directory to
-    read; it defaults to ``config.workspace_root`` so callers that supply
-    nothing keep today's behaviour.
+    *agent_root* pins the run to one workspace's agent root. Callers that
+    supply nothing get every agent root in the install searched for each
+    archive's session blob, which is what a multi-workspace install needs: a
+    single root finds no blob for chats that ran anywhere else.
     """
     stats = _empty_backfill_stats()
     # Archives live under the promoted logs root (see main.py:transcript_root),
@@ -1426,10 +1438,22 @@ async def backfill_insights_task(
     # it. `config.logs_root` is the one place that distinction is made.
     base = config.logs_root / "Chats"
 
-    root = agent_root if agent_root is not None else config.workspace_root
-    project_dir = _claude_projects_dir(root)
+    # One project directory per agent root, not one for the install. The Claude
+    # SDK keys its session store by the cwd the session ran in, which for a
+    # workspace chat is that workspace's agent root; looking only under
+    # `workspace_root` found no blob for any of them and silently demoted every
+    # claude archive to the text-mode path (or, at archive time, skipped it
+    # altogether). An explicit `agent_root` still wins, for callers scoping a
+    # run to one workspace.
+    if agent_root is not None:
+        search_roots = [Path(agent_root)]
+    else:
+        search_roots = [root for root, _name in config.agent_root_targets()]
+        if not search_roots:
+            search_roots = [config.workspace_root]
+    project_dirs = [(r, _claude_projects_dir(r)) for r in search_roots]
 
-    def _discover() -> tuple[list[tuple[Path, str, bool]], int, int]:
+    def _discover() -> tuple[list[tuple[Path, str, Path | None]], int, int]:
         """Walk the archive tree and decide what needs backfilling.
 
         Runs off the loop: this globs the whole archive directory and reads
@@ -1439,7 +1463,7 @@ async def backfill_insights_task(
         both callers (startup and the Automations button) drive it from the
         event loop, where it would stall every request for its duration.
         """
-        found: list[tuple[Path, str, bool]] = []
+        found: list[tuple[Path, str, Path | None]] = []
         # Sorted for a deterministic order (oldest first / alphabetic).
         # All providers (claude and opencode) — the previous
         # `*/claude/*.md` made opencode transcripts invisible to
@@ -1453,7 +1477,7 @@ async def backfill_insights_task(
             if workspace and md.parent.parent.name != workspace:
                 continue
 
-            match = UUID_RE.search(md.name)
+            match = SESSION_ID_RE.search(md.name)
             session_id = match.group(0) if match else None
             if not session_id:
                 continue
@@ -1462,13 +1486,16 @@ async def backfill_insights_task(
                 done += 1
                 continue
 
-            has_jsonl = (project_dir / f"{session_id}.jsonl").exists()
+            jsonl_root = next(
+                (r for r, d in project_dirs if (d / f"{session_id}.jsonl").exists()),
+                None,
+            )
 
             # Decide if we keep this one based on mode filter
-            if has_jsonl and mode in {"both", "full"}:
-                found.append((md, session_id, True))
-            elif (not has_jsonl) and mode in {"both", "text"}:
-                found.append((md, session_id, False))
+            if jsonl_root is not None and mode in {"both", "full"}:
+                found.append((md, session_id, jsonl_root))
+            elif jsonl_root is None and mode in {"both", "text"}:
+                found.append((md, session_id, None))
         return found, len(archives), done
 
     if not base.exists():
@@ -1508,8 +1535,8 @@ async def backfill_insights_task(
 
     logger.info("Starting backfill for %d archives (dry_run=%s, mode=%s)...", len(todo), dry_run, mode)
     if dry_run:
-        for md, _, hj in todo[:20]:
-            m = "full" if hj else "text"
+        for md, _, jsonl_root in todo[:20]:
+            m = "full" if jsonl_root is not None else "text"
             # Relative to the ARCHIVE root, not the vault: the re-rooting
             # promotes Logs/ out of the vault, so `relative_to(vault_root)`
             # raises ValueError and takes down the dry run from inside a log
@@ -1525,12 +1552,16 @@ async def backfill_insights_task(
 
     sem = asyncio.Semaphore(concurrency)
 
-    async def worker(archive_path: Path, session_id: str, has_jsonl: bool) -> str:
+    async def worker(
+        archive_path: Path, session_id: str, jsonl_root: Path | None
+    ) -> str:
         async with sem:
             try:
                 insights_model = model_override or resolve_insights_model(config)
-                if has_jsonl:
-                    filtered = filter_session_jsonl(root, session_id)
+                if jsonl_root is not None:
+                    filtered = filter_session_jsonl(
+                        config.workspace_root, session_id, agent_root=jsonl_root
+                    )
                     if not filtered:
                         logger.warning("Session JSONL empty or filtered to nothing for %s", archive_path)
                         return "skipped"
@@ -1635,7 +1666,7 @@ async def backfill_insights_task(
                 logger.exception("Failed backfilling insights for %s", archive_path)
                 return "error"
 
-    tasks = [worker(md, sid, hj) for md, sid, hj in todo]
+    tasks = [worker(md, sid, jsonl_root) for md, sid, jsonl_root in todo]
     results = await asyncio.gather(*tasks, return_exceptions=True)
     stats["processed"] = len(results)
     for result in results:

--- a/ciao/main.py
+++ b/ciao/main.py
@@ -563,9 +563,13 @@ async def _run_server_locked(config: CiaoConfig) -> int:
 
     def _resolve_schedule_target(entry):
         # Empty entry.model / entry.mode means "use the current default".
-        ctx = ChatContext(chat_id=0)
-        mode = entry.mode or state.get_mode(ctx)
+        # The mode default is the operator's pin for the provider this run
+        # actually resolves to (Settings -> Providers -> permission mode), so a
+        # routine obeys the same setting a hand-opened chat on that provider
+        # does. It used to fall back to the Telegram context's mode, which is a
+        # different surface's state and belongs to no workspace.
         provider, model, _workspace = pcm.schedule_effective_routing(entry)
+        mode = entry.mode or config.default_mode_for_provider(provider)
         return ("claude", model, mode, provider)
 
     from ciao.node_state import NodeStateManager

--- a/ciao/schedules.py
+++ b/ciao/schedules.py
@@ -29,11 +29,13 @@ from datetime import UTC, datetime, timedelta
 from importlib import resources
 from pathlib import Path
 from collections.abc import Sequence
-from typing import Any, Callable, Coroutine, Protocol
+from typing import Any, Callable, Coroutine, Protocol, cast
 from zoneinfo import ZoneInfo
 
 from ciao.jsonio import read_json_dict
 from ciao.models import BridgeMode
+
+_BRIDGE_MODES = frozenset({"normal", "plan", "auto", "bypass"})
 
 DEFAULT_TIMEZONE = "Europe/Zurich"
 logger = logging.getLogger(__name__)
@@ -1050,6 +1052,20 @@ class ScheduleStore:
         return payload
 
 
+def entry_mode(entry: "ScheduleEntry") -> BridgeMode:
+    """The entry's own permission mode, narrowed for the no-resolver path.
+
+    ``ScheduleEntry.mode`` is a plain ``str`` because "" means "inherit", which
+    is not a ``BridgeMode``. Resolution normally happens in the manager's
+    ``resolve_target`` callback, which consults the operator's per-provider pin;
+    this is only the fallback for a manager constructed without one (tests, and
+    any standalone driver), where there is no config to consult and ``auto`` is
+    the safe read of "unset".
+    """
+    mode = getattr(entry, "mode", "")
+    return cast(BridgeMode, mode) if mode in _BRIDGE_MODES else "auto"
+
+
 class _DispatchToWeb(Protocol):
     """Callback that dispatches a schedule entry through the web pipeline.
 
@@ -1325,7 +1341,7 @@ class ScheduleManager:
         _, model, mode, provider = (
             self._resolve_target(entry)
             if self._resolve_target is not None
-            else ("claude", entry.model, entry.mode, entry.provider)
+            else ("claude", entry.model, entry_mode(entry), entry.provider)
         )
         # The binding as it stood *before* prepare_chat, which is what
         # `_run_interval` needs to tell a re-home apart from a user edit.
@@ -1458,7 +1474,7 @@ class ScheduleManager:
         _, model, mode, provider = (
             self._resolve_target(entry)
             if self._resolve_target is not None
-            else ("claude", entry.model, entry.mode, entry.provider)
+            else ("claude", entry.model, entry_mode(entry), entry.provider)
         )
         # Prepare the chat synchronously so we can return its ID immediately.
         # Pass it through to dispatch so it doesn't create a second chat.
@@ -1533,7 +1549,7 @@ class ScheduleManager:
             _, model, mode, provider = (
                 self._resolve_target(entry)
                 if self._resolve_target is not None
-                else ("claude", entry.model, entry.mode, entry.provider)
+                else ("claude", entry.model, entry_mode(entry), entry.provider)
             )
             # Prepare the chat synchronously (like dispatch_now) so
             # last_run_chat_id is durable in the same write as
@@ -1622,7 +1638,7 @@ class ScheduleManager:
             _, model, mode, provider = (
                 self._resolve_target(entry)
                 if self._resolve_target is not None
-                else ("claude", entry.model, entry.mode, entry.provider)
+                else ("claude", entry.model, entry_mode(entry), entry.provider)
             )
             logger.info(
                 "Schedule %s: catch-up fire (latest missed %s, now %s)",

--- a/ciao/schedules.py
+++ b/ciao/schedules.py
@@ -591,7 +591,16 @@ class ScheduleEntry:
     # means "inherit the target chat's provider (existing web_chat_id) or use
     # the resolver's default (new web_project_id chat)".
     provider: str = ""
-    mode: BridgeMode = "auto"
+    # "" means "inherit", exactly as an empty `model`/`provider` does: the
+    # permission mode is resolved from the operator's own per-provider pin
+    # (Settings -> Providers) on every dispatch. A hardcoded "auto" here was
+    # not a default, it was an override — truthy, so it won every dispatch and
+    # the inheritance fallback below it could never fire. A routine on a
+    # provider pinned to `bypass` still stamped its chat `auto`, and a reply
+    # to that chat then ran under different permission rules than the run it
+    # was answering (which `unattended` forces to bypass) — which on opencode
+    # rotates the session, because a session's rules are fixed at creation.
+    mode: str = ""
     timezone_name: str = DEFAULT_TIMEZONE
     last_triggered_on: str = ""
     # Full ISO timestamp of the most recent dispatch through any path

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -3769,13 +3769,19 @@ class ProjectChatManager:
         session through ``DELETE /session/{id}``.
         Provider cleanup is fail-open: the Ciaobot archive remains durable even
         when an external provider is unavailable.
+
+        Both providers store a session under the agent root the chat ran in —
+        the Claude SDK by hashing that path into its projects directory, and
+        opencode because its server is started there. Reclaiming against
+        ``workspace_root`` therefore found nothing for a workspace-scoped chat
+        and leaked every blob and session it was meant to drop.
         """
         raw_ids = (
             session_ids
             if session_ids is not None
             else [*chat.previous_session_ids, chat.session_id]
         )
-        workspace = self._config.workspace_root
+        root = self._agent_root_for_chat(chat.chat_id)
         seen: set[str] = set()
         for sid in raw_ids:
             sid = str(sid or "")
@@ -3784,9 +3790,9 @@ class ProjectChatManager:
             seen.add(sid)
             try:
                 if chat.provider == "claude":
-                    deleted = self._transcripts.delete_sdk_session_blob(workspace, sid)
+                    deleted = self._transcripts.delete_sdk_session_blob(root, sid)
                 elif chat.provider == "opencode":
-                    deleted = await OpencodeProvider.delete_thread(workspace, sid)
+                    deleted = await OpencodeProvider.delete_thread(root, sid)
                 else:
                     continue
             except Exception:  # noqa: BLE001 — provider cleanup is fail-open
@@ -3913,7 +3919,7 @@ class ProjectChatManager:
     # ── Session management ───────────────────────────────────────────────
 
     def _read_archive_inputs(
-        self, chat_id: str, ctx: ChatContext, chat: ChatInfo
+        self, chat_id: str, ctx: ChatContext, chat: ChatInfo, agent_root: Path
     ) -> tuple[int, str | None, Path | None]:
         """Disk half of archiving one chat, safe to run off the event loop.
 
@@ -3921,11 +3927,20 @@ class ProjectChatManager:
         id — read the turn count and the filtered JSONL, then render and write
         the markdown archive. It touches no shared in-memory state and no
         asyncio primitives, which is what lets ``archive_chat`` hand it to a
-        worker thread.
+        worker thread. ``agent_root`` is resolved by the caller on the loop for
+        that reason.
 
         Ordering matters: the turn count has to be taken before
         ``archive_session`` consumes the in-progress transcript, and the
         filtered JSONL before the caller deletes the session blob.
+
+        The Claude SDK writes a chat's session blob under the agent root the
+        chat actually ran in, so that root — not ``workspace_root`` — is what
+        finds it. Resolving it against the install root instead returned None
+        for every workspace-scoped chat, and a None here is indistinguishable
+        from "nothing to extract": ``run_archive_postprocess`` skipped insights,
+        the project-doc fold, the trajectory and memory proposals in silence,
+        with no job run and no log line.
         """
         turn_count = self._transcripts.peek_turn_count(ctx, chat.provider)
         filtered_jsonl: str | None = None
@@ -3933,7 +3948,9 @@ class ProjectChatManager:
             from ciao.insights import filter_session_jsonl
             try:
                 filtered_jsonl = filter_session_jsonl(
-                    self._config.workspace_root, chat.session_id
+                    self._config.workspace_root,
+                    chat.session_id,
+                    agent_root=agent_root,
                 )
             except Exception:  # noqa: BLE001 — never fail archive over insights prep
                 logger.exception(
@@ -4002,8 +4019,9 @@ class ProjectChatManager:
         # every streaming turn until it finished, so it runs in a worker
         # thread. Awaited before anything else happens, so the chat_archived
         # event still fires in the same place it always did.
+        agent_root = self._agent_root_for_chat(chat_id)
         turn_count, filtered_jsonl, result = await asyncio.to_thread(
-            self._read_archive_inputs, chat_id, ctx, chat
+            self._read_archive_inputs, chat_id, ctx, chat, agent_root
         )
         # The await above is a suspension point, so the chat may have been
         # deleted while the transcript was being written. Marking a row that is

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -3762,6 +3762,8 @@ class ProjectChatManager:
         self,
         chat: ChatInfo,
         session_ids: list[str] | None = None,
+        *,
+        agent_root: Path | None = None,
     ) -> None:
         """Drop provider-side session blobs/threads for abandoned chats.
 
@@ -3775,13 +3777,24 @@ class ProjectChatManager:
         opencode because its server is started there. Reclaiming against
         ``workspace_root`` therefore found nothing for a workspace-scoped chat
         and leaked every blob and session it was meant to drop.
+
+        ``agent_root`` is that root, and a caller that has already dropped the
+        chat from the registry MUST pass it: ``_agent_root_for_chat`` resolves
+        through ``self._chats``, so on the delete path (which pops the row
+        before scheduling this cleanup) it would silently fall back to the
+        PRIMARY workspace's root and reclaim nothing — the same leak, now
+        reported as a success.
         """
         raw_ids = (
             session_ids
             if session_ids is not None
             else [*chat.previous_session_ids, chat.session_id]
         )
-        root = self._agent_root_for_chat(chat.chat_id)
+        root = (
+            agent_root
+            if agent_root is not None
+            else self._agent_root_for_chat(chat.chat_id)
+        )
         seen: set[str] = set()
         for sid in raw_ids:
             sid = str(sid or "")
@@ -3829,8 +3842,14 @@ class ProjectChatManager:
         chat: ChatInfo,
         provider: ProviderService | None,
         session_ids: list[str] | None = None,
+        *,
+        agent_root: Path | None = None,
     ) -> None:
-        """Disconnect then reclaim provider storage for sync lifecycle calls."""
+        """Disconnect then reclaim provider storage for sync lifecycle calls.
+
+        ``agent_root`` is forwarded to the reclaim; see its docstring for why a
+        caller that has already unregistered the chat has to resolve it first.
+        """
 
         if provider is None and not any(
             str(session_id or "")
@@ -3844,11 +3863,18 @@ class ProjectChatManager:
 
         async def cleanup() -> None:
             await self._disconnect_provider(chat.chat_id, provider)
-            await self._reclaim_provider_sessions_async(chat, session_ids)
+            await self._reclaim_provider_sessions_async(
+                chat, session_ids, agent_root=agent_root
+            )
 
         asyncio.ensure_future(cleanup())
 
     def delete_chat(self, chat_id: str) -> bool:
+        # Resolved before the row leaves the registry: the cleanup below runs
+        # after the pop (and asynchronously), and `_agent_root_for_chat` reads
+        # `self._chats`, so resolving it there lands on the primary workspace's
+        # root and leaves this chat's blob or opencode session behind.
+        agent_root = self._agent_root_for_chat(chat_id)
         chat = self._chats.pop(chat_id, None)
         if chat is None:
             return False
@@ -3860,7 +3886,7 @@ class ProjectChatManager:
         self._cancel_between_turns_drain(chat_id)
         self._last_drain_result.pop(chat_id, None)
         provider = self._providers.pop(chat_id, None)
-        self._schedule_provider_cleanup(chat, provider)
+        self._schedule_provider_cleanup(chat, provider, agent_root=agent_root)
         # Explicit deletion is a tombstone, not merely a sidebar mutation.
         # Remove every recovery signal so startup repair cannot revive it.
         self._state.delete_context(ctx)

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -4828,6 +4828,23 @@ class ProjectChatManager:
             )
         return primary
 
+    def chat_workspaces(self) -> dict[str, str]:
+        """Every known chat id mapped to its project's workspace.
+
+        Archives live under one shared ``Logs/Chats/<chat-id>/`` tree — the
+        re-rooting promotes Logs out of the vault but does not split it per
+        workspace — so an archive's path says which CHAT wrote it and nothing
+        about where that chat ran. Anything filtering archives by workspace has
+        to come back through the registry, which is here and not in
+        ``ciao.insights``; the backfill scanner compared the chat-id path
+        segment to a workspace name directly, which can never match, so a
+        workspace-scoped run silently found nothing.
+        """
+        return {
+            chat_id: getattr(self._projects.get(chat.project_id), "workspace", "") or ""
+            for chat_id, chat in self._chats.items()
+        }
+
     def schedule_workspace(self, entry: object) -> str:
         """Resolve the workspace that owns a schedule's execution context."""
         web_chat_id = getattr(entry, "web_chat_id", None)

--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -5524,7 +5524,10 @@ async def trigger_backfill_insights(request: Request) -> JSONResponse:
             model=model,
         ) as handle:
             result = await backfill_insights_task(
-                config, mode="both", model_override=model,
+                config,
+                mode="both",
+                model_override=model,
+                chat_workspaces=request.app.state.project_chat_manager.chat_workspaces(),
             )
             handle.extra.update(result)
             summary = format_backfill_summary(result)
@@ -5541,7 +5544,6 @@ async def trigger_backfill_insights(request: Request) -> JSONResponse:
 
 async def create_schedule(request: Request) -> JSONResponse:
     sm = request.app.state.schedule_manager
-    state = request.app.state.state_store
     pcm = request.app.state.project_chat_manager
     body = await request.json()
 
@@ -5551,9 +5553,11 @@ async def create_schedule(request: Request) -> JSONResponse:
     # Persist only explicit overrides. Empty model/provider values mean
     # "inherit the selected workspace" and are resolved afresh at dispatch
     # time, so changing a workspace default also changes future runs.
-    ctx = ChatContext(chat_id=0)
     model = (body.get("model") or "").strip()
-    mode = state.get_mode(ctx)
+    # Left unset on purpose. The form offers no permission-mode choice, so
+    # capturing one here froze whatever the Telegram context happened to be on
+    # into the entry; mode inherits at dispatch like model and provider do.
+    mode = ""
 
     frequency = body.get("frequency", "weekly")
     if frequency not in FREQUENCIES:

--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -5889,13 +5889,14 @@ async def create_loop(request: Request) -> JSONResponse:
 
     project_id = getattr(chat, "project_id", "") or ""
     project = pcm.get_project(project_id) if project_id else None
-    state = request.app.state.state_store
     entry = sm.create(
         daily_time_utc="",
         prompt=prompt,
-        # Empty model/mode is what makes each run inherit the target chat.
+        # Empty model/mode is what makes each run inherit the target chat, as
+        # the comment always said — it used to freeze the Telegram context's
+        # mode into the entry instead, which is a different surface's state.
         model="",
-        mode=state.get_mode(ChatContext(chat_id=0)),
+        mode="",
         chat_id=0,
         frequency=INTERVAL_FREQUENCY,
         interval_minutes=interval_minutes,

--- a/tests/test_archive_postprocess_state.py
+++ b/tests/test_archive_postprocess_state.py
@@ -205,7 +205,10 @@ def test_archive_inputs_include_opencode_transcripts(tmp_path: Path, monkeypatch
     )
 
     turn_count, filtered_jsonl, result = manager._read_archive_inputs(
-        chat_id, ChatContext.for_web(chat_id), chat
+        chat_id,
+        ChatContext.for_web(chat_id),
+        chat,
+        manager._agent_root_for_chat(chat_id),
     )
 
     assert turn_count == 1

--- a/tests/test_auto_mode_defaults.py
+++ b/tests/test_auto_mode_defaults.py
@@ -30,8 +30,13 @@ def test_chat_info_default_mode_is_auto() -> None:
     assert chat.mode == "auto"
 
 
-def test_schedule_default_mode_is_auto() -> None:
-    """Scheduled runs also go through the classifier."""
+def test_schedule_default_mode_inherits() -> None:
+    """A schedule pins no mode: "" resolves to the operator's per-provider pin
+    at dispatch, the same setting a hand-opened chat on that provider obeys.
+
+    It used to default to "auto", which is truthy and therefore an override,
+    not a default — a routine on a provider pinned to `bypass` still stamped
+    its chat `auto`, and the inheritance fallback behind it was dead code."""
     sched = ScheduleEntry(
         schedule_id="s1",
         daily_time_utc="09:00",
@@ -39,7 +44,7 @@ def test_schedule_default_mode_is_auto() -> None:
         chat_id=0,
         created_at="2026-04-20T00:00:00Z",
     )
-    assert sched.mode == "auto"
+    assert sched.mode == ""
 
 
 def test_bridge_config_default_claude_mode_is_auto() -> None:
@@ -62,3 +67,45 @@ def test_config_ignores_legacy_mode_env() -> None:
         "CLAUDE_PERMISSION_MODE": "bypassPermissions",
     })
     assert config.claude_mode == "auto"
+
+
+def test_schedule_chat_is_stamped_with_the_providers_pinned_mode(tmp_path) -> None:
+    """The end of the chain the empty default unblocks.
+
+    A routine chat is created with the entry's mode, so a hardcoded "auto" on
+    the entry was stamped onto the chat and the operator's Settings -> Providers
+    pin never applied. The chat then disagreed with its own unattended run
+    (which `_effective_mode_for_chat` forces to bypass), and on opencode a reply
+    to that chat rotated the session — a session's permission rules are fixed
+    when it is created.
+    """
+    from ciao.sessions import StateStore
+    from ciao.transcripts import TranscriptStore
+    from ciao.web.project_chats import ProjectChatManager
+
+    runtime = tmp_path / ".runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    config = CiaoConfig(
+        pwa_auth_token="t",
+        workspace_root=tmp_path,
+        state_path=runtime / "state.json",
+        media_root=runtime / "media",
+    )
+    config.provider_default_modes = {"opencode": "bypass", "claude": "auto"}
+    pcm = ProjectChatManager(
+        config,
+        state_store=StateStore(config.state_path, tmp_path, config.media_root),
+        transcript_store=TranscriptStore(runtime, tmp_path / "transcripts"),
+        path=runtime / "web_projects.json",
+    )
+    project = pcm.create_project("General", "personal")
+
+    inherited = pcm.create_chat(
+        project.project_id, title="routine", mode="", provider="opencode"
+    )
+    assert inherited.mode == "bypass"
+
+    explicit = pcm.create_chat(
+        project.project_id, title="pinned", mode="plan", provider="opencode"
+    )
+    assert explicit.mode == "plan", "an explicit mode still wins"

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -1594,3 +1594,99 @@ def test_overflow_log_only_names_the_budget_that_applies(
         )
     assert "CIAO_INSIGHTS_MAX_INPUT_CHARS" not in caplog.text
     assert "larger window" in caplog.text
+
+
+# ── backfill across agent roots, and opencode session ids ────────────────────
+#
+# Backfill slugged one project directory out of `config.workspace_root`. On a
+# multi-workspace install every Claude blob lives under its own agent root, so
+# that directory held none of them: every archive fell through to the text-mode
+# path (or, when discovery could not read an id out of the filename at all, was
+# skipped entirely). The id regex was UUID-only, which made every opencode
+# archive — `ses_<base62>` — permanently unreachable by backfill, even though
+# text mode needs nothing but the markdown.
+
+
+def _rerooted_config(tmp_path: Path):
+    from ciao.config import WorkspaceConfig, reset_reroot_cache
+
+    runtime = tmp_path / "ws" / ".runtime"
+    receipt = runtime / "migration" / "workspace-rooting.json"
+    receipt.parent.mkdir(parents=True, exist_ok=True)
+    receipt.write_text('{"status": "migrated"}', encoding="utf-8")
+    reset_reroot_cache()
+
+    config = _config()
+    config.state_path = runtime / "state.json"
+    config.vault_root = tmp_path / "vault"
+    config.workspace_root = tmp_path / "ws"
+    config.insights_model = "deepseek-v4-flash:0731-cloud"
+    config.workspaces = {
+        "work": WorkspaceConfig(name="work", vault_root=str(tmp_path / "vault"))
+    }
+    return config
+
+
+def test_backfill_finds_a_blob_under_a_workspace_agent_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # After the re-rooting `config.logs_root` is <install>/Logs, not the vault's.
+    chats_dir = tmp_path / "ws" / "Logs" / "Chats" / "chat-123" / "claude"
+    chats_dir.mkdir(parents=True)
+    session = "00000000-0000-0000-0000-0000000000aa"
+    archive = chats_dir / f"work-{session}.md"
+    archive.write_text("# Archived chat\n", encoding="utf-8")
+
+    fake_home = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    config = _rerooted_config(tmp_path)
+
+    agent_root = config.agent_root("work")
+    assert agent_root != config.workspace_root
+    slug = str(agent_root).replace("/", "-").lstrip("-")
+    project_dir = fake_home / ".claude" / "projects" / f"-{slug}"
+    project_dir.mkdir(parents=True)
+    _write_jsonl(project_dir / f"{session}.jsonl", [
+        {"type": "user", "message": {"content": "hello"}},
+    ])
+
+    seen: list[str] = []
+
+    async def fake_oneshot(user_prompt: str, **kwargs) -> str:
+        seen.append(user_prompt)
+        return "## Decisions\n- d\n"
+
+    monkeypatch.setattr("ciao.providers.oneshot.run_oneshot", fake_oneshot)
+    result = asyncio.run(
+        insights.backfill_insights_task(config, mode="full", concurrency=1)
+    )
+
+    assert result["eligible"] == 1, "the blob is under the work root, not the install root"
+    assert result["success"] == 1
+    assert any("line-oriented JSON" in p or "JSONL" in p for p in seen)
+
+
+def test_backfill_discovers_an_opencode_archive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    chats_dir = tmp_path / "vault" / "Logs" / "Chats" / "chat-456" / "opencode"
+    chats_dir.mkdir(parents=True)
+    archive = chats_dir / "2026-08-31T00-04-57Z-ses_faae15d4affeoEsvKh19Ro4Tob.md"
+    archive.write_text("# Archived chat\n\nsome text\n", encoding="utf-8")
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    config = _config()
+    config.vault_root = tmp_path / "vault"
+    config.workspace_root = tmp_path / "ws"
+    config.insights_model = "deepseek-v4-flash:0731-cloud"
+
+    async def fake_oneshot(user_prompt: str, **kwargs) -> str:
+        return "## Decisions\n- d\n"
+
+    monkeypatch.setattr("ciao.providers.oneshot.run_oneshot", fake_oneshot)
+    result = asyncio.run(
+        insights.backfill_insights_task(config, mode="both", concurrency=1)
+    )
+
+    assert result["eligible"] == 1, "a ses_ id is a session id too"
+    assert "## Session insights" in archive.read_text(encoding="utf-8")

--- a/tests/test_insights.py
+++ b/tests/test_insights.py
@@ -1690,3 +1690,73 @@ def test_backfill_discovers_an_opencode_archive(
 
     assert result["eligible"] == 1, "a ses_ id is a session id too"
     assert "## Session insights" in archive.read_text(encoding="utf-8")
+
+
+def test_backfill_workspace_filter_uses_the_chat_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Archives sit under a shared `Logs/Chats/<chat-id>/` tree, so the path
+    segment is a chat id and comparing it to a workspace name never matches —
+    a workspace-scoped run found nothing at all."""
+    chats = tmp_path / "vault" / "Logs" / "Chats"
+    for chat_id in ("chat-work1", "chat-home1"):
+        d = chats / chat_id / "opencode"
+        d.mkdir(parents=True)
+        (d / f"2026-08-31T00-00-00Z-ses_{chat_id.replace('-', '')}.md").write_text(
+            "# Archived chat\n", encoding="utf-8"
+        )
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    config = _config()
+    config.vault_root = tmp_path / "vault"
+    config.workspace_root = tmp_path / "ws"
+    config.insights_model = "deepseek-v4-flash:0731-cloud"
+
+    async def fake_oneshot(user_prompt: str, **kwargs) -> str:
+        return "## Decisions\n- d\n"
+
+    monkeypatch.setattr("ciao.providers.oneshot.run_oneshot", fake_oneshot)
+    result = asyncio.run(
+        insights.backfill_insights_task(
+            config,
+            mode="both",
+            concurrency=1,
+            workspace="work",
+            chat_workspaces={"chat-work1": "work", "chat-home1": "personal"},
+        )
+    )
+
+    assert result["eligible"] == 1
+    assert "## Session insights" in next(
+        (chats / "chat-work1" / "opencode").glob("*.md")
+    ).read_text(encoding="utf-8")
+    assert "## Session insights" not in next(
+        (chats / "chat-home1" / "opencode").glob("*.md")
+    ).read_text(encoding="utf-8")
+
+
+def test_backfill_refuses_to_silently_scope_without_a_map(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog
+) -> None:
+    """A workspace with no mapping cannot filter; scan everything and say so
+    rather than reporting a clean run over zero archives."""
+    d = tmp_path / "vault" / "Logs" / "Chats" / "chat-a" / "opencode"
+    d.mkdir(parents=True)
+    (d / "2026-08-31T00-00-00Z-ses_aaa.md").write_text("# c\n", encoding="utf-8")
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    config = _config()
+    config.vault_root = tmp_path / "vault"
+    config.workspace_root = tmp_path / "ws"
+    config.insights_model = "deepseek-v4-flash:0731-cloud"
+
+    async def fake_oneshot(user_prompt: str, **kwargs) -> str:
+        return "## Decisions\n- d\n"
+
+    monkeypatch.setattr("ciao.providers.oneshot.run_oneshot", fake_oneshot)
+    result = asyncio.run(
+        insights.backfill_insights_task(
+            config, mode="both", concurrency=1, workspace="work"
+        )
+    )
+    assert result["eligible"] == 1

--- a/tests/test_session_paths_per_root.py
+++ b/tests/test_session_paths_per_root.py
@@ -206,3 +206,105 @@ def _make_manager(tmp_path: Path) -> ProjectChatManager:
         transcript_store=transcripts,
         path=runtime / "web_projects.json",
     )
+
+
+# -- archiving reads and reclaims the chat's OWN root -------------------------
+#
+# `_read_archive_inputs` resolved the Claude session blob against
+# `config.workspace_root`, but a workspace chat's blob is keyed by the agent
+# root it ran in. On a re-rooted install that lookup returned None for every
+# workspace-scoped chat, and a None there is indistinguishable from "nothing to
+# extract": `run_archive_postprocess` gates on `outcome.filtered_jsonl`, so
+# insights, the project-doc fold, the trajectory and memory proposals were all
+# skipped in silence — no job run, no log line. Observed live: 26 of 26 Claude
+# archives over two days had no insights section while every opencode archive
+# (which uses the provider-neutral transcript instead) had one.
+
+
+def _rerooted_manager(tmp_path: Path, workspace: str) -> ProjectChatManager:
+    """A manager on a re-rooted install with one registered workspace."""
+    from ciao.config import WorkspaceConfig, reset_reroot_cache
+
+    receipt = tmp_path / ".runtime" / "migration" / "workspace-rooting.json"
+    receipt.parent.mkdir(parents=True, exist_ok=True)
+    receipt.write_text(json.dumps({"status": "migrated"}), encoding="utf-8")
+    reset_reroot_cache()
+
+    pcm = _make_manager(tmp_path)
+    pcm._config.workspaces = {
+        workspace: WorkspaceConfig(
+            name=workspace, vault_root=str(tmp_path / workspace / "memory-vault")
+        )
+    }
+    return pcm
+
+
+def _archived_chat(pcm: ProjectChatManager, workspace: str, session: str) -> ChatInfo:
+    project = pcm.create_project("General", workspace)
+    chat = pcm.create_chat(project.project_id, title="t", model="sonnet")
+    chat.session_id = session
+    chat.provider = "claude"
+    return chat
+
+
+def test_archive_inputs_read_the_chats_own_agent_root(
+    tmp_path: Path, fake_home: Path
+) -> None:
+    from ciao.models import ChatContext
+
+    pcm = _rerooted_manager(tmp_path, "work")
+    session = "33333333-3333-3333-3333-333333333333"
+    chat = _archived_chat(pcm, "work", session)
+    agent_root = pcm._agent_root_for_chat(chat.chat_id)
+    assert agent_root != pcm._config.workspace_root
+    _write_session(_projects_dir_for(agent_root), session)
+
+    _, filtered, _ = pcm._read_archive_inputs(
+        chat.chat_id, ChatContext.for_web(chat.chat_id), chat, agent_root
+    )
+    assert filtered, "the chat's own agent root holds the blob"
+
+
+def test_archive_inputs_miss_a_blob_under_the_install_root(
+    tmp_path: Path, fake_home: Path
+) -> None:
+    """The bug's shape: a blob written under the install root is not this
+    chat's, and must not be read as if it were."""
+    from ciao.models import ChatContext
+
+    pcm = _rerooted_manager(tmp_path, "work")
+    session = "44444444-4444-4444-4444-444444444444"
+    chat = _archived_chat(pcm, "work", session)
+    _write_session(_projects_dir_for(pcm._config.workspace_root), session)
+
+    _, filtered, _ = pcm._read_archive_inputs(
+        chat.chat_id,
+        ChatContext.for_web(chat.chat_id),
+        chat,
+        pcm._agent_root_for_chat(chat.chat_id),
+    )
+    assert not filtered
+
+
+def test_reclaim_targets_the_chats_agent_root(
+    tmp_path: Path, fake_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The blob lives under the root the chat ran in, so that is the directory
+    reclaim must hand the SDK. Pointing it at ``workspace_root`` deleted
+    nothing and leaked a session blob per archived workspace chat."""
+    import asyncio
+
+    pcm = _rerooted_manager(tmp_path, "work")
+    session = "55555555-5555-5555-5555-555555555555"
+    chat = _archived_chat(pcm, "work", session)
+
+    seen: list[Path] = []
+    monkeypatch.setattr(
+        pcm._transcripts,
+        "delete_sdk_session_blob",
+        lambda root, sid: (seen.append(Path(root)), True)[1],
+    )
+
+    asyncio.run(pcm._reclaim_provider_sessions_async(chat, [session]))
+    assert seen == [pcm._agent_root_for_chat(chat.chat_id)]
+    assert seen != [pcm._config.workspace_root]

--- a/tests/test_session_paths_per_root.py
+++ b/tests/test_session_paths_per_root.py
@@ -308,3 +308,40 @@ def test_reclaim_targets_the_chats_agent_root(
     asyncio.run(pcm._reclaim_provider_sessions_async(chat, [session]))
     assert seen == [pcm._agent_root_for_chat(chat.chat_id)]
     assert seen != [pcm._config.workspace_root]
+
+
+def test_delete_reclaims_against_the_chats_root_not_the_primary(
+    tmp_path: Path, fake_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``delete_chat`` pops the row before scheduling the reclaim.
+
+    ``_agent_root_for_chat`` resolves through ``self._chats``, so resolving it
+    inside the (async) cleanup found no chat, fell back to ``primary_workspace``
+    and reclaimed the wrong root — leaving the deleted chat's blob on disk while
+    reporting success. The root has to be captured before the pop.
+    """
+    import asyncio
+
+    pcm = _rerooted_manager(tmp_path, "work")
+    pcm._config.workspaces["personal"] = pcm._config.workspaces["work"].__class__(
+        name="personal", vault_root=str(tmp_path / "personal" / "memory-vault")
+    )
+    session = "66666666-6666-6666-6666-666666666666"
+    chat = _archived_chat(pcm, "work", session)
+    expected = pcm._agent_root_for_chat(chat.chat_id)
+
+    seen: list[Path] = []
+    monkeypatch.setattr(
+        pcm._transcripts,
+        "delete_sdk_session_blob",
+        lambda root, sid: (seen.append(Path(root)), True)[1],
+    )
+
+    async def run() -> None:
+        assert pcm.delete_chat(chat.chat_id) is True
+        # Let the fire-and-forget cleanup task run.
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+    asyncio.run(run())
+    assert seen == [expected]


### PR DESCRIPTION
## What broke

Archiving resolved a chat's Claude SDK session blob against `config.workspace_root`, but the SDK keys its store by the cwd the session ran in — for a workspace chat that is the workspace's agent root. On a re-rooted install the lookup returned `None` for every workspace-scoped chat, and a `None` there is indistinguishable from "nothing to extract": `run_archive_postprocess` gates on `outcome.filtered_jsonl`, so **insights, the project-doc fold, the trajectory and memory proposals were all skipped in silence** — no job run, no log line, nothing on the Automations page.

Measured on a live install before the fix:

| Sep 1–2 archives | with a `## Session insights` section |
|---|---:|
| claude | **0 / 26** |
| opencode | 7 / 9 |

opencode was unaffected because it takes the provider-neutral transcript path instead. One workspace (`work`, Claude-only) had never had a single memory-proposal batch in its history.

`_reclaim_provider_sessions_async` had the same mistake, for both providers, so every archived workspace chat also leaked its session blob or opencode session.

## Also fixed

**Schedules ignored the operator's permission-mode pin.** A routine's mode came from three places, none of them Settings → Providers:

- `ScheduleEntry.mode` defaulted to `"auto"` — truthy, so an *override*, not a default. The `entry.mode or …` inheritance behind it was dead code, and every system routine took it since the stock definitions declare no mode.
- The dispatch resolver fell back to the Telegram context's mode — a different surface's state, belonging to no workspace.
- The PWA form, the MCP `schedule_preview`, and both loop-creation paths each froze a mode into the entry, though none of them offers a mode to choose.

The visible damage: a routine on a provider pinned to `bypass` still stamped its chat `auto`. The chat then disagreed with its own unattended run (which `_effective_mode_for_chat` forces to bypass), and on opencode answering that chat **rotated the session** — a session's permission rules are fixed at creation, so a mode switch cannot reuse it and the reply lost the conversation it was replying to. `_serialize_entry` never persisted `mode`, so nothing needs migrating.

**Backfill couldn't reach two whole classes of archive.** It slugged one project directory out of `workspace_root` (finding no blob on a multi-workspace install, silently demoting every archive to text mode), and its filename id regex was UUID-only, so opencode archives (`ses_<base62>`) were undiscoverable entirely. Its `workspace` filter compared an archive's chat-id path segment to a workspace name and so could never match; archives share one `Logs/Chats` tree, so the mapping now comes from the chat registry via `ProjectChatManager.chat_workspaces()`.

## Verification

- `pytest tests/` — **3470 passed**
- 11 new regression tests, each confirmed failing before its fix
- Backfilled 319 archives on a live install with the patched code: 319 succeeded, 0 failed

## Deliberately not in this PR

The backfill worker still passes the run-level `workspace` to `proposal_vault_root` / `guide_path`, so an unscoped run (the startup job and the Settings button) files no memory proposals. The `by_chat` map this PR threads in would let each archive be attributed to its owning workspace, but routing proposals per archive is a behavior change beyond this diff.

`ciao/cleanup_sdk_blobs.py` carries the same UUID-only matching and single-root assumption; it is a standalone maintenance CLI untouched here.

## Note for upgraders

New archives are fixed from this change onward. Existing gaps are not backfilled automatically — `insights_backfill_on_startup` still defaults to `False`, so recovering history stays an explicit Settings → Automations → *Insights backfill* action. Flipping that default would mean one model call per archive (481 on the install this was found on) firing silently on first launch, which is an operator's decision rather than a side effect of a bug fix.
