### PR TITLE
fix(setup): hand out runnable commands and put `ciao` on PATH

### DIFF
--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -14,8 +14,12 @@ writes a shim at `~/.local/bin/ciao` that forwards to it — that is what makes
 the `ciao ...` commands in this document work in a terminal. Two cases need a
 manual step, and the installer says which one applies:
 
-- `~/.local/bin` is not on your `PATH`: add it
-  (`echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc`).
+- `~/.local/bin` is not on your `PATH`: add it. The setup wizard shows the
+  exact copyable line for your shell; the variants are:
+  - zsh (default): `echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc`
+  - bash (login shells read `~/.bash_profile`, not `~/.bashrc`):
+    `echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bash_profile && source ~/.bash_profile`
+  - fish: `fish_add_path $HOME/.local/bin`.
 - Another `ciao` already exists (the name collides with Ciao Prolog, among
   others): the installer never overwrites it, so call Ciaobot's engine by its
   full path instead.

--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -6,6 +6,23 @@ SDK-level wiring notes (fallback_model, hooks, setting_sources) live in the modu
 
 ## CLI Tools
 
+### The `ciao` command
+
+The installed app keeps the engine inside
+`Ciaobot.app/Contents/Resources/ciao-runtime/bin/ciao`, so the installer also
+writes a shim at `~/.local/bin/ciao` that forwards to it — that is what makes
+the `ciao ...` commands in this document work in a terminal. Two cases need a
+manual step, and the installer says which one applies:
+
+- `~/.local/bin` is not on your `PATH`: add it
+  (`echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc`).
+- Another `ciao` already exists (the name collides with Ciao Prolog, among
+  others): the installer never overwrites it, so call Ciaobot's engine by its
+  full path instead.
+
+Provider logins do not depend on the shim: the setup wizard hands out each
+provider's own login command (`claude auth login`, `opencode auth login`).
+
 ## opencode
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ During setup, choose the folder where Ciaobot should work. It can be a new folde
 
 Ciaobot does not replace the agent CLI or ask you to create a second model account. It runs the CLI you have already authenticated:
 
-- **Anthropic / Claude:** install [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), sign in with your personal or organization-provided Anthropic access, then choose **Claude Code** in Ciaobot. Ciaobot uses that official Claude Code session, adds the relevant workspace and project context, and handles chat archiving, memory extraction, and proposal review around it.
+- **Anthropic / Claude:** install [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) (`curl -fsSL https://claude.ai/install.sh | bash`; it lands in `~/.local/bin`, so add that to your `PATH` if `claude` is not found afterwards), sign in with `claude auth login`, then choose **Claude Code** in Ciaobot. Ciaobot uses that official Claude Code session, adds the relevant workspace and project context, and handles chat archiving, memory extraction, and proposal review around it.
 - **OpenAI, OpenRouter, Ollama, and other providers:** install [opencode](https://opencode.ai/docs/), then configure and authenticate the provider in opencode. Choose **opencode** in Ciaobot; its connected models appear in Ciaobot's model picker. This also includes local models running on your own machine.
 
 Ciaobot keeps provider credentials in the provider's own CLI. It supplies the interface, workspace context, files, projects, scheduling, and second-brain memory around the agent. See [INTEGRATIONS.md](INTEGRATIONS.md) for current installation and authentication commands.

--- a/ciao/cli.py
+++ b/ciao/cli.py
@@ -3290,14 +3290,14 @@ def _desktop_command(args: argparse.Namespace) -> int:
 
     try:
         result = desktop_install.uninstall_desktop_app(app_dir=app_dir)
-        return report(
-            result,
-            [
-                f"Removed {result['path']}"
-                if result["removed"]
-                else f"Nothing to remove at {result['path']}"
-            ],
-        )
+        lines = [
+            f"Removed {result['path']}"
+            if result["removed"]
+            else f"Nothing to remove at {result['path']}"
+        ]
+        if result.get("removed_shim"):
+            lines.append(f"Removed {result['removed_shim']}")
+        return report(result, lines)
     except desktop_install.InstallError as exc:
         if as_json:
             print(json.dumps({"ok": False, "error": str(exc)}, indent=2))

--- a/ciao/desktop_install.py
+++ b/ciao/desktop_install.py
@@ -93,12 +93,39 @@ def _remove_installer_launch_agents(
     return removed
 
 
+# Line the one-line installer writes into ~/.local/bin/ciao so both sides can
+# tell its shim apart from a `ciao` belonging to some other project.
+SHIM_MARKER = "# Ciaobot shim (managed by the Ciaobot installer)"
+
+
+def _remove_installer_shim(*, destination: Path, shim_path: Path | None = None) -> str:
+    """Delete the installer's ``ciao`` shim when it points at this bundle.
+
+    Only a file carrying the installer's marker *and* naming this bundle is
+    touched: an unrelated ``ciao`` in ``~/.local/bin`` belongs to its owner,
+    and a shim naming a different bundle belongs to that install.
+    """
+    shim = shim_path or (Path.home() / ".local" / "bin" / "ciao")
+    try:
+        content = shim.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    if SHIM_MARKER not in content or str(destination) not in content:
+        return ""
+    try:
+        shim.unlink()
+    except OSError:
+        return ""
+    return str(shim)
+
+
 def uninstall_desktop_app(
     *,
     app_dir: Path,
     launch_agents_dir: Path | None = None,
     uid: int | None = None,
     runner: Callable[..., Any] = subprocess.run,
+    shim_path: Path | None = None,
 ) -> dict[str, Any]:
     """Remove a Ciaobot.app bundle without deleting a browser-installed PWA."""
 
@@ -118,12 +145,16 @@ def uninstall_desktop_app(
         uid=uid,
         runner=runner,
     )
+    removed_shim = _remove_installer_shim(destination=destination, shim_path=shim_path)
     try:
         shutil.rmtree(destination)
     except OSError as exc:
         raise InstallError(f"could not remove {destination}: {exc}") from exc
-    return {
+    result: dict[str, Any] = {
         "removed": True,
         "path": str(destination),
         "removed_agents": removed_agents,
     }
+    if removed_shim:
+        result["removed_shim"] = removed_shim
+    return result

--- a/ciao/desktop_install.py
+++ b/ciao/desktop_install.py
@@ -98,6 +98,13 @@ def _remove_installer_launch_agents(
 SHIM_MARKER = "# Ciaobot shim (managed by the Ciaobot installer)"
 
 
+def _collapse_slashes(value: str) -> str:
+    """Collapse duplicate ``/`` so a trailing-slash install dir matches."""
+    while "//" in value:
+        value = value.replace("//", "/")
+    return value
+
+
 def _remove_installer_shim(*, destination: Path, shim_path: Path | None = None) -> str:
     """Delete the installer's ``ciao`` shim when it points at this bundle.
 
@@ -112,8 +119,11 @@ def _remove_installer_shim(*, destination: Path, shim_path: Path | None = None) 
         return ""
     engine = destination / "Contents" / "Resources" / "ciao-runtime" / "bin" / "ciao"
     # The full quoted exec target, not a substring of the path: a bundle
-    # directory can be the prefix of a longer one.
-    if SHIM_MARKER not in content or f'"{engine}"' not in content:
+    # directory can be the prefix of a longer one. Slash-collapsed on both
+    # sides: the installer used to embed ``$app_dir`` verbatim, so
+    # ``CIAO_APP_DIR=~/Applications/`` (trailing slash) wrote a ``//`` the
+    # exact-string match below would miss, orphaning the shim.
+    if SHIM_MARKER not in content or _collapse_slashes(f'"{engine}"') not in _collapse_slashes(content):
         return ""
     try:
         shim.unlink()

--- a/ciao/desktop_install.py
+++ b/ciao/desktop_install.py
@@ -110,7 +110,10 @@ def _remove_installer_shim(*, destination: Path, shim_path: Path | None = None) 
         content = shim.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return ""
-    if SHIM_MARKER not in content or str(destination) not in content:
+    engine = destination / "Contents" / "Resources" / "ciao-runtime" / "bin" / "ciao"
+    # The full quoted exec target, not a substring of the path: a bundle
+    # directory can be the prefix of a longer one.
+    if SHIM_MARKER not in content or f'"{engine}"' not in content:
         return ""
     try:
         shim.unlink()
@@ -145,11 +148,14 @@ def uninstall_desktop_app(
         uid=uid,
         runner=runner,
     )
-    removed_shim = _remove_installer_shim(destination=destination, shim_path=shim_path)
     try:
         shutil.rmtree(destination)
     except OSError as exc:
         raise InstallError(f"could not remove {destination}: {exc}") from exc
+    # Only after the bundle is actually gone: a failed rmtree leaves the app
+    # installed, and deleting the shim first would take away the `ciao`
+    # command while the install it points at is still there.
+    removed_shim = _remove_installer_shim(destination=destination, shim_path=shim_path)
     result: dict[str, Any] = {
         "removed": True,
         "path": str(destination),

--- a/ciao/setup_status.py
+++ b/ciao/setup_status.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import json
@@ -189,6 +190,7 @@ def _provider(
     install_url: str = "",
     app_path: str = "",
     cli_path: str = "",
+    path_command: str = "",
 ) -> dict[str, Any]:
     row: dict[str, Any] = {
         "name": name,
@@ -214,6 +216,8 @@ def _provider(
         row["app_path"] = app_path
     if cli_path:
         row["cli_path"] = cli_path
+    if path_command:
+        row["path_command"] = path_command
     return row
 
 
@@ -637,6 +641,51 @@ def claude_install_command() -> str:
     return "curl -fsSL https://claude.ai/install.sh | bash"
 
 
+def claude_path_command() -> str:
+    """Shell line that puts Claude's install directory on the login PATH.
+
+    The documented installer drops ``claude`` into ``~/.local/bin``, which is
+    not on a default macOS PATH, so the very next command in the user's
+    terminal still reports "command not found". The installer prints this line
+    itself; repeating it here means the wizard can hand it over as a second
+    copyable step instead of leaving the user stuck one command short.
+    """
+    if sys.platform == "win32":
+        return ""
+    # The engine usually runs under launchd, where SHELL is unset; zsh is the
+    # macOS default and the shell the documented installer assumes.
+    shell = os.path.basename(os.environ.get("SHELL", "") or "zsh")
+    rc = "~/.bashrc" if shell == "bash" else "~/.zshrc"
+    return f"""echo 'export PATH="$HOME/.local/bin:$PATH"' >> {rc} && source {rc}"""
+
+
+def claude_auth_command(cli_path: str = "") -> str:
+    """Terminal command that signs the user into Claude Code.
+
+    Deliberately not ``ciao auth claude``: an app install keeps the engine
+    inside ``Ciaobot.app`` and puts nothing named ``ciao`` on PATH, so that
+    command only ever worked from a dev checkout. In a normal install the
+    user's shell either finds nothing or finds an unrelated ``ciao`` and
+    answers with a confusing "Unknown command 'auth'". Claude's own login
+    command works in every install.
+
+    The bare word is only usable when the user's own shell can resolve it.
+    Ciaobot itself usually runs the ``claude`` bundled with the Agent SDK,
+    which is inside the app and on nobody's PATH, so when the login shell has
+    no ``claude`` of its own the binary is named by absolute path instead.
+    """
+    from ciao.tool_path import resolve_tool
+
+    try:
+        on_login_path = resolve_tool("claude")
+    except Exception:
+        on_login_path = None
+    if on_login_path:
+        return "claude auth login"
+    binary = cli_path or claude_cli_path()
+    return f"{shlex.quote(binary)} auth login" if binary else "claude auth login"
+
+
 def claude_app_path() -> str:
     """Path to an installed Claude desktop app, or "".
 
@@ -722,13 +771,14 @@ def _claude_status(
             mcps=claude_mcps,
             install_url=CLAUDE_INSTALL_DOCS_URL,
             app_path=app_path,
+            path_command=claude_path_command(),
         )
     if env.get("ANTHROPIC_API_KEY", "").strip():
         return _provider(
             name="claude",
             ok=True,
             auth="api_key",
-            command="ciao auth claude",
+            command=claude_auth_command(binary),
             detail="ANTHROPIC_API_KEY is set.",
             version=version,
             account="Anthropic API",
@@ -749,7 +799,7 @@ def _claude_status(
             name="claude",
             ok=True,
             auth="oauth",
-            command="ciao auth claude",
+            command=claude_auth_command(binary),
             detail=detail,
             version=version,
             account=account,
@@ -786,9 +836,10 @@ def _claude_status(
             cli_path=binary,
         )
     app_path = claude_app_path()
+    auth_command = claude_auth_command(binary)
     detail = (
-        "Claude Desktop uses an app-private login. Sign in once via `ciao auth claude`; "
-        "no separate CLI install is needed."
+        "Claude Desktop uses an app-private login. Sign in once via "
+        f"`{auth_command}`; no separate CLI install is needed."
         if app_path
         else "Run Claude OAuth or set ANTHROPIC_API_KEY."
     )
@@ -796,7 +847,7 @@ def _claude_status(
         name="claude",
         ok=False,
         auth="missing",
-        command="ciao auth claude",
+        command=auth_command,
         detail=detail,
         version=version,
         skills=claude_skills,

--- a/ciao/setup_status.py
+++ b/ciao/setup_status.py
@@ -996,6 +996,17 @@ def setup_status(
     ``env`` is injectable for tests and lets the API route pass the live
     process environment without exposing secret values in the response.
     """
+    # Fresh terminal-PATH probe per call: the wizard polls this endpoint every
+    # 2s after the user edits their rc file, and a cached miss would keep
+    # showing the PATH hint after the terminal is fixed until engine restart.
+    # Within this call the short TTL still shares one probe across the up to 3
+    # ``resolve_on_terminal_path`` lookups.
+    try:
+        from ciao import tool_path as _tool_path
+
+        _tool_path.clear_terminal_path_cache()
+    except Exception:
+        pass
     source = env if env is not None else os.environ
     # ``Path.cwd()`` cannot be the getattr default: it is evaluated even when the
     # config carries an explicit workspace_root, and it raises once the cwd is gone.

--- a/ciao/setup_status.py
+++ b/ciao/setup_status.py
@@ -641,8 +641,8 @@ def claude_install_command() -> str:
     return "curl -fsSL https://claude.ai/install.sh | bash"
 
 
-def claude_path_command() -> str:
-    """Shell line that puts Claude's install directory on the login PATH.
+def claude_path_command(directory: str = "") -> str:
+    """Shell line that puts ``directory`` on the login PATH.
 
     The documented installer drops ``claude`` into ``~/.local/bin``, which is
     not on a default macOS PATH, so the very next command in the user's
@@ -652,11 +652,50 @@ def claude_path_command() -> str:
     """
     if sys.platform == "win32":
         return ""
+    home = str(Path.home())
+    target = directory or str(Path.home() / ".local" / "bin")
+    if target == home or target.startswith(home + os.sep):
+        # Written into an rc file, so keep it portable across machines and
+        # readable to whoever opens that file later.
+        target = "$HOME" + target[len(home) :]
     # The engine usually runs under launchd, where SHELL is unset; zsh is the
     # macOS default and the shell the documented installer assumes.
     shell = os.path.basename(os.environ.get("SHELL", "") or "zsh")
-    rc = "~/.bashrc" if shell == "bash" else "~/.zshrc"
-    return f"""echo 'export PATH="$HOME/.local/bin:$PATH"' >> {rc} && source {rc}"""
+    if shell == "fish":
+        return f"fish_add_path {target}"
+    # macOS terminals start login shells, which read ~/.bash_profile — not
+    # ~/.bashrc, which would fix only the shell the user is sitting in.
+    rc = "~/.bash_profile" if shell == "bash" else "~/.zshrc"
+    return f"""echo 'export PATH="{target}:$PATH"' >> {rc} && source {rc}"""
+
+
+def claude_path_hint(cli_path: str) -> str:
+    """PATH line worth offering for ``cli_path``, or "" when none is.
+
+    Nothing to fix when the user's terminal already resolves ``claude``, and
+    nothing to suggest when the only binary is the one inside the app: its
+    directory does not belong on anybody's PATH, and ``claude_auth_command``
+    names that binary in full instead.
+    """
+    from ciao.providers.claude import get_bundled_claude_path
+    from ciao.tool_path import resolve_on_terminal_path
+
+    try:
+        if resolve_on_terminal_path("claude"):
+            return ""
+    except Exception:
+        return ""
+    if not cli_path:
+        # Not installed yet: point at where the documented installer puts it.
+        return claude_path_command()
+    try:
+        bundled = get_bundled_claude_path()
+    except Exception:
+        bundled = None
+    if bundled and cli_path == bundled:
+        return ""
+    directory = os.path.dirname(cli_path)
+    return claude_path_command(directory) if directory else ""
 
 
 def claude_auth_command(cli_path: str = "") -> str:
@@ -669,18 +708,22 @@ def claude_auth_command(cli_path: str = "") -> str:
     answers with a confusing "Unknown command 'auth'". Claude's own login
     command works in every install.
 
-    The bare word is only usable when the user's own shell can resolve it.
-    Ciaobot itself usually runs the ``claude`` bundled with the Agent SDK,
-    which is inside the app and on nobody's PATH, so when the login shell has
-    no ``claude`` of its own the binary is named by absolute path instead.
+    The bare word is only usable when the user's own terminal resolves it --
+    which is why this asks ``resolve_on_terminal_path`` rather than the
+    augmented lookup Ciaobot uses to *run* the CLI: that one adds
+    ``~/.local/bin`` and Homebrew whether or not the user's shell has them, so
+    it would answer "yes" for exactly the newly installed CLI whose directory
+    is still missing from PATH. Ciaobot itself usually runs the ``claude``
+    bundled with the Agent SDK, which is inside the app and on nobody's PATH;
+    that binary is named by absolute path instead.
     """
-    from ciao.tool_path import resolve_tool
+    from ciao.tool_path import resolve_on_terminal_path
 
     try:
-        on_login_path = resolve_tool("claude")
+        in_terminal = resolve_on_terminal_path("claude")
     except Exception:
-        on_login_path = None
-    if on_login_path:
+        in_terminal = None
+    if in_terminal:
         return "claude auth login"
     binary = cli_path or claude_cli_path()
     return f"{shlex.quote(binary)} auth login" if binary else "claude auth login"
@@ -771,7 +814,7 @@ def _claude_status(
             mcps=claude_mcps,
             install_url=CLAUDE_INSTALL_DOCS_URL,
             app_path=app_path,
-            path_command=claude_path_command(),
+            path_command=claude_path_hint(""),
         )
     if env.get("ANTHROPIC_API_KEY", "").strip():
         return _provider(
@@ -834,6 +877,7 @@ def _claude_status(
             mcps=claude_mcps,
             install_url=CLAUDE_INSTALL_DOCS_URL,
             cli_path=binary,
+            path_command=claude_path_hint(binary),
         )
     app_path = claude_app_path()
     auth_command = claude_auth_command(binary)
@@ -853,6 +897,9 @@ def _claude_status(
         skills=claude_skills,
         mcps=claude_mcps,
         cli_path=binary,
+        # An installed CLI the terminal cannot find still needs the PATH line:
+        # the user is about to be handed a command to type into that terminal.
+        path_command=claude_path_hint(binary),
     )
 
 

--- a/ciao/tool_path.py
+++ b/ciao/tool_path.py
@@ -45,6 +45,47 @@ def common_tool_dirs() -> list[str]:
 
 
 @functools.lru_cache(maxsize=1)
+def terminal_path() -> str:
+    """PATH the user's own interactive login shell reports, or "".
+
+    Exactly what a command typed in Terminal would be resolved against — no
+    fallback directories, no inherited process PATH. Telling someone to run a
+    bare ``claude`` is only correct when *this* PATH resolves it, so the
+    augmented :func:`login_shell_path` (which appends ``~/.local/bin`` and
+    Homebrew whether or not the user's shell has them) cannot answer that
+    question. Cached for the process lifetime like the augmented form.
+    """
+    shell = os.environ.get("SHELL", "/bin/zsh")
+    # Without PATH the shell builds its own from /etc/profile (path_helper) and
+    # the user's rc files — which is the question being asked. Inheriting ours
+    # would answer it wrongly: the engine prepends common_tool_dirs() to its
+    # own PATH at startup (ciao/main.py), so ~/.local/bin would come back out
+    # of the probe as if the user's terminal had it.
+    env = {k: v for k, v in os.environ.items() if k != "PATH"}
+    try:
+        # -l login, -i interactive so nvm / rbenv / rc-file PATH edits apply.
+        result = subprocess.run(
+            [shell, "-lic", f'printf "{_START}%s{_END}" "$PATH"'],
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+            env=env,
+        )
+        out = result.stdout
+        if _START in out and _END in out:
+            return out.split(_START, 1)[1].split(_END, 1)[0]
+    except Exception:
+        pass
+    return ""
+
+
+def resolve_on_terminal_path(cmd: str) -> str | None:
+    """Absolute path to ``cmd`` as the user's terminal would resolve it, or None."""
+    path = terminal_path()
+    return shutil.which(cmd, path=path) if path else None
+
+
+@functools.lru_cache(maxsize=1)
 def login_shell_path() -> str:
     """PATH as seen by the user's interactive login shell.
 
@@ -54,21 +95,7 @@ def login_shell_path() -> str:
     installed into one of them.
     """
     current = os.environ.get("PATH", "")
-    shell = os.environ.get("SHELL", "/bin/zsh")
-    shell_path = ""
-    try:
-        # -l login, -i interactive so nvm / rbenv / rc-file PATH edits apply.
-        result = subprocess.run(
-            [shell, "-lic", f'printf "{_START}%s{_END}" "$PATH"'],
-            capture_output=True,
-            text=True,
-            timeout=5.0,
-        )
-        out = result.stdout
-        if _START in out and _END in out:
-            shell_path = out.split(_START, 1)[1].split(_END, 1)[0]
-    except Exception:
-        shell_path = ""
+    shell_path = terminal_path()
 
     ordered: list[str] = []
     seen: set[str] = set()

--- a/ciao/tool_path.py
+++ b/ciao/tool_path.py
@@ -19,6 +19,8 @@ import glob
 import os
 import shutil
 import subprocess
+import threading
+import time
 from pathlib import Path
 
 # Markers wrap the printed PATH so noisy shell rc files (which may echo banners
@@ -44,7 +46,28 @@ def common_tool_dirs() -> list[str]:
     return dirs
 
 
-@functools.lru_cache(maxsize=1)
+# The setup wizard polls ``setup_status`` every 2s while telling the user
+# "this check refreshes on its own" after they edit their rc file to add
+# ``~/.local/bin``. A process-lifetime cache would keep serving the pre-edit
+# miss, so the wizard would keep showing the PATH hint after the terminal is
+# fixed until the engine restarts. Keep only a short TTL so repeated
+# ``resolve_on_terminal_path`` calls within one status probe share one shell
+# invocation, while the next poll re-probes. ``setup_status`` additionally
+# clears this cache at the start of each call (see
+# ``clear_terminal_path_cache``) so every wizard poll is fresh even when polls
+# land inside the TTL window.
+_TERMINAL_PATH_TTL_SECONDS = 5.0
+_terminal_path_cache: tuple[float, str] | None = None
+_terminal_path_lock = threading.Lock()
+
+
+def clear_terminal_path_cache() -> None:
+    """Drop the cached login-shell PATH probe (tests and status refresh)."""
+    global _terminal_path_cache
+    with _terminal_path_lock:
+        _terminal_path_cache = None
+
+
 def terminal_path() -> str:
     """PATH the user's own interactive login shell reports, or "".
 
@@ -53,8 +76,17 @@ def terminal_path() -> str:
     bare ``claude`` is only correct when *this* PATH resolves it, so the
     augmented :func:`login_shell_path` (which appends ``~/.local/bin`` and
     Homebrew whether or not the user's shell has them) cannot answer that
-    question. Cached for the process lifetime like the augmented form.
+    question. Cached briefly (see ``_TERMINAL_PATH_TTL_SECONDS``), unlike the
+    process-lifetime :func:`login_shell_path`.
     """
+    global _terminal_path_cache
+    now = time.monotonic()
+    with _terminal_path_lock:
+        if (
+            _terminal_path_cache is not None
+            and now - _terminal_path_cache[0] < _TERMINAL_PATH_TTL_SECONDS
+        ):
+            return _terminal_path_cache[1]
     shell = os.environ.get("SHELL", "/bin/zsh")
     # Without PATH the shell builds its own from /etc/profile (path_helper) and
     # the user's rc files — which is the question being asked. Inheriting ours
@@ -62,6 +94,7 @@ def terminal_path() -> str:
     # own PATH at startup (ciao/main.py), so ~/.local/bin would come back out
     # of the probe as if the user's terminal had it.
     env = {k: v for k, v in os.environ.items() if k != "PATH"}
+    value = ""
     try:
         # -l login, -i interactive so nvm / rbenv / rc-file PATH edits apply.
         result = subprocess.run(
@@ -73,10 +106,16 @@ def terminal_path() -> str:
         )
         out = result.stdout
         if _START in out and _END in out:
-            return out.split(_START, 1)[1].split(_END, 1)[0]
+            value = out.split(_START, 1)[1].split(_END, 1)[0]
     except Exception:
         pass
-    return ""
+    with _terminal_path_lock:
+        _terminal_path_cache = (time.monotonic(), value)
+    return value
+
+
+# Back-compat for callers/tests that clear the old lru_cache.
+terminal_path.cache_clear = clear_terminal_path_cache  # type: ignore[attr-defined]
 
 
 def resolve_on_terminal_path(cmd: str) -> str | None:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -525,8 +525,21 @@ if [ "$shim_installed" -eq 1 ]; then
             fi
             ;;
         *)
+            # macOS terminals start login shells: bash reads ~/.bash_profile,
+            # not ~/.bashrc, so naming the wrong file fixes only this shell.
             echo "Add ~/.local/bin to your PATH to use the 'ciao' command:"
-            echo "  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.zshrc && source ~/.zshrc"
+            case "${SHELL:-/bin/zsh}" in
+                */fish)
+                    echo "  fish_add_path \$HOME/.local/bin"
+                    ;;
+                *)
+                    case "${SHELL:-/bin/zsh}" in
+                        */bash) rc=~/.bash_profile ;;
+                        *) rc=~/.zshrc ;;
+                    esac
+                    echo "  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> $rc && source $rc"
+                    ;;
+            esac
             ;;
     esac
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -365,6 +365,40 @@ stage=
 installer_done
 
 engine="$destination/Contents/Resources/ciao-runtime/bin/ciao"
+
+# The engine lives inside the app bundle, so a terminal has no `ciao` at all
+# unless the install puts one there -- yet the docs, the setup wizard and every
+# support answer hand out bare `ciao ...` commands. Users who had an unrelated
+# `ciao` on PATH got its error message instead ("Unknown command 'auth'"), and
+# users who had none got "command not found".
+#
+# A shim, not a symlink: the bundled launcher derives its runtime root from
+# `dirname "$0"`, which through a symlink resolves to the link's directory and
+# breaks. Never overwrite a `ciao` we did not write -- it may be someone's own
+# tool -- so the marker line is what makes replacement safe on updates.
+shim_dir="$HOME/.local/bin"
+shim="$shim_dir/ciao"
+shim_marker="# Ciaobot shim (managed by the Ciaobot installer)"
+shim_installed=0
+if { [ -e "$shim" ] || [ -L "$shim" ]; } && ! grep -qF "$shim_marker" "$shim" 2>/dev/null; then
+    echo "Ciaobot installer: $shim exists and was not created by Ciaobot; leaving it alone" >&2
+    echo "Ciaobot installer: run the CLI as $engine" >&2
+elif mkdir -p "$shim_dir" 2>/dev/null; then
+    shim_tmp="$shim.tmp.$$"
+    if {
+        printf '%s\n' '#!/bin/sh'
+        printf '%s\n' "$shim_marker"
+        printf 'exec "%s" "$@"\n' "$engine"
+    } > "$shim_tmp" 2>/dev/null && chmod 755 "$shim_tmp" && mv "$shim_tmp" "$shim"; then
+        shim_installed=1
+    else
+        rm -f "$shim_tmp"
+        echo "Ciaobot installer: could not create $shim" >&2
+    fi
+else
+    echo "Ciaobot installer: could not create $shim_dir" >&2
+fi
+
 plist="$HOME/Library/LaunchAgents/com.ciao.server.plist"
 desktop_plist="$HOME/Library/LaunchAgents/Ciaobot.plist"
 workspace=
@@ -476,4 +510,23 @@ if [ -n "$workspace" ]; then
     echo "Workspace: $workspace"
 else
     echo "Workspace: first-run onboarding will ask where to create or adopt one"
+fi
+if [ "$shim_installed" -eq 1 ]; then
+    # Installing the shim is not enough on its own: ~/.local/bin is not on a
+    # default macOS PATH, and when it is, an unrelated `ciao` earlier in the
+    # PATH still wins. Say which of the two happened instead of leaving the
+    # user to discover it through a confusing error.
+    case ":${PATH:-}:" in
+        *":$shim_dir:"*)
+            resolved=$(command -v ciao || true)
+            if [ -n "$resolved" ] && [ "$resolved" != "$shim" ]; then
+                echo "Note: another 'ciao' comes first on your PATH ($resolved)."
+                echo "      Run Ciaobot's CLI as $shim"
+            fi
+            ;;
+        *)
+            echo "Add ~/.local/bin to your PATH to use the 'ciao' command:"
+            echo "  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.zshrc && source ~/.zshrc"
+            ;;
+    esac
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -120,6 +120,12 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 
+# Normalize for the shim identity check: a trailing slash would otherwise be
+# embedded verbatim (".../Applications//Ciaobot.app/...") while uninstall
+# computes the single-slash form and misses, orphaning the shim.
+app_dir=${app_dir%/}
+[ -n "$app_dir" ] || app_dir="/"
+
 for command in curl tar shasum mktemp mkdir mv find sw_vers awk uname id launchctl pgrep sed grep sysctl; do
     command -v "$command" >/dev/null 2>&1 || fail "required command not found: $command"
 done

--- a/tests/test_desktop_install.py
+++ b/tests/test_desktop_install.py
@@ -122,3 +122,45 @@ def test_uninstall_leaves_a_ciao_it_did_not_install_alone(tmp_path: Path) -> Non
         app_dir=tmp_path, shim_path=other_shim
     )
     assert other_shim.exists()
+
+
+def test_uninstall_keeps_the_shim_when_the_bundle_could_not_be_removed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed rmtree leaves the app installed, so removing the shim first
+    would take away the `ciao` command while what it points at still runs."""
+    bundle = _native_bundle(tmp_path)
+    shim = tmp_path / "bin" / "ciao"
+    shim.parent.mkdir()
+    shim.write_text(
+        f'#!/bin/sh\n{desktop_install.SHIM_MARKER}\nexec "{bundle}/Contents/Resources/ciao-runtime/bin/ciao" "$@"\n',
+        encoding="utf-8",
+    )
+
+    def boom(path):
+        raise OSError("Operation not permitted")
+
+    monkeypatch.setattr(desktop_install.shutil, "rmtree", boom)
+
+    with pytest.raises(desktop_install.InstallError, match="could not remove"):
+        desktop_install.uninstall_desktop_app(app_dir=tmp_path, shim_path=shim)
+
+    assert shim.exists()
+
+
+def test_uninstall_leaves_a_shim_for_a_prefix_named_bundle_alone(tmp_path: Path) -> None:
+    """`str(destination) in content` would also match a longer path that
+    merely starts with this bundle's path."""
+    _native_bundle(tmp_path)
+    other = tmp_path / f"{desktop_install.APP_BUNDLE_NAME}.previous"
+    shim = tmp_path / "bin" / "ciao"
+    shim.parent.mkdir()
+    shim.write_text(
+        f'#!/bin/sh\n{desktop_install.SHIM_MARKER}\nexec "{other}/Contents/Resources/ciao-runtime/bin/ciao" "$@"\n',
+        encoding="utf-8",
+    )
+
+    result = desktop_install.uninstall_desktop_app(app_dir=tmp_path, shim_path=shim)
+
+    assert "removed_shim" not in result
+    assert shim.exists()

--- a/tests/test_desktop_install.py
+++ b/tests/test_desktop_install.py
@@ -79,3 +79,46 @@ def test_uninstall_reports_an_empty_directory(tmp_path: Path) -> None:
         "removed": False,
         "path": str(tmp_path / desktop_install.APP_BUNDLE_NAME),
     }
+
+
+def test_uninstall_removes_the_installers_ciao_shim(tmp_path: Path) -> None:
+    """The installer puts a `ciao` shim in ~/.local/bin so terminals have the
+    command; leaving it behind would point at a bundle that no longer exists."""
+    bundle = _native_bundle(tmp_path)
+    shim = tmp_path / "bin" / "ciao"
+    shim.parent.mkdir()
+    shim.write_text(
+        f'#!/bin/sh\n{desktop_install.SHIM_MARKER}\nexec "{bundle}/Contents/Resources/ciao-runtime/bin/ciao" "$@"\n',
+        encoding="utf-8",
+    )
+
+    result = desktop_install.uninstall_desktop_app(app_dir=tmp_path, shim_path=shim)
+
+    assert result["removed_shim"] == str(shim)
+    assert not shim.exists()
+
+
+def test_uninstall_leaves_a_ciao_it_did_not_install_alone(tmp_path: Path) -> None:
+    """`ciao` collides with other projects (Ciao Prolog ships one), and a shim
+    naming a different bundle belongs to that install, not this uninstall."""
+    _native_bundle(tmp_path)
+    foreign = tmp_path / "bin" / "ciao"
+    foreign.parent.mkdir()
+    foreign.write_text("#!/bin/sh\necho other project\n", encoding="utf-8")
+    other_bundle = tmp_path / "elsewhere" / desktop_install.APP_BUNDLE_NAME
+    other_shim = tmp_path / "bin" / "ciao-other"
+    other_shim.write_text(
+        f'#!/bin/sh\n{desktop_install.SHIM_MARKER}\nexec "{other_bundle}/x" "$@"\n',
+        encoding="utf-8",
+    )
+
+    assert "removed_shim" not in desktop_install.uninstall_desktop_app(
+        app_dir=tmp_path, shim_path=foreign
+    )
+    assert foreign.exists()
+
+    _native_bundle(tmp_path)
+    assert "removed_shim" not in desktop_install.uninstall_desktop_app(
+        app_dir=tmp_path, shim_path=other_shim
+    )
+    assert other_shim.exists()

--- a/tests/test_one_line_installer.py
+++ b/tests/test_one_line_installer.py
@@ -314,3 +314,82 @@ def test_installer_verifier_is_outside_the_tauri_package() -> None:
     assert (verifier / "Cargo.toml").is_file()
     assert (verifier / "src" / "main.rs").is_file()
     assert not (tauri_bins / "ciaobot-installer-verify.rs").exists()
+
+
+def _shim_block() -> str:
+    """The installer's ``ciao`` shim logic, runnable on its own.
+
+    The surrounding script downloads and verifies a signed release, so the
+    block is exercised in isolation with ``engine`` supplied by the caller.
+    """
+    script = (REPO_ROOT / "scripts" / "install.sh").read_text(encoding="utf-8")
+    start = script.index('shim_dir="$HOME/.local/bin"')
+    end = script.index('\nplist="$HOME/Library/LaunchAgents', start)
+    return script[start:end]
+
+
+def _run_shim_block(home: Path, engine: Path) -> subprocess.CompletedProcess[str]:
+    program = f'engine="{engine}"\n' + _shim_block() + '\necho "shim_installed=$shim_installed"\n'
+    return subprocess.run(
+        ["sh", "-c", program],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "HOME": str(home)},
+        check=False,
+    )
+
+
+def test_installer_puts_ciao_on_path_as_a_shim_not_a_symlink(tmp_path: Path) -> None:
+    """The engine lives inside Ciaobot.app, so without this a terminal has no
+    `ciao` at all and every documented `ciao ...` command fails -- with
+    "command not found", or with an unrelated `ciao`'s error message.
+
+    A symlink would not do: the bundled launcher derives its runtime root from
+    `dirname "$0"`, which resolves to the link's own directory.
+    """
+    engine = tmp_path / "Ciaobot.app" / "Contents" / "Resources" / "ciao-runtime" / "bin" / "ciao"
+    engine.parent.mkdir(parents=True)
+    engine.write_text('#!/bin/sh\necho "engine ran: $*"\n', encoding="utf-8")
+    engine.chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+
+    result = _run_shim_block(home, engine)
+    assert result.returncode == 0, result.stderr
+    assert "shim_installed=1" in result.stdout
+
+    shim = home / ".local" / "bin" / "ciao"
+    assert shim.is_file() and not shim.is_symlink()
+    assert os.access(shim, os.X_OK)
+    forwarded = subprocess.run(
+        [str(shim), "auth", "claude"], capture_output=True, text=True, check=False
+    )
+    assert forwarded.stdout.strip() == "engine ran: auth claude"
+
+
+def test_installer_replaces_its_own_shim_but_not_a_foreign_ciao(tmp_path: Path) -> None:
+    """`ciao` is a common enough name to collide (Ciao Prolog ships one), and
+    clobbering someone else's binary is not the installer's call. Its own
+    marker is what makes replacement on update safe."""
+    engine = tmp_path / "Ciaobot.app" / "Contents" / "Resources" / "ciao-runtime" / "bin" / "ciao"
+    engine.parent.mkdir(parents=True)
+    engine.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    engine.chmod(0o755)
+    home = tmp_path / "home"
+    bin_dir = home / ".local" / "bin"
+    bin_dir.mkdir(parents=True)
+    foreign = bin_dir / "ciao"
+    foreign.write_text("#!/bin/sh\necho other project\n", encoding="utf-8")
+
+    result = _run_shim_block(home, engine)
+    assert result.returncode == 0, result.stderr
+    assert "shim_installed=0" in result.stdout
+    assert foreign.read_text(encoding="utf-8") == "#!/bin/sh\necho other project\n"
+    assert "leaving it alone" in result.stderr
+
+    # A shim the installer wrote itself is replaced, so updates re-point it at
+    # the new bundle instead of failing shut.
+    foreign.unlink()
+    assert "shim_installed=1" in _run_shim_block(home, engine).stdout
+    assert "shim_installed=1" in _run_shim_block(home, engine).stdout
+    assert str(engine) in (bin_dir / "ciao").read_text(encoding="utf-8")

--- a/tests/test_setup_status.py
+++ b/tests/test_setup_status.py
@@ -406,6 +406,7 @@ def test_setup_status_reports_a_missing_claude_cli_as_an_install_step(
     """
     monkeypatch.setattr("ciao.setup_status.claude_cli_path", lambda: "")
     monkeypatch.setattr("ciao.setup_status.claude_app_path", lambda: "")
+    monkeypatch.setattr("ciao.tool_path.resolve_on_terminal_path", lambda cmd: None)
     config = _config(tmp_path)
 
     claude = setup_status(config, env={"ANTHROPIC_API_KEY": "sk-anthropic"})["providers"]["claude"]
@@ -448,7 +449,9 @@ def test_setup_status_offers_claudes_own_login_not_ciao_auth(tmp_path, monkeypat
     Ciaobot.app), so a wizard that told users to run `ciao auth claude` sent
     them to a command their shell could not resolve -- or, when some unrelated
     `ciao` was installed, to its "Unknown command 'auth'" error."""
-    monkeypatch.setattr("ciao.tool_path.resolve_tool", lambda cmd: "/usr/local/bin/claude")
+    monkeypatch.setattr(
+        "ciao.tool_path.resolve_on_terminal_path", lambda cmd: "/usr/local/bin/claude"
+    )
     config = _config(tmp_path)
 
     claude = setup_status(config, env={})["providers"]["claude"]
@@ -462,12 +465,70 @@ def test_setup_status_names_a_bundled_claude_by_path(tmp_path, monkeypatch) -> N
     `claude auth login` would fail for them too."""
     bundled = "/opt/sdk/claude_agent_sdk/_bundled/claude"
     monkeypatch.setattr("ciao.setup_status.claude_cli_path", lambda: bundled)
-    monkeypatch.setattr("ciao.tool_path.resolve_tool", lambda cmd: None)
+    monkeypatch.setattr("ciao.tool_path.resolve_on_terminal_path", lambda cmd: None)
     config = _config(tmp_path)
 
     claude = setup_status(config, env={})["providers"]["claude"]
 
     assert claude["command"] == f"{bundled} auth login"
+
+
+def test_setup_status_offers_the_path_line_for_a_cli_the_terminal_cannot_find(
+    tmp_path, monkeypatch
+) -> None:
+    """The install step is not the only moment the PATH line is needed: once
+    `claude` exists in ~/.local/bin but the user's PATH still omits it, they
+    are about to be handed a command to type into that same terminal."""
+    monkeypatch.setattr(
+        "ciao.setup_status.claude_cli_path",
+        lambda: str(Path.home() / ".local" / "bin" / "claude"),
+    )
+    monkeypatch.setattr("ciao.tool_path.resolve_on_terminal_path", lambda cmd: None)
+    config = _config(tmp_path)
+
+    claude = setup_status(config, env={})["providers"]["claude"]
+
+    assert claude["path_command"].startswith("echo 'export PATH=\"$HOME/.local/bin")
+
+
+def test_setup_status_offers_no_path_line_for_the_bundled_cli(tmp_path, monkeypatch) -> None:
+    """The CLI inside the app is not something to add to a user's PATH -- the
+    login command names it in full instead."""
+    bundled = "/opt/sdk/claude_agent_sdk/_bundled/claude"
+    monkeypatch.setattr("ciao.setup_status.claude_cli_path", lambda: bundled)
+    monkeypatch.setattr("ciao.providers.claude.get_bundled_claude_path", lambda: bundled)
+    monkeypatch.setattr("ciao.tool_path.resolve_on_terminal_path", lambda cmd: None)
+    config = _config(tmp_path)
+
+    claude = setup_status(config, env={})["providers"]["claude"]
+
+    assert "path_command" not in claude
+
+
+def test_setup_status_offers_no_path_line_when_the_terminal_finds_claude(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "ciao.tool_path.resolve_on_terminal_path", lambda cmd: "/usr/local/bin/claude"
+    )
+    config = _config(tmp_path)
+
+    claude = setup_status(config, env={})["providers"]["claude"]
+
+    assert "path_command" not in claude
+
+
+def test_claude_path_command_names_the_file_a_login_shell_reads(monkeypatch) -> None:
+    """macOS terminals start login shells: bash reads ~/.bash_profile, and
+    ~/.bashrc would fix only the shell the user is sitting in."""
+    from ciao.setup_status import claude_path_command
+
+    monkeypatch.setenv("SHELL", "/bin/bash")
+    assert claude_path_command().endswith(">> ~/.bash_profile && source ~/.bash_profile")
+    monkeypatch.setenv("SHELL", "/opt/homebrew/bin/fish")
+    assert claude_path_command() == "fish_add_path $HOME/.local/bin"
+    monkeypatch.delenv("SHELL")
+    assert "~/.zshrc" in claude_path_command()
 
 
 def test_setup_status_route_is_public_before_login(tmp_path) -> None:

--- a/tests/test_setup_status.py
+++ b/tests/test_setup_status.py
@@ -389,7 +389,10 @@ def test_setup_status_explains_desktop_login_is_app_private(tmp_path, monkeypatc
     claude = setup_status(config, env={})["providers"]["claude"]
     assert claude["ok"] is False
     assert "app-private" in claude["detail"]
-    assert "ciao auth claude" in claude["detail"]
+    # `ciao auth claude` only exists on a dev checkout: an app install puts no
+    # `ciao` on PATH, so the wizard must hand out Claude's own login command.
+    assert "claude auth login" in claude["detail"]
+    assert "ciao auth" not in claude["detail"]
     assert "no separate CLI install" in claude["detail"]
 
 
@@ -412,6 +415,9 @@ def test_setup_status_reports_a_missing_claude_cli_as_an_install_step(
     assert claude["install_url"].startswith("https://code.claude.com/docs/")
     assert "install" in claude["command"]
     assert "not installed" in claude["detail"]
+    # The installer drops `claude` into ~/.local/bin, which a default macOS
+    # PATH omits, so the wizard offers the PATH line as a second step.
+    assert "$HOME/.local/bin" in claude["path_command"]
 
 
 def test_setup_status_names_the_desktop_app_when_only_the_cli_is_missing(
@@ -435,6 +441,33 @@ def test_setup_status_reports_the_resolved_cli_path(tmp_path) -> None:
     claude = setup_status(config, env={"ANTHROPIC_API_KEY": "sk-anthropic"})["providers"]["claude"]
 
     assert claude["cli_path"] == "/usr/local/bin/claude"
+
+
+def test_setup_status_offers_claudes_own_login_not_ciao_auth(tmp_path, monkeypatch) -> None:
+    """`ciao` is not on PATH in an app install (the engine lives inside
+    Ciaobot.app), so a wizard that told users to run `ciao auth claude` sent
+    them to a command their shell could not resolve -- or, when some unrelated
+    `ciao` was installed, to its "Unknown command 'auth'" error."""
+    monkeypatch.setattr("ciao.tool_path.resolve_tool", lambda cmd: "/usr/local/bin/claude")
+    config = _config(tmp_path)
+
+    claude = setup_status(config, env={})["providers"]["claude"]
+
+    assert claude["command"] == "claude auth login"
+
+
+def test_setup_status_names_a_bundled_claude_by_path(tmp_path, monkeypatch) -> None:
+    """Ciaobot normally runs the `claude` bundled with the Agent SDK, which is
+    on nobody's PATH: when the user's own shell has no `claude`, a bare
+    `claude auth login` would fail for them too."""
+    bundled = "/opt/sdk/claude_agent_sdk/_bundled/claude"
+    monkeypatch.setattr("ciao.setup_status.claude_cli_path", lambda: bundled)
+    monkeypatch.setattr("ciao.tool_path.resolve_tool", lambda cmd: None)
+    config = _config(tmp_path)
+
+    claude = setup_status(config, env={})["providers"]["claude"]
+
+    assert claude["command"] == f"{bundled} auth login"
 
 
 def test_setup_status_route_is_public_before_login(tmp_path) -> None:

--- a/tests/test_tool_path.py
+++ b/tests/test_tool_path.py
@@ -7,7 +7,11 @@ from ciao import tool_path
 
 
 def _clear_cache():
-    tool_path.login_shell_path.cache_clear()
+    # Tolerant of monkeypatched replacements, which carry no cache.
+    for name in ("login_shell_path", "terminal_path"):
+        clear = getattr(getattr(tool_path, name), "cache_clear", None)
+        if clear is not None:
+            clear()
 
 
 def test_resolve_tool_finds_binary_on_login_shell_path(tmp_path, monkeypatch):
@@ -57,4 +61,61 @@ def test_login_shell_path_survives_shell_probe_failure(monkeypatch):
     monkeypatch.setenv("PATH", "/usr/bin")
     result = tool_path.login_shell_path()
     assert "/usr/bin" in result.split(os.pathsep)
+    _clear_cache()
+
+
+def test_terminal_path_does_not_inherit_our_own_path(tmp_path, monkeypatch):
+    """The engine prepends common_tool_dirs() to its own PATH at startup
+    (ciao/main.py). Handing that to the probe would make ~/.local/bin come
+    back as if the user's terminal had it, and setup would then tell them to
+    type a bare command their shell cannot resolve."""
+    _clear_cache()
+    captured: dict[str, object] = {}
+
+    class _Result:
+        returncode = 0
+        stdout = f"{tool_path._START}/usr/bin{tool_path._END}"
+        stderr = ""
+
+    def fake_run(*args, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return _Result()
+
+    monkeypatch.setattr(tool_path.subprocess, "run", fake_run)
+    monkeypatch.setenv("PATH", str(tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    assert tool_path.terminal_path() == "/usr/bin"
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert "PATH" not in env
+    # Everything else the rc files may need is still there.
+    assert env["HOME"] == str(tmp_path)
+    _clear_cache()
+
+
+def test_resolve_on_terminal_path_ignores_the_fallback_dirs(tmp_path, monkeypatch):
+    """`resolve_tool` searches ~/.local/bin and Homebrew whether or not the
+    user's shell has them; the terminal-only lookup must not."""
+    _clear_cache()
+    fallback = tmp_path / "local-bin"
+    fallback.mkdir()
+    fake = fallback / "claude"
+    fake.write_text("#!/bin/sh\n", encoding="utf-8")
+    fake.chmod(fake.stat().st_mode | stat.S_IEXEC)
+
+    monkeypatch.setattr(tool_path, "common_tool_dirs", lambda: [str(fallback)])
+    monkeypatch.setattr(tool_path, "terminal_path", lambda: "/usr/bin:/bin")
+    # Keep the host's own PATH (which may hold a real `claude`) out of it.
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+    assert tool_path.resolve_on_terminal_path("claude") is None
+    assert tool_path.resolve_tool("claude") == str(fake)
+    _clear_cache()
+
+
+def test_resolve_on_terminal_path_returns_none_when_the_probe_fails(monkeypatch):
+    _clear_cache()
+    monkeypatch.setattr(tool_path, "terminal_path", lambda: "")
+    assert tool_path.resolve_on_terminal_path("sh") is None
     _clear_cache()

--- a/web/src/components/LoginView.vue
+++ b/web/src/components/LoginView.vue
@@ -201,9 +201,27 @@
                 :disabled="loading"
                 @click="copyCommand(setupStatus.providers[provider].command || '')"
               >
-                {{ copyStatus || 'Copy' }}
+                {{ copyLabel(setupStatus.providers[provider].command || '') }}
               </button>
             </div>
+            <!-- The CLI installer drops `claude` in ~/.local/bin, which a
+                 default macOS PATH does not include, so the very next command
+                 still fails with "command not found". Offer the PATH line as a
+                 second copyable step rather than as prose nobody can run. -->
+            <template v-if="setupStatus.providers[provider].path_command">
+              <p class="hint">Then make it findable in new terminals:</p>
+              <div class="command-row">
+                <code>{{ setupStatus.providers[provider].path_command }}</code>
+                <button
+                  class="btn-small"
+                  type="button"
+                  :disabled="loading"
+                  @click="copyCommand(setupStatus.providers[provider].path_command || '')"
+                >
+                  {{ copyLabel(setupStatus.providers[provider].path_command || '') }}
+                </button>
+              </div>
+            </template>
             <p v-if="setupStatus.providers[provider].install_url" class="hint">
               Other ways to install (Homebrew, WinGet, Linux packages):
               <a
@@ -503,6 +521,9 @@ const passwordReady = computed(
 const isRestarting = ref(false)
 const workspaceName = ref('personal')
 const copyStatus = ref('')
+// Which command the status belongs to: the install step can show two copy
+// buttons, and a shared status would report "Copied!" on both.
+const copiedCommand = ref('')
 const advancedOpen = ref(false)
 
 // Folder inspection: when the chosen workspace folder already contains
@@ -711,8 +732,16 @@ const canFinish = computed(() => {
 
 async function copyCommand(text: string) {
   const copied = await writeClipboard(text)
+  copiedCommand.value = text
   copyStatus.value = copied ? 'Copied!' : 'Failed'
-  setTimeout(() => { copyStatus.value = '' }, 2000)
+  setTimeout(() => {
+    copyStatus.value = ''
+    copiedCommand.value = ''
+  }, 2000)
+}
+
+function copyLabel(text: string) {
+  return copyStatus.value && copiedCommand.value === text ? copyStatus.value : 'Copy'
 }
 
 async function doFinish() {

--- a/web/src/components/LoginView.vue
+++ b/web/src/components/LoginView.vue
@@ -524,6 +524,7 @@ const copyStatus = ref('')
 // Which command the status belongs to: the install step can show two copy
 // buttons, and a shared status would report "Copied!" on both.
 const copiedCommand = ref('')
+let copyTimer: ReturnType<typeof setTimeout> | null = null
 const advancedOpen = ref(false)
 
 // Folder inspection: when the chosen workspace folder already contains
@@ -681,7 +682,7 @@ const providerInstruction = computed(() => {
       : 'Not installed yet. Run this in your Terminal to install it:'
   }
   if (provider.value === 'opencode' && setupStatus.value?.providers?.opencode?.auth === 'missing') {
-    return 'Install opencode if needed, then run `ciao auth opencode` and refresh this check:'
+    return 'Install opencode if needed, then run this in your Terminal and refresh this check:'
   }
   return 'To authorize, run this command in your Terminal:'
 })
@@ -734,9 +735,13 @@ async function copyCommand(text: string) {
   const copied = await writeClipboard(text)
   copiedCommand.value = text
   copyStatus.value = copied ? 'Copied!' : 'Failed'
-  setTimeout(() => {
+  // One timer, re-armed: an earlier button's pending revert would otherwise
+  // clear the status of the button just pressed.
+  if (copyTimer !== null) clearTimeout(copyTimer)
+  copyTimer = setTimeout(() => {
     copyStatus.value = ''
     copiedCommand.value = ''
+    copyTimer = null
   }, 2000)
 }
 
@@ -837,6 +842,10 @@ onUnmounted(() => {
   if (pollInterval) {
     clearInterval(pollInterval)
     pollInterval = null
+  }
+  if (copyTimer !== null) {
+    clearTimeout(copyTimer)
+    copyTimer = null
   }
 })
 </script>

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -700,6 +700,13 @@
                         rel="noopener noreferrer"
                       >installation guide ↗</a>
                     </p>
+                    <p
+                      v-if="conn.auth !== 'not_installed' && conn.path_command"
+                      class="hint hint--compact"
+                    >
+                      Your terminal cannot find this CLI yet — put it on your PATH with
+                      <code>{{ conn.path_command }}</code>
+                    </p>
                   </div>
                   <span class="badge" :class="conn.ok ? 'badge--success' : 'badge--error'">
                     {{ conn.ok ? `Connected · ${conn.auth}` : 'Not connected' }}

--- a/web/src/components/SettingsView.vue
+++ b/web/src/components/SettingsView.vue
@@ -689,6 +689,10 @@
                     <p v-if="conn.auth === 'not_installed'" class="hint hint--compact">
                       {{ conn.detail }}
                       Install it with <code>{{ conn.command }}</code>
+                      <template v-if="conn.path_command">
+                        , then put it on your PATH with
+                        <code>{{ conn.path_command }}</code>
+                      </template>
                       <a
                         v-if="conn.install_url"
                         :href="conn.install_url"

--- a/web/src/components/__tests__/LoginView.test.ts
+++ b/web/src/components/__tests__/LoginView.test.ts
@@ -88,7 +88,7 @@ describe('LoginView setup wizard tests', () => {
           name: 'claude',
           ok: false,
           auth: 'missing',
-          command: 'ciao auth claude',
+          command: 'claude auth login',
           detail: 'Run OAuth'
         }
       }
@@ -106,7 +106,7 @@ describe('LoginView setup wizard tests', () => {
     // No notification-email field: Web Push works out of the box with a
     // default VAPID subject, so setup never asks for a contact.
     expect(wrapper.find('#setup-push').exists()).toBe(false)
-    expect(wrapper.text()).toContain('ciao auth claude')
+    expect(wrapper.text()).toContain('claude auth login')
     expect(wrapper.text()).toContain('Keep the terminal running ciao run open while you finish this setup')
     expect(wrapper.text()).toContain('close the terminal and open Ciaobot Server.app')
 
@@ -208,7 +208,7 @@ describe('LoginView setup wizard tests', () => {
         bootstrap: true,
         mode: 'bootstrap',
         providers: {
-          claude: { name: 'claude', ok: true, auth: 'oauth', command: 'ciao auth claude', detail: 'Ready' }
+          claude: { name: 'claude', ok: true, auth: 'oauth', command: 'claude auth login', detail: 'Ready' }
         }
       })
     })
@@ -335,6 +335,7 @@ describe('LoginView setup wizard tests', () => {
           command: 'curl -fsSL https://claude.ai/install.sh | bash',
           detail: 'Claude Code is not installed on this machine.',
           install_url: 'https://code.claude.com/docs/en/quickstart#step-1-install-claude-code',
+          path_command: 'echo \'export PATH="$HOME/.local/bin:$PATH"\' >> ~/.zshrc && source ~/.zshrc',
         },
       },
     })
@@ -348,6 +349,91 @@ describe('LoginView setup wizard tests', () => {
     expect(link.attributes('href')).toBe(
       'https://code.claude.com/docs/en/quickstart#step-1-install-claude-code',
     )
+  })
+
+  it('offers the PATH line as a second copyable step after the install', async () => {
+    // Claude's installer drops the binary in ~/.local/bin, which a default
+    // macOS PATH omits: without this step the next command a new user runs
+    // still reports "command not found".
+    mockApiGet.mockResolvedValue({
+      configured: false,
+      bootstrap: true,
+      mode: 'bootstrap',
+      providers: {
+        claude: {
+          name: 'claude',
+          ok: false,
+          auth: 'not_installed',
+          command: 'curl -fsSL https://claude.ai/install.sh | bash',
+          detail: 'Claude Code is not installed on this machine.',
+          path_command: 'echo \'export PATH="$HOME/.local/bin:$PATH"\' >> ~/.zshrc && source ~/.zshrc',
+        },
+      },
+    })
+
+    const wrapper = await mountLoginView()
+
+    const rows = wrapper.findAll('.command-row')
+    expect(rows).toHaveLength(2)
+    expect(rows[1].text()).toContain('export PATH="$HOME/.local/bin:$PATH"')
+    expect(wrapper.text()).toContain('Then make it findable in new terminals:')
+  })
+
+  it('flashes Copied! on the button that was pressed, not on both', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+    mockApiGet.mockResolvedValue({
+      configured: false,
+      bootstrap: true,
+      mode: 'bootstrap',
+      providers: {
+        claude: {
+          name: 'claude',
+          ok: false,
+          auth: 'not_installed',
+          command: 'curl -fsSL https://claude.ai/install.sh | bash',
+          detail: 'Claude Code is not installed on this machine.',
+          path_command: 'echo \'export PATH="$HOME/.local/bin:$PATH"\' >> ~/.zshrc && source ~/.zshrc',
+        },
+      },
+    })
+
+    const wrapper = await mountLoginView()
+    const buttons = wrapper.findAll('.command-row button')
+    await buttons[1].trigger('click')
+    await flushPromises()
+
+    expect(writeText).toHaveBeenCalledWith(
+      'echo \'export PATH="$HOME/.local/bin:$PATH"\' >> ~/.zshrc && source ~/.zshrc',
+    )
+    expect(wrapper.findAll('.command-row button')[0].text()).toBe('Copy')
+    expect(wrapper.findAll('.command-row button')[1].text()).toBe('Copied!')
+  })
+
+  it('shows no PATH step when the provider CLI is already installed', async () => {
+    mockApiGet.mockResolvedValue({
+      configured: false,
+      bootstrap: true,
+      mode: 'bootstrap',
+      providers: {
+        claude: {
+          name: 'claude',
+          ok: false,
+          auth: 'missing',
+          command: 'claude auth login',
+          detail: 'Run Claude OAuth or set ANTHROPIC_API_KEY.',
+        },
+      },
+    })
+
+    const wrapper = await mountLoginView()
+
+    expect(wrapper.findAll('.command-row')).toHaveLength(1)
+    expect(wrapper.text()).toContain('claude auth login')
+    expect(wrapper.text()).not.toContain('Then make it findable')
   })
 
   it('points at the desktop app when only the CLI is missing', async () => {
@@ -383,7 +469,7 @@ describe('LoginView setup wizard tests', () => {
           name: 'claude',
           ok: true,
           auth: 'oauth',
-          command: 'ciao auth claude',
+          command: 'claude auth login',
           detail: 'Ready'
         }
       }

--- a/web/src/components/__tests__/LoginView.test.ts
+++ b/web/src/components/__tests__/LoginView.test.ts
@@ -413,6 +413,46 @@ describe('LoginView setup wizard tests', () => {
     expect(wrapper.findAll('.command-row button')[1].text()).toBe('Copied!')
   })
 
+  it('does not let an earlier copy timer clear the button just pressed', async () => {
+    vi.useFakeTimers()
+    try {
+      const writeText = vi.fn().mockResolvedValue(undefined)
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText },
+        configurable: true,
+      })
+      mockApiGet.mockResolvedValue({
+        configured: false,
+        bootstrap: true,
+        mode: 'bootstrap',
+        providers: {
+          claude: {
+            name: 'claude',
+            ok: false,
+            auth: 'not_installed',
+            command: 'curl -fsSL https://claude.ai/install.sh | bash',
+            detail: 'Claude Code is not installed on this machine.',
+            path_command: 'echo \'export PATH="$HOME/.local/bin:$PATH"\' >> ~/.zshrc',
+          },
+        },
+      })
+
+      const wrapper = await mountLoginView()
+      await wrapper.findAll('.command-row button')[0].trigger('click')
+      await flushPromises()
+      vi.advanceTimersByTime(1500)
+      await wrapper.findAll('.command-row button')[1].trigger('click')
+      await flushPromises()
+      vi.advanceTimersByTime(600)
+      await nextTick()
+
+      // The first press's revert must not fire while the second is showing.
+      expect(wrapper.findAll('.command-row button')[1].text()).toBe('Copied!')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('shows no PATH step when the provider CLI is already installed', async () => {
     mockApiGet.mockResolvedValue({
       configured: false,

--- a/web/src/components/__tests__/mountSmoke.test.ts
+++ b/web/src/components/__tests__/mountSmoke.test.ts
@@ -68,7 +68,7 @@ vi.mock('../../lib/api', () => {
           name: 'claude',
           ok: true,
           auth: 'oauth',
-          command: 'ciao auth claude',
+          command: 'claude auth login',
           version: '2.1.205 (Claude Code)',
           account: 'person@example.com',
           protocol: 'Agent SDK ready',

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -609,7 +609,7 @@ export interface ProviderConnection {
   skills?: string[]
   /** Docs page for installing the CLI, set when `auth === 'not_installed'`. */
   install_url?: string
-  /** Shell line that puts the freshly installed CLI on PATH (`not_installed`). */
+  /** Shell line that puts the CLI on PATH (`not_installed`, `missing`, `cli_too_old`). */
   path_command?: string
   /** Desktop app found while the CLI is missing. */
   app_path?: string
@@ -989,7 +989,7 @@ export interface SetupProviderStatus {
   detail?: string
   /** Documentation page for installing the provider CLI (`auth: 'not_installed'`). */
   install_url?: string
-  /** Shell line that puts the freshly installed CLI on PATH (`auth: 'not_installed'`). */
+  /** Shell line that puts the CLI on PATH (`not_installed`, `missing`, `cli_too_old`). */
   path_command?: string
   /** Desktop app found while the CLI is missing, so setup can say which step is left. */
   app_path?: string

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -609,6 +609,8 @@ export interface ProviderConnection {
   skills?: string[]
   /** Docs page for installing the CLI, set when `auth === 'not_installed'`. */
   install_url?: string
+  /** Shell line that puts the freshly installed CLI on PATH (`not_installed`). */
+  path_command?: string
   /** Desktop app found while the CLI is missing. */
   app_path?: string
   /** Absolute path of the CLI binary Ciaobot would run. */
@@ -987,6 +989,8 @@ export interface SetupProviderStatus {
   detail?: string
   /** Documentation page for installing the provider CLI (`auth: 'not_installed'`). */
   install_url?: string
+  /** Shell line that puts the freshly installed CLI on PATH (`auth: 'not_installed'`). */
+  path_command?: string
   /** Desktop app found while the CLI is missing, so setup can say which step is left. */
   app_path?: string
   /** Absolute path of the CLI binary Ciaobot would run. */


### PR DESCRIPTION
## Problem

A new user followed the setup wizard, which told them to run `ciao auth claude` in a terminal, and got:

```
{ERROR (ciao_builder): Unknown command 'auth'.}
```

That error is from Ciao Prolog's builder, not from us. `ciao auth claude` only ever worked from a dev checkout: an app install keeps the engine at `Ciaobot.app/Contents/Resources/ciao-runtime/bin/ciao` and puts nothing named `ciao` on PATH, so the shell either finds nothing ("command not found") or finds an unrelated `ciao` and answers with its error.

## Changes

**Runnable login command** (`ciao/setup_status.py`) — the wizard now reports each provider's own login command. `claude auth login` when the user's login shell can resolve `claude` (via `resolve_tool`, so `~/.local/bin` and Homebrew are seen even under launchd), otherwise the absolute path of the binary Ciaobot would run — usually the Agent-SDK-bundled `claude`, which is on nobody's PATH, so a bare word would fail there too. opencode already reported `opencode auth login`.

**PATH step** — new `path_command` on the not-installed provider row. Claude's installer drops the binary in `~/.local/bin`, which a default macOS PATH omits, so the very next command a new user runs still reports "command not found". The wizard renders it as a second copyable step ("Then make it findable in new terminals:"); Settings shows it inline. Copy status is now tracked per button, so one press no longer flashes "Copied!" on both.

**`ciao` on PATH** (`scripts/install.sh`) — the installer writes a shim to `~/.local/bin/ciao` that forwards to the bundle's engine, which is what makes the `ciao ...` commands in the docs work in a terminal. A shim, not a symlink: the bundled launcher derives its runtime root from `dirname "$0"`, which through a symlink resolves to the link's own directory. A `ciao` the installer did not write is never overwritten (its marker line is how it tells them apart), and after installing it reports whichever problem is left — the directory not being on PATH, or another `ciao` winning the PATH race.

**Uninstall** (`ciao/desktop_install.py`) — `ciao desktop uninstall` removes the shim, but only when it carries the installer marker *and* names the bundle being removed.

**Docs** — INTEGRATIONS.md gains a "The `ciao` command" section covering the shim and the two manual cases; README's Claude bullet names the install command, the `~/.local/bin` caveat, and `claude auth login`.

## Testing

- `pytest tests/` — 3484 passed.
- `npm test` — 1053 passed; `npm run build` clean.
- New: 2 tests in `test_setup_status.py`, 2 in `test_one_line_installer.py` that execute the installer's shim block in a temp HOME (forwards args to the engine; refuses to clobber a foreign `ciao`, replaces its own), 2 in `test_desktop_install.py`, 3 in `LoginView.test.ts`.
- Visual: ran a throwaway bootstrap server with Claude forced missing and inspected the live wizard — both command rows render with the right hints, and the long PATH line wraps with no horizontal overflow. Screenshot capture timed out in that browser session, so the check is DOM-level rather than a picture.