### PR TITLE
fix(chat): keep the model and context % on hydrated turn footers

### DIFF
--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -468,7 +468,7 @@
                 <span v-if="item.meta.timestamp">{{ formatTime(item.meta.timestamp) }}</span>
                 <span v-if="item.meta.duration_ms"> &middot; {{ formatDuration(item.meta.duration_ms) }}</span>
                 <span v-if="item.meta.effective_model"> &middot; {{ item.meta.effective_model }}</span>
-                <span v-if="formatTokenUsage(item.meta.usage)" class="tokens-group"> | <span v-html="formatTokenUsage(item.meta.usage)"></span></span>
+                <span v-if="formatTokenUsage(item.meta.usage)" class="tokens-group">&nbsp;| <span v-html="formatTokenUsage(item.meta.usage)"></span></span>
               </div>
             </div>
             <div v-if="item.msg.content?.trim()" class="message-actions">

--- a/web/src/stores/projects.test.ts
+++ b/web/src/stores/projects.test.ts
@@ -2132,6 +2132,36 @@ describe('optimistic user bubble reconciliation', () => {
     expect(last.duration_ms).toBe(23000)
   })
 
+  test('loadMessages keeps the server turn footer facts on a cold hydrate', async () => {
+    // The provider session file carries no usage/model, so the server stitches
+    // both on from the durable transcript. The row mapper used to drop them,
+    // which left every reloaded turn's footer with just the time and duration
+    // — no model, no context %.
+    const store = useProjectStore()
+    const chatId = 'chat-cold-hydrate'
+    apiGet.mockResolvedValue({
+      items: [
+        { i: 0, role: 'user', content: 'why are links missing?', sent_at: '2026-09-03T09:33:00Z', turn_index: 0 },
+        {
+          i: 1,
+          role: 'assistant',
+          content: 'Because the mapper dropped them.',
+          sent_at: '2026-09-03T09:34:00Z',
+          duration_ms: 47000,
+          effective_model: 'claude-opus-5',
+          usage: { input_tokens: '10007', output_tokens: '92', context_pct: '13.2%' },
+        },
+      ],
+      total: 2, offset: 0, limit: 50, hasMore: false, nextOffset: null,
+    })
+
+    await store.loadMessages(chatId)
+
+    const last = store.messages[chatId][store.messages[chatId].length - 1]
+    expect(last.effective_model).toBe('claude-opus-5')
+    expect(last.usage).toEqual({ input_tokens: '10007', output_tokens: '92', context_pct: '13.2%' })
+  })
+
   test('loadMessages keeps the live copy while the server window has no settled reply for it', async () => {
     // Half-persisted turn: the window has the first part but not the row that
     // closes it, so the client's copy is still the only complete rendering.

--- a/web/src/stores/projects.ts
+++ b/web/src/stores/projects.ts
@@ -2716,7 +2716,7 @@ export const useProjectStore = defineStore('projects', () => {
     }
   }
 
-  type ServerRow = { role: string; content: string; tool_name?: string; images?: string[]; turn_index?: number; sent_at?: string; duration_ms?: number; is_error?: boolean; file_path?: string; action?: string; tool?: string; phase?: 'commentary' | 'final_answer'; i?: number; lazy?: boolean; full_length?: number; unattended?: boolean }
+  type ServerRow = { role: string; content: string; tool_name?: string; images?: string[]; turn_index?: number; sent_at?: string; duration_ms?: number; is_error?: boolean; file_path?: string; action?: string; tool?: string; phase?: 'commentary' | 'final_answer'; i?: number; lazy?: boolean; full_length?: number; unattended?: boolean; usage?: Record<string, string>; quota?: Record<string, unknown>; effective_model?: string }
   const toChatMessage = (m: ServerRow) => ({
     role: m.role as 'user' | 'assistant' | 'system',
     content: m.content,
@@ -2749,6 +2749,14 @@ export const useProjectStore = defineStore('projects', () => {
     i: m.i,
     lazy: m.lazy,
     full_length: m.full_length,
+    // Turn footer facts. The provider session file carries none of these, so
+    // the server stitches them on from the durable transcript
+    // (`_overlay_transcript_metadata`). Dropping them here left every
+    // hydrated turn's footer with only the time and duration — no model, no
+    // context %.
+    usage: m.usage,
+    quota: m.quota,
+    effective_model: m.effective_model,
   })
 
   /** True for a trace row the client renders from streaming events. */
@@ -2801,10 +2809,10 @@ export const useProjectStore = defineStore('projects', () => {
       : userPositions.length === 1 && typeof merged[userPositions[0]].i === 'number'
         ? userPositions[0]
         : firstAppendPos
-    // `ServerRow` carries no token usage — that only ever reaches the client on
-    // the result event, which is exactly the row about to be dropped. Carry it
-    // (and the model that answered) onto the server row that closes the turn,
-    // or the footer would lose the turn's cost on every reload.
+    // A server row carries the turn's usage only once `record_turn` has run;
+    // for the turn that just streamed it may still be missing. Carry the live
+    // values (and the model that answered) onto the server row that closes the
+    // turn, or the footer would lose the turn's cost on that reconcile.
     const carried: Partial<ChatMessage> = {}
     const kept: ChatMessage[] = []
     for (let p = 0; p < merged.length; p++) {
@@ -2835,7 +2843,10 @@ export const useProjectStore = defineStore('projects', () => {
       for (let p = kept.length - 1; p >= 0; p--) {
         const row = kept[p]
         if (row.role !== 'assistant' || (target !== undefined && row.i !== target)) continue
-        kept[p] = { ...carried, ...row }
+        // Fill only the facts the row is actually missing. A plain spread let
+        // an explicitly-undefined key on the server row shadow the carried
+        // value and lose the turn's cost again.
+        kept[p] = mergeMessageFields(row, carried as ChatMessage)
         break
       }
     }
@@ -3009,7 +3020,11 @@ export const useProjectStore = defineStore('projects', () => {
             if (typeof abs !== 'number') continue
             const pos = posByIndex.get(abs)
             if (pos !== undefined) {
-              merged[pos] = item
+              // The server row is authoritative for content, but its footer
+              // facts land only once `record_turn` has written the turn to the
+              // durable transcript. Keep whatever the live stream already gave
+              // us for the fields the row is still missing.
+              merged[pos] = mergeMessageFields(item, merged[pos])
               continue
             }
             if (abs < cachedEnd) {


### PR DESCRIPTION
## Problem

Chat turn footers showed only the completion time and duration — no model, no context % — for both Claude and opencode chats.

## Cause

The backend was fine. `_overlay_transcript_metadata` already stitches each turn's `usage` (including `context_pct`), `quota` and `effective_model` onto history rows from the durable transcript, because the provider session files carry none of it. The PWA's `toChatMessage` mapper in `stores/projects.ts` never copied those fields off the wire, so anything hydrated from server history lost them. The mapper is shared, which is why both providers regressed together.

Two adjacent paths dropped the same facts:

- The indexed-row replace in the window merge overwrote a live row wholesale, losing a just-streamed turn's footer to a server row `record_turn` had not reached yet.
- The live-to-server carry-forward used `{ ...carried, ...row }`. Now that the mapper emits the keys explicitly, an `undefined` value on the server row shadowed the carried one.

Both now go through `mergeMessageFields`, which fills only what is missing.

## Also

Vue's whitespace condensing was eating the space before the token group's separator: `claude-sonnet-5| Tokens` → `claude-sonnet-5 | Tokens`.

## Verification

- `npm test` — 1051 passed, including a new cold-hydrate regression test.
- `npm run build` — clean.
- Rendered in a browser against a throwaway runtime root (isolated `HOME`, `CIAO_RUNTIME_ROOT`, `CIAO_MEMORY_DIR`, `CIAO_LAUNCH_AGENTS_DIR`), one chat per provider:
  - Claude — `11:19 · 2m 24s · claude-sonnet-5 | Tokens 4 in · 1,521 out · 21.4% ctx`
  - opencode — `10:16 · 9.9s · ollama-cloud/glm-5.3-flash | Tokens 53,848 in · 232 out · 5.4% ctx`

No Python changed, so the backend suite was not run.