### PR TITLE
fix(background): root background runs in the owning workspace, and make them visible

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,24 @@ Project shape:
 
 Verification:
 - Run focused tests for the changed behavior.
-- Run `pytest tests/` before claiming backend work is complete.
-- Run `cd web && npm run build` after frontend changes.
+- Run every gate CI blocks on before pushing, not just the tests. CI's
+  blocking steps are, in order:
+  1. `mypy ciao` — easy to forget and it fails the whole job. Watch for
+     `no-any-return`: several attributes (`ProjectChatManager._background_runner`,
+     for one) are typed `Any` because they are wired after construction, so
+     returning a call on one straight out of a typed function is an error.
+     Annotate the local instead.
+  2. `pytest tests/` — the full suite, before claiming backend work is
+     complete. A fake object in an unrelated test can break on a new
+     attribute (adding a field to the `/ws/events` snapshot broke
+     `tests/test_ws_auth.py`, whose `SimpleNamespace` stub had no such
+     attribute), so a green focused run proves nothing about the suite.
+  3. `cd web && npm test` — the full frontend suite. Needs Node >= 20.19;
+     `npx vitest` on an older Node silently skips component files while
+     printing green.
+  4. `cd web && npm run build` after frontend changes.
+  `pip-audit`, `npm audit` and `npm run lint` are advisory in CI (`|| true`).
+  Lint is still worth running — it just will not fail the build for you.
 - Run `./scripts/check-desktop.sh` after changes under `desktop/` — nothing else
   compiles the Rust shell, the Swift native sidecar, or assembles `Ciaobot.app`,
   so those break in CI rather than locally. Use `--fast` to skip the bundle step

--- a/ciao/background.py
+++ b/ciao/background.py
@@ -489,11 +489,15 @@ class BackgroundRunner:
         store: BackgroundRunStore,
         *,
         workspace_root: Path,
+        agent_root: Callable[[str], Path] | None = None,
+        on_start: Callable[[BackgroundRun], None] | None = None,
         on_finish: Callable[[BackgroundRun, list[str]], None] | None = None,
         record_job_runs: bool = True,
     ) -> None:
         self._store = store
         self._workspace_root = Path(workspace_root)
+        self._agent_root = agent_root
+        self._on_start = on_start
         self._on_finish = on_finish
         self._record_job_runs = record_job_runs
         self._procs: dict[str, asyncio.subprocess.Process] = {}
@@ -570,6 +574,20 @@ class BackgroundRunner:
     def active_count(self, chat_id: str) -> int:
         return sum(1 for run in self.list_for_chat(chat_id) if not run.is_terminal())
 
+    def active_counts(self) -> dict[str, int]:
+        """Live run count per owning chat (>0 only).
+
+        Read straight off the registry rather than a cached tally, so a
+        client connecting mid-run paints the same number a restart replay
+        would.
+        """
+        counts: dict[str, int] = {}
+        for run in self._store.list():
+            if run.is_terminal() or not run.parent_chat_id:
+                continue
+            counts[run.parent_chat_id] = counts.get(run.parent_chat_id, 0) + 1
+        return counts
+
     def log_path(self, run_id: str) -> Path:
         return self._store.log_path(run_id)
 
@@ -577,6 +595,38 @@ class BackgroundRunner:
         return read_tail(self._store.log_path(run_id), lines)
 
     # ── start ─────────────────────────────────────────────────────────
+
+    def root_for(self, workspace: str) -> Path:
+        """Root a run in ``workspace`` is resolved against and confined to.
+
+        This must be the workspace's AGENT ROOT, not the install root the
+        runner was constructed with, and the difference is not cosmetic. A
+        chat runs with its agent root as cwd, so the relative paths a model
+        writes are relative to ``<install>/<workspace>``. Resolving them
+        against the install root missed by exactly one level on every
+        re-rooted install — ``memory-vault/automations/x.py`` became
+        ``<install>/memory-vault/...`` instead of ``<install>/work/
+        memory-vault/...`` and the run died with ENOENT — and, worse, it
+        pointed the containment check at the wrong boundary: a ``work`` run
+        could read and write every other workspace's files, ``personal``
+        included.
+
+        Falls back to the install root when the workspace is unnamed, does
+        not resolve to one folder, or has no directory yet. That is the
+        pre-re-rooting layout, where ``agent_root`` returns the install root
+        for every workspace anyway.
+        """
+        if not workspace or self._agent_root is None:
+            return self._workspace_root
+        try:
+            root = Path(self._agent_root(workspace))
+        except ValueError:
+            # An unusable workspace name names no root (stale reference, or a
+            # renamed workspace). The install root is the safe answer, not a
+            # crash inside a tool call.
+            logger.debug("Background run workspace %r names no agent root", workspace)
+            return self._workspace_root
+        return root if root.is_dir() else self._workspace_root
 
     async def start_run(
         self,
@@ -593,8 +643,11 @@ class BackgroundRunner:
         if not parent_chat_id:
             raise BackgroundRunError("chat_required", "A background run needs an owning chat.")
         argv = validate_cmd(cmd)
-        run_dir = resolve_cwd(self._workspace_root, cwd)
-        executable = resolve_executable(argv[0], run_dir, self._workspace_root)
+        # Both resolutions are anchored at the OWNING WORKSPACE's agent root,
+        # which is the chat's cwd and the boundary the run belongs inside.
+        root = self.root_for(workspace)
+        run_dir = resolve_cwd(root, cwd)
+        executable = resolve_executable(argv[0], run_dir, root)
         timeout = validate_timeout(timeout_s)
         clean_label = sanitize_label(label)
         active = self.active_count(parent_chat_id)
@@ -658,6 +711,15 @@ class BackgroundRunner:
             self._supervise(run_id, proc, log_path, timeout),
             name=f"background-run-{run_id}",
         )
+        # Announce the live run before returning: the tool result goes to the
+        # model, not to the PWA, so without this the chat goes idle with
+        # nothing anywhere saying work is still in flight. A failed announce
+        # must not fail the run that already started.
+        if self._on_start is not None:
+            try:
+                self._on_start(run)
+            except Exception:  # noqa: BLE001 — a live run outranks its indicator
+                logger.exception("Background run %s start announce failed", run_id)
         return run
 
     # ── cancel ────────────────────────────────────────────────────────

--- a/ciao/background.py
+++ b/ciao/background.py
@@ -611,22 +611,34 @@ class BackgroundRunner:
         could read and write every other workspace's files, ``personal``
         included.
 
-        Falls back to the install root when the workspace is unnamed, does
-        not resolve to one folder, or has no directory yet. That is the
-        pre-re-rooting layout, where ``agent_root`` returns the install root
-        for every workspace anyway.
+        The install root is used only where it is the honest answer: a runner
+        built without a resolver, and a run with no owning workspace at all.
+        Both are the pre-re-rooting layout, where ``agent_root`` returns the
+        install root for every workspace anyway.
+
+        Anything else fails closed. A name that resolves to no folder, or to
+        a folder that is not there, is a stale or renamed workspace — and
+        answering the install root for it would silently widen both the cwd
+        and the containment boundary back to the whole install, which is the
+        cross-workspace escape this method exists to close. Refusing is also
+        the better tool result: the run could not have found its files under
+        the wrong root anyway.
         """
         if not workspace or self._agent_root is None:
             return self._workspace_root
         try:
             root = Path(self._agent_root(workspace))
-        except ValueError:
-            # An unusable workspace name names no root (stale reference, or a
-            # renamed workspace). The install root is the safe answer, not a
-            # crash inside a tool call.
-            logger.debug("Background run workspace %r names no agent root", workspace)
-            return self._workspace_root
-        return root if root.is_dir() else self._workspace_root
+        except ValueError as exc:
+            raise BackgroundRunError(
+                "workspace_unavailable",
+                f"Workspace '{workspace}' names no agent root.",
+            ) from exc
+        if not root.is_dir():
+            raise BackgroundRunError(
+                "workspace_unavailable",
+                f"Workspace '{workspace}' has no directory at {root}.",
+            )
+        return root
 
     async def start_run(
         self,

--- a/ciao/background.py
+++ b/ciao/background.py
@@ -242,6 +242,8 @@ def resolve_cwd(workspace_root: Path, cwd: str) -> Path:
     root = Path(workspace_root).resolve()
     raw = (cwd or "").strip()
     if not raw:
+        if not root.is_dir():
+            raise BackgroundRunError("cwd_not_found", "workspace root is not a directory.")
         return root
     if "\x00" in raw:
         raise BackgroundRunError("invalid_cwd", "cwd may not contain NUL.")
@@ -628,7 +630,9 @@ class BackgroundRunner:
             return self._workspace_root
         try:
             root = Path(self._agent_root(workspace))
-        except ValueError as exc:
+        except BackgroundRunError:
+            raise
+        except Exception as exc:
             raise BackgroundRunError(
                 "workspace_unavailable",
                 f"Workspace '{workspace}' names no agent root.",

--- a/ciao/main.py
+++ b/ciao/main.py
@@ -605,7 +605,14 @@ async def _run_server_locked(config: CiaoConfig) -> int:
     # window, so a batch finishing together produces one turn.
     from ciao.background import BackgroundRun, BackgroundRunner, BackgroundRunStore
 
+    def _background_started(run: BackgroundRun) -> None:
+        pcm.announce_background_runs(run.parent_chat_id)
+
     def _background_finished(run: BackgroundRun, tail: list[str]) -> None:
+        # Drop the indicator now. The wake below is coalesced over a short
+        # window, so waiting for it would leave the chat claiming a run is
+        # live for seconds after it exited.
+        pcm.announce_background_runs(run.parent_chat_id)
         pcm.queue_background_wake(
             run.parent_chat_id,
             run_id=run.run_id,
@@ -620,6 +627,12 @@ async def _run_server_locked(config: CiaoConfig) -> int:
     background_runner = BackgroundRunner(
         BackgroundRunStore(config.state_path.parent),
         workspace_root=config.workspace_root,
+        # A run resolves its cwd and relative cmd path against the owning
+        # workspace's agent root — the same directory its chat runs in. The
+        # install root is only the fallback for a pre-re-rooting layout; see
+        # BackgroundRunner.root_for.
+        agent_root=config.agent_root,
+        on_start=_background_started,
         on_finish=_background_finished,
     )
 

--- a/ciao/mcp_server.py
+++ b/ciao/mcp_server.py
@@ -1346,9 +1346,10 @@ class CiaoMcpService:
                     single string is rejected: there is no shell, so nothing
                     would split it. For shell features, run
                     ["bash", "-lc", "..."] explicitly and own that choice.
-                cwd: Directory for the run, relative to the workspace root.
-                    Defaults to the workspace root. Paths outside it are
-                    rejected.
+                cwd: Directory for the run, relative to THIS chat's workspace
+                    root — the same directory your own shell commands run in,
+                    so a path that works in Bash works here unchanged.
+                    Defaults to that root. Paths outside it are rejected.
                 env: Extra environment variables. Loader hooks (LD_PRELOAD and
                     friends) and Ciaobot's own session token are rejected.
                 timeout_s: Wall-clock ceiling; the process tree is terminated

--- a/ciao/observability/hooks.py
+++ b/ciao/observability/hooks.py
@@ -155,7 +155,13 @@ def build_foreground_bash_hook():
                     "additionalContext": (
                         "Ciaobot kept this Bash command in the foreground because "
                         "background shell processes stop when the SDK turn ends. "
-                        "Wait for the tool result before replying."
+                        "Wait for the tool result before replying. If you expect "
+                        "this to take minutes, cancel it and use the "
+                        "`background_run_start` MCP tool instead: a foreground "
+                        "Bash command that outlives its timeout is moved to the "
+                        "CLI's own background tracking, which this hook cannot "
+                        "intercept and whose result is frequently never "
+                        "delivered to the chat."
                     ),
                 }
             }

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -6208,7 +6208,13 @@ class ProjectChatManager:
         died before producing a report, so anything the run was supposed to do
         with the results (write the log, commit) did not happen. Used by
         :meth:`dispatch_schedule` to keep such a run visible instead of
-        auto-archiving a stub (the 2026-08-30 daily-log failure).
+        auto-archiving a stub (the 2026-08-30 daily-log failure), and by the
+        turn-done branch to hold the result announce back until the synthesis
+        nudge produces the real reply.
+
+        The patterns are deliberately broad ("waiting on ..."), so a caller
+        that suppresses anything on the strength of this must be certain
+        something else will fire in its place.
         """
         flat = " ".join((text or "").strip().splitlines()).strip()
         if not flat:
@@ -6983,14 +6989,20 @@ class ProjectChatManager:
                 # instead of leaving the chat stuck on "I'll compile once the
                 # agents report back".
                 chat_for_watcher = self._chats.get(chat_id)
-                subagent_watcher_started = False
+                # True only when a synthesis nudge can actually re-announce
+                # this chat's result later. Holding the announce back is safe
+                # ONLY then: the nudge's reply carries the real push. The
+                # opencode watcher has no nudge path at all, so gating on the
+                # watcher alone dropped the push, the unread badge and the
+                # archive proposal outright for any opencode reply that merely
+                # said "waiting on ...".
+                nudge_can_reannounce = False
                 if (
                     chat_for_watcher is not None
                     and chat_for_watcher.session_id
                     and capabilities_for(chat_for_watcher.provider).background_subagents
                 ):
                     self._start_subagent_watcher(chat_id, project_id)
-                    subagent_watcher_started = True
                     # Keep the SDK pipe drained while the client idles: a
                     # finishing background subagent triggers a CLI-initiated
                     # parent turn whose events would otherwise rot in the
@@ -6999,6 +7011,7 @@ class ProjectChatManager:
                     # a live view of that follow-up turn.
                     if chat_for_watcher.provider == "claude":
                         self._start_between_turns_drain(chat_id, project_id)
+                        nudge_can_reannounce = True
                 # Successful turn(s): announce result ready (drives unread
                 # badges + in-app toast on clients that aren't focused on
                 # this chat) and dispatch web push (decoupled from any WS).
@@ -7018,17 +7031,25 @@ class ProjectChatManager:
                         self._save()
                     title = chat_now.title if chat_now else "Ciaobot"
                     # A turn that ends on "I'll report back once the agents
-                    # finish" is not a result: the watcher started above will
+                    # finish" is not a result: the drain started above will
                     # nudge the synthesis turn and that reply carries the real
                     # push. Only the announce is held back — the state above
                     # (recents order, snippet, pending-retry clear) belongs to
                     # every non-error turn, and withholding it left a retried
-                    # chat pinned at retry_status="pending" forever. Gated on
-                    # the watcher too, so a chat with no background subagents
-                    # at all (another provider, or a reply that merely says
-                    # "waiting on legal") still announces normally.
-                    interim = subagent_watcher_started and (
-                        self._is_interim_subagent_text(last_assistant_text)
+                    # chat pinned at retry_status="pending" forever.
+                    #
+                    # Held back only when something will announce in its place:
+                    # the nudge needs the between-turns drain (claude), and it
+                    # stands down when the turn ended on a question for the
+                    # user (see _nudge_synthesis_after_subagents), which would
+                    # otherwise leave that question with no notification at
+                    # all. `_INTERIM_SUBAGENT_PATTERNS` is broad on purpose
+                    # ("waiting on ..."), so every case where the nudge cannot
+                    # fire has to announce normally.
+                    interim = (
+                        nudge_can_reannounce
+                        and not (chat_now is not None and chat_now.pending_question)
+                        and self._is_interim_subagent_text(last_assistant_text)
                     )
                     if not interim:
                         # Schedule the push with a small delay. If the user reads

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -5889,6 +5889,43 @@ class ProjectChatManager:
         """Last announced running-background-subagent count per chat (>0 only)."""
         return {cid: n for cid, n in self._background_agents_last.items() if n > 0}
 
+    @property
+    def background_run_counts(self) -> dict[str, int]:
+        """Live ``background_run_start`` count per chat (>0 only).
+
+        Read from the runner's registry, not a cached tally, so this survives
+        a restart: the runs themselves are persisted and re-supervised, and a
+        client reconnecting mid-run gets the real number.
+        """
+        runner = self._background_runner
+        if runner is None:
+            return {}
+        try:
+            return runner.active_counts()
+        except Exception:  # noqa: BLE001 — an indicator must not break /ws/events
+            logger.exception("Background run counts unavailable")
+            return {}
+
+    def announce_background_runs(self, chat_id: str) -> None:
+        """Publish this chat's live background-run count to connected clients.
+
+        Called on both edges (a run starting, a run finishing). A background
+        run is deliberately non-blocking, so the chat's turn ends while the
+        command is still going; this event is the only thing that keeps the
+        chat from looking finished. Distinct from ``chat_subagents_ready``:
+        these runs have no transcript and no agent to open, only a count and
+        a log.
+        """
+        if not chat_id:
+            return
+        chat = self._chats.get(chat_id)
+        self._events.publish({
+            "type": "chat_background_runs",
+            "chat_id": chat_id,
+            "project_id": chat.project_id if chat is not None else "",
+            "running": self.background_run_counts.get(chat_id, 0),
+        })
+
     def _park_pending_for_retry(self, chat_id: str, stream: "ChatStream") -> None:
         """Move queued follow-ups off the (about-to-be-torn-down) stream onto
         the chat so a scheduled retry re-seeds them instead of dropping them.
@@ -6946,12 +6983,14 @@ class ProjectChatManager:
                 # instead of leaving the chat stuck on "I'll compile once the
                 # agents report back".
                 chat_for_watcher = self._chats.get(chat_id)
+                subagent_watcher_started = False
                 if (
                     chat_for_watcher is not None
                     and chat_for_watcher.session_id
                     and capabilities_for(chat_for_watcher.provider).background_subagents
                 ):
                     self._start_subagent_watcher(chat_id, project_id)
+                    subagent_watcher_started = True
                     # Keep the SDK pipe drained while the client idles: a
                     # finishing background subagent triggers a CLI-initiated
                     # parent turn whose events would otherwise rot in the
@@ -6978,18 +7017,32 @@ class ProjectChatManager:
                         chat_now.last_snippet = snippet
                         self._save()
                     title = chat_now.title if chat_now else "Ciaobot"
-                    # Schedule the push with a small delay. If the user reads
-                    # the chat on any device in the window (via /api/chats/
-                    # {id}/read), the pending task is cancelled and no push
-                    # fires. New replies to the same chat cancel and restart
-                    # the timer (see _schedule_push).
-                    self._announce_result_ready(
-                        chat_id, project_id, title, snippet
+                    # A turn that ends on "I'll report back once the agents
+                    # finish" is not a result: the watcher started above will
+                    # nudge the synthesis turn and that reply carries the real
+                    # push. Only the announce is held back — the state above
+                    # (recents order, snippet, pending-retry clear) belongs to
+                    # every non-error turn, and withholding it left a retried
+                    # chat pinned at retry_status="pending" forever. Gated on
+                    # the watcher too, so a chat with no background subagents
+                    # at all (another provider, or a reply that merely says
+                    # "waiting on legal") still announces normally.
+                    interim = subagent_watcher_started and (
+                        self._is_interim_subagent_text(last_assistant_text)
                     )
-                    self._spawn_detached(
-                        self._maybe_archive_proposal_helper(chat_id),
-                        f"archive-proposal-helper-{chat_id}",
-                    )
+                    if not interim:
+                        # Schedule the push with a small delay. If the user reads
+                        # the chat on any device in the window (via /api/chats/
+                        # {id}/read), the pending task is cancelled and no push
+                        # fires. New replies to the same chat cancel and restart
+                        # the timer (see _schedule_push).
+                        self._announce_result_ready(
+                            chat_id, project_id, title, snippet
+                        )
+                        self._spawn_detached(
+                            self._maybe_archive_proposal_helper(chat_id),
+                            f"archive-proposal-helper-{chat_id}",
+                        )
 
         asyncio.create_task(_drive())
         return stream

--- a/ciao/web/project_chats.py
+++ b/ciao/web/project_chats.py
@@ -5901,10 +5901,13 @@ class ProjectChatManager:
         if runner is None:
             return {}
         try:
-            return runner.active_counts()
+            # ``_background_runner`` is typed Any (wired after construction),
+            # so the annotation is what keeps this a dict[str, int].
+            counts: dict[str, int] = runner.active_counts()
         except Exception:  # noqa: BLE001 — an indicator must not break /ws/events
             logger.exception("Background run counts unavailable")
             return {}
+        return counts
 
     def announce_background_runs(self, chat_id: str) -> None:
         """Publish this chat's live background-run count to connected clients.

--- a/ciao/web/routes_chat.py
+++ b/ciao/web/routes_chat.py
@@ -370,6 +370,10 @@ async def ws_events(websocket: WebSocket) -> None:
             # client can paint the "N agents running" indicator immediately
             # (and clear a count left stale by a missed event during a gap).
             "background_agents": pcm.background_agent_counts,
+            # Same idea for tracked background command runs. These outlive the
+            # turn that started them *and* a server restart, so a reconnecting
+            # client must be told about them or the chat reads as finished.
+            "background_runs": pcm.background_run_counts,
             # Chats whose post-archive pipeline is mid-flight. A client that
             # connects between the start and finish events would otherwise show
             # nothing at all until the next archive.

--- a/tests/test_background_runs.py
+++ b/tests/test_background_runs.py
@@ -286,8 +286,13 @@ async def test_run_cannot_reach_another_workspace(tmp_path: Path) -> None:
     assert excinfo.value.code == "cwd_forbidden"
 
 
-def test_workspace_root_falls_back_to_the_install_root(tmp_path: Path) -> None:
-    """Unnamed, unresolvable, and not-yet-created workspaces keep the old root."""
+def test_workspace_root_falls_back_only_where_that_is_honest(tmp_path: Path) -> None:
+    """The install root is for the pre-re-rooting layout, not for a bad name.
+
+    Answering the install root for a stale or renamed workspace would widen
+    the containment boundary back to the whole install — the cross-workspace
+    escape ``root_for`` exists to close — so those fail closed instead.
+    """
 
     def resolver(name: str) -> Path:
         if name == "missing":
@@ -296,7 +301,9 @@ def test_workspace_root_falls_back_to_the_install_root(tmp_path: Path) -> None:
 
     runner = _rerooted_runner(tmp_path)
     assert runner.root_for("work") == tmp_path / "work"
-    # No resolver at all: the pre-re-rooting construction.
+    # No resolver at all, and no owning workspace: both genuinely mean the
+    # install root, because that is where a pre-re-rooting install keeps
+    # every workspace's assets.
     assert _runner(tmp_path).root_for("work") == tmp_path
 
     scoped = BackgroundRunner(
@@ -306,8 +313,26 @@ def test_workspace_root_falls_back_to_the_install_root(tmp_path: Path) -> None:
         record_job_runs=False,
     )
     assert scoped.root_for("") == tmp_path
-    assert scoped.root_for("bad/name") == tmp_path
-    assert scoped.root_for("missing") == tmp_path
+    for unusable in ("bad/name", "missing"):
+        with pytest.raises(BackgroundRunError) as excinfo:
+            scoped.root_for(unusable)
+        assert excinfo.value.code == "workspace_unavailable"
+
+
+async def test_run_is_refused_when_its_workspace_directory_is_gone(
+    tmp_path: Path,
+) -> None:
+    """A renamed or deleted workspace refuses the run instead of re-rooting it."""
+    runner = _rerooted_runner(tmp_path)
+    (tmp_path / "work").rename(tmp_path / "work-renamed")
+
+    with pytest.raises(BackgroundRunError) as excinfo:
+        await runner.start_run(
+            parent_chat_id="chat-1",
+            workspace="work",
+            cmd=["/bin/sh", "-c", "true"],
+        )
+    assert excinfo.value.code == "workspace_unavailable"
 
 
 # ── runner ────────────────────────────────────────────────────────────────

--- a/tests/test_background_runs.py
+++ b/tests/test_background_runs.py
@@ -222,6 +222,94 @@ def test_timeout_is_clamped_not_unbounded() -> None:
         validate_timeout("soon")
 
 
+# ── workspace rooting ─────────────────────────────────────────────────────
+
+
+def _rerooted_runner(tmp_path: Path, **kwargs) -> BackgroundRunner:
+    """Runner over a re-rooted install: ``<install>/work``, ``<install>/personal``."""
+    for name in ("work", "personal"):
+        (tmp_path / name).mkdir(parents=True, exist_ok=True)
+    runtime = tmp_path / ".runtime"
+    runtime.mkdir(parents=True, exist_ok=True)
+    return BackgroundRunner(
+        BackgroundRunStore(runtime),
+        workspace_root=tmp_path,
+        agent_root=lambda name: tmp_path / name,
+        record_job_runs=False,
+        **kwargs,
+    )
+
+
+async def test_run_resolves_paths_against_the_owning_workspace_root(
+    tmp_path: Path,
+) -> None:
+    """The chat's cwd is its agent root, so a model's relative path means that.
+
+    Anchoring at the install root instead dropped the workspace segment and
+    every relative path in a re-rooted workspace failed with ENOENT.
+    """
+    runner = _rerooted_runner(tmp_path)
+    scripts = tmp_path / "work" / "automations"
+    scripts.mkdir(parents=True)
+    probe = scripts / "probe.sh"
+    probe.write_text("#!/bin/sh\npwd\n", encoding="utf-8")
+    probe.chmod(probe.stat().st_mode | stat.S_IXUSR)
+
+    run = await runner.start_run(
+        parent_chat_id="chat-1",
+        workspace="work",
+        cmd=["./probe.sh"],
+        cwd="automations",
+    )
+    assert Path(run.cwd) == scripts.resolve()
+
+    final = await _await_terminal(runner, run.run_id)
+    assert final.status == "ok"
+    assert any(str(scripts.resolve()) in line for line in runner.tail(run.run_id))
+
+
+async def test_run_cannot_reach_another_workspace(tmp_path: Path) -> None:
+    """Containment follows the agent root, so `personal/` is out of reach.
+
+    Against the install root this escape resolved *inside* the boundary and
+    was allowed.
+    """
+    runner = _rerooted_runner(tmp_path)
+
+    with pytest.raises(BackgroundRunError) as excinfo:
+        await runner.start_run(
+            parent_chat_id="chat-1",
+            workspace="work",
+            cmd=["/bin/sh", "-c", "true"],
+            cwd="../personal",
+        )
+    assert excinfo.value.code == "cwd_forbidden"
+
+
+def test_workspace_root_falls_back_to_the_install_root(tmp_path: Path) -> None:
+    """Unnamed, unresolvable, and not-yet-created workspaces keep the old root."""
+
+    def resolver(name: str) -> Path:
+        if name == "missing":
+            return tmp_path / "missing"
+        raise ValueError("workspace name must identify one folder")
+
+    runner = _rerooted_runner(tmp_path)
+    assert runner.root_for("work") == tmp_path / "work"
+    # No resolver at all: the pre-re-rooting construction.
+    assert _runner(tmp_path).root_for("work") == tmp_path
+
+    scoped = BackgroundRunner(
+        BackgroundRunStore(tmp_path / ".runtime"),
+        workspace_root=tmp_path,
+        agent_root=resolver,
+        record_job_runs=False,
+    )
+    assert scoped.root_for("") == tmp_path
+    assert scoped.root_for("bad/name") == tmp_path
+    assert scoped.root_for("missing") == tmp_path
+
+
 # ── runner ────────────────────────────────────────────────────────────────
 
 
@@ -790,6 +878,60 @@ async def test_background_wake_queues_behind_a_live_turn(
 
     assert len(recorder.queued) == 1
     assert recorder.started == []
+
+
+async def test_live_runs_are_announced_and_snapshotted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A run in flight has to be visible: the turn that started it has ended.
+
+    ``background_run_start`` is non-blocking by design, so without this event
+    the chat reads as finished while the command is still going and the only
+    trace anywhere is whatever the model happened to say.
+    """
+    manager = _make_manager(tmp_path)
+    project = manager.create_project("Runs", workspace="work")
+    chat = manager.create_chat(project.project_id, title="Owner")
+    published: list[dict] = []
+    monkeypatch.setattr(manager._events, "publish", published.append)
+    manager._background_runner = SimpleNamespace(
+        active_counts=lambda: {chat.chat_id: 2},
+    )
+
+    # The snapshot a reconnecting client gets, which must not depend on
+    # having seen the start event.
+    assert manager.background_run_counts == {chat.chat_id: 2}
+
+    manager.announce_background_runs(chat.chat_id)
+    events = [e for e in published if e.get("type") == "chat_background_runs"]
+    assert len(events) == 1
+    assert events[0]["running"] == 2
+    assert events[0]["project_id"] == project.project_id
+
+    # Finishing drops it back to zero, which is how the client clears the pill.
+    manager._background_runner = SimpleNamespace(active_counts=lambda: {})
+    manager.announce_background_runs(chat.chat_id)
+    events = [e for e in published if e.get("type") == "chat_background_runs"]
+    assert events[-1]["running"] == 0
+
+
+async def test_runner_announces_both_edges(tmp_path: Path) -> None:
+    """on_start fires with the run live; on_finish is the manager's own hook."""
+    started: list[tuple[str, dict[str, int]]] = []
+    runner = _rerooted_runner(tmp_path)
+    # Sampled inside the callback: the announce has to happen while the run is
+    # still countable, otherwise the client is told "0 running" for a live run.
+    runner._on_start = lambda run: started.append((run.run_id, runner.active_counts()))
+
+    run = await runner.start_run(
+        parent_chat_id="chat-1",
+        workspace="work",
+        cmd=["/bin/sh", "-c", "true"],
+    )
+    assert started == [(run.run_id, {"chat-1": 1})]
+
+    await _await_terminal(runner, run.run_id)
+    assert runner.active_counts() == {}
 
 
 async def test_background_wake_publishes_its_delivery(

--- a/tests/test_ws_auth.py
+++ b/tests/test_ws_auth.py
@@ -27,6 +27,7 @@ def _events_app(*, auth_required: bool) -> Starlette:
         active_stream_chat_ids=lambda: [],
         get_chat=lambda _cid: None,
         background_agent_counts={},
+        background_run_counts={},
         postprocessing_chat_ids=lambda: [],
         events=SimpleNamespace(subscribe=_never_yield),
     )

--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -1049,6 +1049,19 @@
       </button>
     </div>
 
+    <!-- Running-agent links, revealed by expanding the dock's "N agent(s)
+         running" pill above. The pill itself sits inside a <button> (can't
+         nest a link there), so the actual links live in this sibling block,
+         same disclosure pattern as queued-messages/questions below. -->
+    <div v-if="dockExpanded && dockAgentsPillShown && dockRunningAgents.length" class="dock-agent-links">
+      <router-link
+        v-for="sub in dockRunningAgents"
+        :key="sub.agent_id"
+        class="dock-agent-link"
+        :to="subagentPath(chat.chat_id, sub.agent_id)"
+      >{{ sub.description || shortAgentId(sub.agent_id) }}</router-link>
+    </div>
+
     <!-- @-mention picker (textarea version: inserts plain backend-facing text) -->
     <div v-if="showMentionPicker" class="commands-picker mention-picker" role="listbox" aria-label="Mentions">
       <div
@@ -1218,6 +1231,7 @@ import { useReentrySummaryPreference } from '../composables/useReentrySummaryPre
 import { useTypeToComment } from '../composables/useTypeToComment'
 import ChatCommentPopover from './ChatCommentPopover.vue'
 import CommentComposePopover from './CommentComposePopover.vue'
+import { subagentPath, shortAgentId } from '../lib/subagentIds'
 
 /** The footer facts for one turn: when it landed, how long it took, which
  *  model answered and what it cost. Collected across the turn's assistant
@@ -1659,6 +1673,17 @@ const dockStripVisible = computed(() =>
     || store.currentQueued.length > 0)),
 )
 
+// Whether the strip carries the "N agents running" pill. The links block below
+// is that pill's disclosure, so both read the same condition — otherwise an
+// archived chat with lingering rows renders links no pill ever announced.
+const dockAgentsPillShown = computed(
+  () => store.activeBackgroundAgents > 0 && !chat.value?.archived,
+)
+
+const dockRunsPillShown = computed(
+  () => store.activeBackgroundRuns > 0 && !chat.value?.archived,
+)
+
 const dockDeferred = computed<DockItem[]>(() => {
   const items: DockItem[] = []
   const extraApprovals = pendingApprovals.value.length - 1
@@ -1672,12 +1697,28 @@ const dockDeferred = computed<DockItem[]>(() => {
     const n = store.currentQueued.length
     items.push({ key: 'queued', label: `${n} queued` })
   }
-  if (store.activeBackgroundAgents > 0 && !chat.value?.archived) {
+  if (dockAgentsPillShown.value) {
     const n = store.activeBackgroundAgents
     items.push({ key: 'agents', label: `${n} agent${n === 1 ? '' : 's'} running` })
   }
+  // Tracked `background_run_start` commands. A separate pill, not folded into
+  // the agents one: these have no transcript to open, so the count is all
+  // there is to show, and the wording has to stay honest about that. Shown
+  // even while the chat is idle — that quiet gap is exactly when the user
+  // has no other sign the command is still going.
+  if (dockRunsPillShown.value) {
+    const n = store.activeBackgroundRuns
+    items.push({ key: 'runs', label: `${n} background run${n === 1 ? '' : 's'}` })
+  }
   return items
 })
+
+// Backs the "N agent(s) running" dock pill's expanded state: the pill itself
+// only shows a count (it lives inside the strip's toggle button, which can't
+// nest a link), so expanding it reveals these as a separate block of links.
+const dockRunningAgents = computed(() =>
+  chat.value ? store.runningSubagentsFor(chat.value.chat_id) : [],
+)
 
 onMounted(() => {
   taskStore.fetchSchedules().catch(() => {})
@@ -6328,6 +6369,35 @@ details[open] > .activity-summary::before {
   color: var(--warning);
   background: none;
 }
+
+.dock-agent-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: 0 var(--space-3) var(--space-2);
+  padding-left: calc(var(--space-3) + var(--safe-left));
+  padding-right: calc(var(--space-3) + var(--safe-right));
+  background: var(--bg);
+  border-top: 1px solid var(--border);
+}
+
+.dock-agent-link {
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-sm);
+  background: var(--bg2);
+  color: var(--accent);
+  font-size: var(--text-xs);
+  text-decoration: none;
+  /* Dispatch descriptions are free text and routinely a full sentence; kept on
+     one line, an unbounded chip pushes the composer into horizontal scroll on
+     a phone. Clip instead. */
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dock-agent-link:hover { text-decoration: underline; }
 
 .bg-agents-dot {
   width: 8px;

--- a/web/src/components/ChatPanel.vue
+++ b/web/src/components/ChatPanel.vue
@@ -1053,13 +1053,16 @@
          running" pill above. The pill itself sits inside a <button> (can't
          nest a link there), so the actual links live in this sibling block,
          same disclosure pattern as queued-messages/questions below. -->
-    <div v-if="dockExpanded && dockAgentsPillShown && dockRunningAgents.length" class="dock-agent-links">
-      <router-link
-        v-for="sub in dockRunningAgents"
-        :key="sub.agent_id"
-        class="dock-agent-link"
-        :to="subagentPath(chat.chat_id, sub.agent_id)"
-      >{{ sub.description || shortAgentId(sub.agent_id) }}</router-link>
+    <div v-if="dockExpanded && dockAgentsPillShown" class="dock-agent-links">
+      <template v-if="dockRunningAgents.length">
+        <router-link
+          v-for="sub in dockRunningAgents"
+          :key="sub.agent_id"
+          class="dock-agent-link"
+          :to="subagentPath(chat.chat_id, sub.agent_id)"
+        >{{ sub.description || shortAgentId(sub.agent_id) }}</router-link>
+      </template>
+      <span v-else class="dock-agent-link dock-agent-link--pending">details loading…</span>
     </div>
 
     <!-- @-mention picker (textarea version: inserts plain backend-facing text) -->
@@ -6398,6 +6401,10 @@ details[open] > .activity-summary::before {
 }
 
 .dock-agent-link:hover { text-decoration: underline; }
+.dock-agent-link--pending {
+  color: var(--fg3);
+  background: none;
+}
 
 .bg-agents-dot {
   width: 8px;

--- a/web/src/components/HomeRecentChats.vue
+++ b/web/src/components/HomeRecentChats.vue
@@ -411,7 +411,8 @@ function makeLane(
     tiers: groupHomeTiers(
       chats,
       chatId => store.chatNeedsInput(chatId),
-      chatId => store.isChatStreaming(chatId) || store.chatHasBackgroundAgents(chatId) || store.chatHasRunningSubagents(chatId),
+      chatId => store.isChatStreaming(chatId) || store.chatHasBackgroundAgents(chatId)
+        || store.chatHasBackgroundRuns(chatId) || store.chatHasRunningSubagents(chatId),
       chatId => store.chatUnread(chatId) > 0,
     ),
     archivingChats: (workspace && workspace !== 'unknown' && archivingChatsByWorkspace.value.get(workspace)) || [],

--- a/web/src/components/ProjectView.vue
+++ b/web/src/components/ProjectView.vue
@@ -469,7 +469,8 @@ const totalUnread = computed(() => store.projectUnread(props.projectId))
 const needsInputCount = computed(() => store.projectNeedsInput(props.projectId))
 const workingCount = computed(() =>
   activeChats.value.filter(c =>
-    store.isChatStreaming(c.chat_id) || store.chatHasBackgroundAgents(c.chat_id),
+    store.isChatStreaming(c.chat_id) || store.chatHasBackgroundAgents(c.chat_id)
+    || store.chatHasBackgroundRuns(c.chat_id),
   ).length,
 )
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -380,12 +380,13 @@ export type WsEvent =
 // Global awareness events from /ws/events
 export type EventsWsMessage =
   | { type: 'keepalive' }
-  | { type: 'snapshot'; active_streams: { chat_id: string; project_id: string }[]; background_agents?: Record<string, number>; postprocessing?: string[]; restarting?: boolean }
+  | { type: 'snapshot'; active_streams: { chat_id: string; project_id: string }[]; background_agents?: Record<string, number>; background_runs?: Record<string, number>; postprocessing?: string[]; restarting?: boolean }
   | { type: 'chat_created'; chat: ChatInfo }
   | { type: 'chat_streaming_started'; chat_id: string; project_id: string }
   | { type: 'chat_streaming_done'; chat_id: string; project_id: string; is_error: boolean }
   | { type: 'chat_result_ready'; chat_id: string; project_id: string; title: string; snippet: string }
   | { type: 'chat_subagents_ready'; chat_id: string; project_id: string; remaining: number; nudged?: boolean }
+  | { type: 'chat_background_runs'; chat_id: string; project_id: string; running: number }
   | { type: 'chat_read'; chat_id: string; last_read_at: string }
   | { type: 'chat_unread'; chat_id: string; last_read_at: string }
   | { type: 'chat_title'; chat_id: string; title: string; status?: 'pending' | 'ready' }

--- a/web/src/stores/projects.test.ts
+++ b/web/src/stores/projects.test.ts
@@ -2822,6 +2822,46 @@ describe('background agents indicator', () => {
     expect(store.backgroundAgents['c-stale']).toBeUndefined()
     expect(store.backgroundAgents['c-live']).toBe(2)
   })
+
+  test('tracked background runs get their own count, cleared at zero', () => {
+    const store = useProjectStore()
+    const chatId = 'c-run'
+    store.activeChatId = chatId
+    store.connectEventsWs()
+    const sock = fakeSockets[fakeSockets.length - 1]
+    const fire = (running: number) =>
+      sock.onmessage?.({
+        data: JSON.stringify({ type: 'chat_background_runs', chat_id: chatId, project_id: 'p1', running }),
+      })
+
+    fire(1)
+    expect(store.activeBackgroundRuns).toBe(1)
+    expect(store.chatHasBackgroundRuns(chatId)).toBe(true)
+    fire(2)
+    expect(store.activeBackgroundRuns).toBe(2)
+    fire(0)
+    expect(store.backgroundRuns[chatId]).toBeUndefined()
+    expect(store.chatHasBackgroundRuns(chatId)).toBe(false)
+    // Background agents are a separate signal; a run must not light that pill.
+    expect(store.activeBackgroundAgents).toBe(0)
+  })
+
+  test('the snapshot re-seeds run counts for a client that missed the start', () => {
+    apiGet.mockResolvedValue([])
+    const store = useProjectStore()
+    store.backgroundRuns['c-stale'] = 3
+    store.connectEventsWs()
+    const sock = fakeSockets[fakeSockets.length - 1]
+    sock.onmessage?.({
+      data: JSON.stringify({
+        type: 'snapshot',
+        active_streams: [],
+        background_runs: { 'c-live': 1 },
+      }),
+    })
+    expect(store.backgroundRuns['c-stale']).toBeUndefined()
+    expect(store.backgroundRuns['c-live']).toBe(1)
+  })
 })
 
 describe('postprocessingChats (home tidying list)', () => {

--- a/web/src/stores/projects.ts
+++ b/web/src/stores/projects.ts
@@ -240,6 +240,13 @@ export const useProjectStore = defineStore('projects', () => {
   // running" indicator so the user can see work is ongoing during the quiet
   // gap between the turn ending and the agents reporting back.
   const backgroundAgents = ref<Record<string, number>>({})
+  // Per-chat count of live `background_run_start` command runs. Driven by
+  // `chat_background_runs` over /ws/events and re-seeded from the snapshot.
+  // Separate from `backgroundAgents`: a background run has no transcript and
+  // nothing to open, so it gets a count-only indicator. Without it the chat
+  // goes fully idle the moment the turn ends, with nothing saying a command
+  // is still going — the tool is non-blocking by design.
+  const backgroundRuns = ref<Record<string, number>>({})
   // Full-screen restart overlay while the server drains active chats and
   // relaunches. Driven by /ws/events `server_restarting` (and the same
   // signal on the per-chat socket when a send is rejected mid-drain).
@@ -715,6 +722,10 @@ export const useProjectStore = defineStore('projects', () => {
     backgroundAgents.value[activeChatId.value || ''] || 0
   )
 
+  const activeBackgroundRuns = computed(() =>
+    backgroundRuns.value[activeChatId.value || ''] || 0
+  )
+
   // Paused while the read-only subagent view is open for this chat: that
   // view already polls its single transcript on a 4s timer, so the store's
   // full-chat poll (every subagent, every transcript, re-parsed) would run
@@ -889,6 +900,10 @@ export const useProjectStore = defineStore('projects', () => {
   // streaming but agents are still working.
   function chatHasBackgroundAgents(chatId: string): boolean {
     return (backgroundAgents.value[chatId] || 0) > 0
+  }
+
+  function chatHasBackgroundRuns(chatId: string): boolean {
+    return (backgroundRuns.value[chatId] || 0) > 0
   }
 
   // Subagents this chat has working right now, from /api/subagents/running.
@@ -3965,6 +3980,11 @@ export const useProjectStore = defineStore('projects', () => {
         // count left stale by a missed event (WS gap, server restart) heals
         // on reconnect.
         backgroundAgents.value = { ...(msg.background_agents || {}) }
+        // Same, for tracked command runs. Authoritative for the same reason,
+        // and it matters more here: runs are persisted and re-supervised
+        // across a server restart, so the snapshot is how a client learns
+        // about one that started before it connected.
+        backgroundRuns.value = { ...(msg.background_runs || {}) }
         // Post-archive pipelines still in flight. Authoritative like the counts
         // above: a chat the server no longer lists as running has settled, so
         // clear a stale 'running' rather than leaving it pulsing forever.
@@ -4078,6 +4098,17 @@ export const useProjectStore = defineStore('projects', () => {
         // the Activity view (which fires a visibilitychange).
         if (msg.chat_id === activeChatId.value) {
           void reconcileAfterResult(msg.chat_id)
+        }
+        break
+      }
+      case 'chat_background_runs': {
+        // Count-only: there is no transcript to pull and no agent row to
+        // refresh, unlike `chat_subagents_ready`. The finishing run delivers
+        // its own wake turn, which arrives as a normal chat result.
+        if (msg.running > 0) {
+          backgroundRuns.value[msg.chat_id] = msg.running
+        } else {
+          delete backgroundRuns.value[msg.chat_id]
         }
         break
       }
@@ -5863,13 +5894,13 @@ export const useProjectStore = defineStore('projects', () => {
     // State
     projects, chats, workspaces, workspaceProviderOptions, activeWorkspace, activeChatId, bootstrapped, messages, messageHistoryLoading, subagents, unread, lastResultSnippet, lastResultSnippetAt, lastResultSnippetNeedsRebase, reentrySummaries,
     streaming, streamingText, streamingThinking, pendingImages, pendingComments, pendingChatComments, fileComments, queuedMessages,
-    projectStreaming, backgroundAgents, runningSubagents, toasts, pendingPermissions, activeQuestions, activeCapabilityQuestions, creatingChatProjectIds,
+    projectStreaming, backgroundAgents, backgroundRuns, runningSubagents, toasts, pendingPermissions, activeQuestions, activeCapabilityQuestions, creatingChatProjectIds,
     serverRestarting, serverRestartMessage, hostConnectionUnavailable,
     // Computed
     workspaceProjects, workspaceOptions, activeChat, activeProject, activeMessages, activeSubagents,
-    isStreaming, currentStreamingText, currentStreamingThinking, currentQueued, activeBackgroundAgents, currentActivity, currentTimeline, currentLiveUsage, currentStreamStartedAt, projectChats,
+    isStreaming, currentStreamingText, currentStreamingThinking, currentQueued, activeBackgroundAgents, activeBackgroundRuns, currentActivity, currentTimeline, currentLiveUsage, currentStreamStartedAt, projectChats,
     chatUnread, chatNeedsInput, chatPendingQuestion, chatLastSnippet, projectNeedsInput, projectUnread, workspaceUnread, workspaceNeedsInput, totalUnread, attentionChatCount, clearUnread, markRead, markUnread, markAllRead,
-    recentChats, activeChatsAll, projectIsStreaming, isChatStreaming, chatHasBackgroundAgents, runningSubagentsFor, chatHasRunningSubagents, workspaceIsStreaming, projectFor,
+    recentChats, activeChatsAll, projectIsStreaming, isChatStreaming, chatHasBackgroundAgents, chatHasBackgroundRuns, runningSubagentsFor, chatHasRunningSubagents, workspaceIsStreaming, projectFor,
     chatPostprocess, chatIsPostprocessing, postprocessingChats, workspacePostprocessingCount, projectPostprocessingCount,
     insightsFailedChats, workspaceInsightsFailedCount,
     archivingChats, isArchiving, archivingChatsList, workspaceArchivingCount, projectArchivingCount,


### PR DESCRIPTION
Three defects around `background_run_start`, found from a `work`-workspace chat whose run died with `[Errno 2] No such file or directory`.

## 1. Runs resolved paths against the install root, not the chat's workspace

`BackgroundRunner` was constructed once with `config.workspace_root` and resolved every run's `cwd` and relative `cmd[0]` against it, ignoring the owning workspace. `control_plane.background_run_start` already computed that workspace, but passed it only for run ownership and `build_env`.

A chat runs with its agent root as cwd, so the relative paths a model writes are relative to `<install>/<workspace>`. On a re-rooted install they missed by exactly one level: `memory-vault/automations/bigquery/runner.py` resolved to `<install>/memory-vault/...` instead of `<install>/work/memory-vault/...`.

The ENOENT was the mild half. Anchoring at the install root also pointed the containment check at the wrong boundary, so a `work` run could read and write `personal/`.

`BackgroundRunner.root_for` now resolves the owning workspace's agent root. A name that resolves to no folder, or to a folder that is not there, raises `workspace_unavailable` rather than falling back — falling back would silently widen the boundary again. The install root remains only where it is honest: a runner built without a resolver, or a run with no owning workspace, both of which are the pre-re-rooting layout.

The tool docstring said `cwd` was "relative to the workspace root", which is what made the model's path predictably wrong; it now says the chat's workspace root and notes that a path that works in Bash works here unchanged.

## 2. Nothing showed that a run was in flight

`background_run_start` is non-blocking by design, so the turn ends while the command runs. Nothing anywhere said so — `active_count` was used only to enforce the per-chat cap, with no API field and no UI (`grep -rn backgroundRun web/src` returned nothing). The model's own prose was the sole trace.

Added `chat_background_runs` on `/ws/events` (published on both edges) plus `background_runs` in the reconnect snapshot — runs are persisted and re-supervised across a restart, so a fresh client has to be told about one that started before it connected. Renders as its own dock pill and feeds the home/project "working" predicates.

Deliberately separate from `chat_subagents_ready`: a background run has no transcript and no agent to open, so a count is all there is to show and the wording stays honest about that.

## 3. Background-Bash steering was incomplete

A foreground Bash command that outlives its timeout is moved to the CLI's *own* background tracking. That happens at tool execution, after `PreToolUse`, so the foreground-rewrite hook cannot intercept it — and its result is frequently never delivered to the chat (it surfaces later as a synthetic "no completion record was found" envelope). Forcing foreground is therefore not on its own enough to keep slow work out of that path; if anything it routes slow commands into it.

The rewrite's `additionalContext` now names `background_run_start` and explains that consequence, so the model has a reason to switch before the timeout rather than after.

## Also in this branch

Dock agent links and the interim-push suppression from the same working tree. The `/code-review` gate found the interim gate was keyed off "a subagent watcher started" — true for every claude *and* opencode chat with a session, and silent about whether a subagent ran. With `_INTERIM_SUBAGENT_PATTERNS` matching `waiting on ...`, an ordinary opencode reply lost its push, unread badge and archive proposal outright, since the opencode watcher has no nudge path to announce in their place. Now gated on the between-turns drain the nudge actually needs, and on the turn not ending in a question.

## Verification

- `pytest tests/` — 3494 passed
- `cd web && npm test` — 1053 passed, 88 files
- `cd web && npm run build` — clean
- `/code-review --fix high` — both findings addressed