### PR TITLE
Attended retirement UI for stale vault notes (vault_review frontend)

### DIFF
--- a/PWA_API.md
+++ b/PWA_API.md
@@ -77,7 +77,7 @@ The route source of truth is `ciao/web/app.py`. This file is kept in sync by `te
 | GET | `/api/vault-markdown-paths` | List workspace-relative markdown paths (file viewer resolves Obsidian wikilinks) |
 | GET | `/api/vault/backlinks` | List notes whose wikilinks resolve to a given markdown path |
 | GET | `/api/vault/graph` | Vault-wide note graph (frontmatter `related:` + `[[wikilinks]]`) for the Memory Map page; optional `?workspace=` scopes to one logical workspace |
-| GET, POST | `/api/vault/review` | List explainable note-review candidates or record an explicit keep/link/defer/restore decision; trash and permanent deletion are separate actions, with permanent deletion requiring a trashed candidate and exact confirmation |
+| GET, POST | `/api/vault/review` | List explainable note-review candidates (`?include=trashed` also lists the reversible trash inventory) or record an explicit keep/link/defer/restore decision; trash and permanent deletion are separate actions, with permanent deletion requiring a trashed candidate and exact confirmation |
 | DELETE | `/api/vault/note` | Permanently delete one vault note (`?path=`, the `Entry.path` string form); strips dangling `related:`/`relatedTo:` and `[[wikilink]]` references from every note that linked to it first |
 | POST | `/api/file-restore` | Restore a snapshot to disk |
 | GET, POST | `/api/schedules` | List or create automations of any cadence, including `frequency: "interval"` |
@@ -210,10 +210,21 @@ Reuse the jar with `-b /tmp/ciao.jar` on every other call. The Origin/Referer ho
 # Detection is read-only and scoped to one logical workspace.
 curl -sS -b /tmp/ciao.jar "http://localhost:${PWA_PORT:-8443}/api/vault/review?workspace=default"
 
+# The reversible trash inventory (what the Review → Retirement tab renders).
+curl -sS -b /tmp/ciao.jar "http://localhost:${PWA_PORT:-8443}/api/vault/review?workspace=default&include=trashed"
+
 # Record a reversible decision. Permanent deletion is only available after trash.
 curl -sS -b /tmp/ciao.jar -X POST "http://localhost:${PWA_PORT:-8443}/api/vault/review?workspace=default" \
   -H 'content-type: application/json' \
   -d '{"action":"decide","candidate_id":"<candidate-id>","disposition":"keep"}'
+
+# Retire into the 30-day trash, then restore from it.
+curl -sS -b /tmp/ciao.jar -X POST "http://localhost:${PWA_PORT:-8443}/api/vault/review?workspace=default" \
+  -H 'content-type: application/json' \
+  -d '{"action":"trash","candidate_id":"<candidate-id>"}'
+curl -sS -b /tmp/ciao.jar -X POST "http://localhost:${PWA_PORT:-8443}/api/vault/review?workspace=default" \
+  -H 'content-type: application/json' \
+  -d '{"action":"restore","candidate_id":"<candidate-id>"}'
 ```
 
 **Agent assets**

--- a/ciao/vault_review.py
+++ b/ciao/vault_review.py
@@ -343,6 +343,47 @@ def restore_note(root: Path, candidate_id_value: str, *, actor: str = "user") ->
     return metadata
 
 
+def list_trashed(root: Path, *, workspace: str) -> list[dict[str, Any]]:
+    """Read-only inventory of the reversible trash for one workspace.
+
+    The trash view renders from this rather than from candidate generation:
+    a trashed note is no longer in the vault, so it can never be a
+    candidate again, and its only durable record is the ``.json`` sidecar
+    `trash_note` wrote next to it. Scoped to one workspace; anything that
+    is not a well-formed sidecar for a still-restorable note is skipped.
+    """
+    directory = trash_dir(root)
+    if not directory.is_dir():
+        return []
+    items: list[dict[str, Any]] = []
+    for metadata_path in sorted(directory.glob("*.json")):
+        if not _CANDIDATE_ID_RE.fullmatch(metadata_path.stem):
+            continue
+        try:
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(metadata, dict):
+            continue
+        if str(metadata.get("workspace") or "") != workspace:
+            continue
+        if str(metadata.get("candidate_id") or "") != metadata_path.stem:
+            continue
+        if not (directory / f"{metadata_path.stem}.md").is_file():
+            continue
+        items.append(
+            {
+                "candidate_id": metadata_path.stem,
+                "workspace": workspace,
+                "original_path": str(metadata.get("original_path") or ""),
+                "content_hash": str(metadata.get("content_hash") or ""),
+                "trashed_at": str(metadata.get("trashed_at") or ""),
+            }
+        )
+    items.sort(key=lambda item: item["trashed_at"])
+    return items
+
+
 def delete_permanently(root: Path, candidate_id_value: str, *, confirm: str, actor: str = "user") -> dict[str, Any]:
     _validate_candidate_id(candidate_id_value)
     if confirm != candidate_id_value:

--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -4895,10 +4895,6 @@ async def vault_review(request: Request) -> JSONResponse:
             result = review.record_decision(root, item, str(payload.get("disposition", "")), actor="user", defer_days=int(payload.get("defer_days", 7)))
         elif action == "trash":
             result = review.trash_note(root, item)
-        elif action == "restore":
-            result = review.restore_note(root, item.candidate_id)
-        elif action == "delete":
-            result = review.delete_permanently(root, item.candidate_id, confirm=str(payload.get("confirm", "")))
         else:
             return JSONResponse({"error": "unsupported action"}, status_code=400)
     except (ValueError, OSError) as exc:

--- a/ciao/web/routes_api.py
+++ b/ciao/web/routes_api.py
@@ -4861,7 +4861,15 @@ async def vault_review(request: Request) -> JSONResponse:
             )
         )
     if request.method == "GET":
-        return JSONResponse({"candidates": [item.as_dict() for item in candidates]})
+        review_body: dict[str, Any] = {"candidates": [item.as_dict() for item in candidates]}
+        # The trash view renders the reversible trash, which candidate
+        # generation can never return: a trashed note is no longer in the
+        # vault. Same read-only contract as the candidate listing itself.
+        if "trashed" in {part.strip() for part in request.query_params.get("include", "").split(",")}:
+            review_body["trashed"] = await asyncio.to_thread(
+                functools.partial(review.list_trashed, root, workspace=workspace)
+            )
+        return JSONResponse(review_body)
 
     candidate_id_value = str(payload.get("candidate_id", "") or "")
     if action in {"restore", "delete"}:

--- a/tests/test_vault_review.py
+++ b/tests/test_vault_review.py
@@ -215,6 +215,33 @@ def test_permanent_delete_restores_backlinks_when_audit_fails(
     assert (tmp_path / "Workspace" / ".vault-trash" / f"{candidate.candidate_id}.md").is_file()
 
 
+def test_list_trashed_is_scoped_and_tracks_restore(tmp_path: Path) -> None:
+    _note(tmp_path, "People/A.md", "An unlinked note.")
+    candidate = generate_candidates(tmp_path, workspace="personal")[0]
+
+    assert review.list_trashed(tmp_path, workspace="personal") == []
+
+    trash_note(tmp_path, candidate)
+    (listed,) = review.list_trashed(tmp_path, workspace="personal")
+    assert listed["candidate_id"] == candidate.candidate_id
+    assert listed["original_path"] == candidate.path
+    assert listed["content_hash"] == candidate.content_hash
+    assert listed["trashed_at"]
+    # Another workspace's trash view stays empty.
+    assert review.list_trashed(tmp_path, workspace="work") == []
+
+    restore_note(tmp_path, candidate.candidate_id)
+    assert review.list_trashed(tmp_path, workspace="personal") == []
+
+
+def test_list_trashed_skips_malformed_sidecars(tmp_path: Path) -> None:
+    trash = tmp_path / "Workspace" / ".vault-trash"
+    trash.mkdir(parents=True, exist_ok=True)
+    (trash / "not-a-candidate.json").write_text("{}", encoding="utf-8")
+    (trash / "0123456789abcdef01234567.json").write_text("not json", encoding="utf-8")
+    assert review.list_trashed(tmp_path, workspace="personal") == []
+
+
 def test_an_earlier_unattended_turn_does_not_block_a_later_attended_trash(tmp_path: Path) -> None:
     from types import SimpleNamespace
 

--- a/web/src/components/MemoryMapView.vue
+++ b/web/src/components/MemoryMapView.vue
@@ -1230,7 +1230,11 @@ const vaultReview = useVaultReviewStore()
 // Tab badges, scoped like the lists they count: the workspace toggle scopes
 // both queues, so a global tally would claim rows the tab will not show.
 const proposalCount = computed(() => proposals.scopedRows(store.activeWorkspace).length)
-const retirementCount = computed(() => vaultReview.candidates.length + vaultReview.trashed.length)
+const retirementCount = computed(() =>
+  vaultReview.loadedWorkspace === store.activeWorkspace
+    ? vaultReview.candidates.length + vaultReview.trashed.length
+    : 0,
+)
 // A stale note's detail panel lands directly on the retirement queue.
 function openRetirementReview() {
   mm.reviewTab = 'retirement'

--- a/web/src/components/MemoryMapView.vue
+++ b/web/src/components/MemoryMapView.vue
@@ -2,7 +2,33 @@
   <div class="memory-map">
     <PaneHeader page-tag="memory" @open-sidebar="emit('open-sidebar')" />
 
-    <ProposalReviewPanel v-if="mm.view === 'review'" />
+    <div v-if="mm.view === 'review'" class="mm-review-wrap">
+      <!-- One surface, two queues: agent proposals (additions) and stale-note
+           retirement live side by side so "decide things" has one address.
+           The tab state is shared (`mm.reviewTab`) so entry points elsewhere
+           — the sidebar's "Needs review" list, a stale note's detail panel —
+           can land directly on retirement. -->
+      <div class="mm-review-tabs" role="tablist" aria-label="Review">
+        <button
+          type="button"
+          role="tab"
+          :aria-selected="mm.reviewTab === 'proposals'"
+          class="mm-review-tab"
+          :class="{ active: mm.reviewTab === 'proposals' }"
+          @click="mm.reviewTab = 'proposals'"
+        >Proposals<span v-if="proposalCount" class="mm-review-count">{{ proposalCount }}</span></button>
+        <button
+          type="button"
+          role="tab"
+          :aria-selected="mm.reviewTab === 'retirement'"
+          class="mm-review-tab"
+          :class="{ active: mm.reviewTab === 'retirement' }"
+          @click="mm.reviewTab = 'retirement'"
+        >Retirement<span v-if="retirementCount" class="mm-review-count">{{ retirementCount }}</span></button>
+      </div>
+      <ProposalReviewPanel v-if="mm.reviewTab === 'proposals'" />
+      <VaultReviewPanel v-else />
+    </div>
 
     <div v-else class="mm-body" :class="{ 'mm-body--detail-open': !!mm.selectedNode, 'mm-body--dragging-detail': isDraggingDetail }" :style="detailBodyStyle">
       <div v-if="mm.loading" class="mm-skeleton" role="status" aria-live="polite" aria-label="Loading vault graph">
@@ -181,6 +207,12 @@
           <span v-if="mm.selectedNode.stale" class="stale-badge" title="Unverified past this note type's staleness horizon">needs review</span>
         </div>
         <div v-if="ageLabelOfSelected" class="mm-detail-verified">Last verified {{ ageLabelOfSelected }} ago</div>
+        <button
+          v-if="mm.selectedNode.stale"
+          type="button"
+          class="mm-detail-review-link"
+          @click="openRetirementReview"
+        >Review for retirement →</button>
         <button type="button" class="mm-detail-path" @click="openNoteFile(mm.selectedNode.id)">{{ mm.selectedNode.id }}</button>
 
         <div class="mm-detail-section mm-detail-preview">
@@ -248,7 +280,9 @@
 import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, toRaw, watch } from 'vue'
 import PaneHeader from './PaneHeader.vue'
 import ProposalReviewPanel from './ProposalReviewPanel.vue'
+import VaultReviewPanel from './VaultReviewPanel.vue'
 import { useProposalsStore } from '../stores/proposals'
+import { useVaultReviewStore } from '../stores/vaultReview'
 import { router } from '../router'
 import { useProjectStore } from '../stores/projects'
 import { useFileViewerStore } from '../stores/fileViewer'
@@ -1192,6 +1226,26 @@ function onWheel(e: WheelEvent) {
 // itself lives in the sidebar next to the workspace toggle; this component only
 // mirrors the shared `mm.view` state, seeding it from the URL on mount.
 const proposals = useProposalsStore()
+const vaultReview = useVaultReviewStore()
+// Tab badges, scoped like the lists they count: the workspace toggle scopes
+// both queues, so a global tally would claim rows the tab will not show.
+const proposalCount = computed(() => proposals.scopedRows(store.activeWorkspace).length)
+const retirementCount = computed(() => vaultReview.candidates.length + vaultReview.trashed.length)
+// A stale note's detail panel lands directly on the retirement queue.
+function openRetirementReview() {
+  mm.reviewTab = 'retirement'
+  mm.view = 'review'
+  if (router.currentRoute.value.path !== '/proposals') void router.push('/proposals')
+}
+// The badges need data even while the Retirement tab (which fetches on mount)
+// has never been opened. Joining the in-flight request when the panel mounts
+// keeps this to one GET.
+watch(() => mm.view, (view) => {
+  if (view === 'review') {
+    void proposals.ensureLoaded()
+    if (store.activeWorkspace) void vaultReview.fetch(store.activeWorkspace)
+  }
+})
 mm.view = router.currentRoute.value.path.startsWith('/proposals') ? 'review' : 'graph'
 const sortKey = ref<'title' | 'type' | 'degree' | 'age'>('title')
 const sortDir = ref(1)
@@ -1277,6 +1331,70 @@ onBeforeUnmount(() => {
   height: 100%;
   min-height: 0;
 }
+/* The Review surface holds two queues — agent proposals and stale-note
+   retirement — under one tab bar, matching ProposalReviewPanel's own
+   Queue/History underline style so switching sub-views reads the same way. */
+.mm-review-wrap {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+.mm-review-tabs {
+  display: flex;
+  gap: var(--space-1);
+  padding: 0 var(--space-4);
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  flex: none;
+}
+.mm-review-tab {
+  min-height: var(--touch);
+  padding: var(--space-2) var(--space-3);
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--fg2);
+  cursor: pointer;
+  font: 600 var(--text-sm) var(--font);
+  white-space: nowrap;
+}
+.mm-review-tab:hover { color: var(--fg); background: var(--bg3); }
+.mm-review-tab.active {
+  border-bottom-color: var(--accent);
+  color: var(--fg);
+}
+.mm-review-tab:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.mm-review-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: calc(var(--text-xs) + var(--space-2));
+  min-height: calc(var(--text-xs) + var(--space-1));
+  margin-left: var(--space-1);
+  padding: 0 var(--space-1);
+  border-radius: var(--radius-pill);
+  background: var(--bg3);
+  color: var(--fg2);
+  font-size: var(--text-xs);
+  font-variant-numeric: tabular-nums;
+}
+.mm-review-tab.active .mm-review-count { color: var(--fg); }
+/* A stale note's way into the retirement queue, next to its last-verified
+   line. A text button, not a pink bar: deciding happens in Review, not here. */
+.mm-detail-review-link {
+  background: none;
+  border: none;
+  padding: 0;
+  min-height: var(--touch);
+  font-family: var(--font);
+  font-size: var(--text-xs);
+  color: var(--accent);
+  text-align: left;
+  cursor: pointer;
+}
+.mm-detail-review-link:hover { text-decoration: underline; }
+.mm-detail-review-link:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .mm-body {
   flex: 1;
   min-height: 0;

--- a/web/src/components/ProjectSidebar.vue
+++ b/web/src/components/ProjectSidebar.vue
@@ -697,6 +697,11 @@
             corrects, or removes them. They stay here until you or that run
             resolves them.
           </p>
+          <button
+            type="button"
+            class="mm-link mm-link--block"
+            @click="openRetirementReview()"
+          >Open retirement review →</button>
           <div class="mm-link-list">
             <div
               v-for="n in mm.staleNotes.slice(0, staleLimit)"
@@ -1340,6 +1345,12 @@ function setMemoryView(next: 'graph' | 'list' | 'review') {
   mm.view = next
   const target = next === 'review' ? '/proposals' : '/memory'
   if (route.path !== target) void router.push(target)
+}
+
+/** The "Needs review" list lands directly on the retirement queue. */
+function openRetirementReview() {
+  mm.reviewTab = 'retirement'
+  setMemoryView('review')
 }
 
 function promptTitle(prompt: string): string {
@@ -3307,6 +3318,9 @@ async function confirmDeleteChat(chatId: string) {
 .mm-sep { color: var(--fg3); font-size: var(--text-xs); }
 .mm-link--active { color: var(--fg); font-weight: 600; }
 .mm-link { background: none; border: none; color: var(--accent); font-size: var(--text-xs); cursor: pointer; padding: 0; }
+/* A standalone entry point, not an inline action: full touch target. */
+.mm-link--block { display: inline-flex; align-items: center; min-height: var(--touch); margin-bottom: var(--space-1); }
+.mm-link--block:hover { text-decoration: underline; }
 .mm-hint { color: var(--fg3); font-size: var(--text-xs); margin: 0; }
 
 .mm-stat-grid { display: grid; grid-template-columns: 1fr 1fr; gap: var(--space-2); }

--- a/web/src/components/VaultReviewPanel.vue
+++ b/web/src/components/VaultReviewPanel.vue
@@ -28,7 +28,7 @@ onMounted(() => {
   if (workspace.value) void store.fetch(workspace.value)
 })
 watch(workspace, (ws) => {
-  if (ws) void store.fetch(ws)
+  if (ws) void store.fetch(ws, { force: true })
 })
 
 function refresh() {
@@ -37,12 +37,16 @@ function refresh() {
 
 // "Later" needs a day count per row. Kept local: it is input state, not
 // server state, and it must survive a queue refresh while the user types.
-const deferDays = ref<Record<string, number>>({})
-function daysFor(id: string): number {
-  return deferDays.value[id] ?? 7
+// Stored raw so clearing the field stays empty while typing instead of
+// snapping back to 0; only coerced when the Later action runs.
+const deferDays = ref<Record<string, string>>({})
+function daysFor(id: string): string {
+  return deferDays.value[id] ?? '7'
 }
 function clampDays(id: string): number {
-  const n = Math.floor(Number(daysFor(id)))
+  const raw = (deferDays.value[id] ?? '7').trim()
+  if (!raw) return 7
+  const n = Math.floor(Number(raw))
   return Number.isFinite(n) ? Math.max(1, Math.min(90, n)) : 7
 }
 
@@ -233,7 +237,7 @@ function trashedDate(note: VaultTrashedNote): string {
             :disabled="store.isBusy(candidate.candidate_id)"
             @click="trashRow(candidate)"
           >Retire</button>
-          <label class="vr-defer">
+          <span class="vr-defer">
             <button
               type="button"
               class="btn-small btn-chip"
@@ -248,10 +252,10 @@ function trashedDate(note: VaultTrashedNote): string {
               aria-label="Snooze days"
               class="vr-defer-input"
               :disabled="store.isBusy(candidate.candidate_id)"
-              @input="deferDays[candidate.candidate_id] = Number(($event.target as HTMLInputElement).value)"
+              @input="deferDays[candidate.candidate_id] = ($event.target as HTMLInputElement).value"
             />
             <span class="vr-defer-unit">days</span>
-          </label>
+          </span>
           <button
             type="button"
             class="btn-small btn-chip"

--- a/web/src/components/VaultReviewPanel.vue
+++ b/web/src/components/VaultReviewPanel.vue
@@ -1,0 +1,512 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import { useVaultReviewStore } from '../stores/vaultReview'
+import { useProjectStore } from '../stores/projects'
+import { useFileViewerStore } from '../stores/fileViewer'
+import type { VaultReviewCandidate, VaultTrashedNote } from '../lib/types'
+import { candidateLeaf, signalReasons, verificationLabel } from '../lib/vaultReviewLabels'
+import { askConfirm } from '../lib/confirm'
+
+const store = useVaultReviewStore()
+const projectStore = useProjectStore()
+const fileViewer = useFileViewerStore()
+
+const workspace = computed(() => projectStore.activeWorkspace)
+
+// Failures go to the app's error toast, matching ProposalReviewPanel: an
+// inline banner would sit above the list with no way to dismiss it.
+watch(
+  () => store.error,
+  (message) => {
+    if (!message) return
+    projectStore.pushErrorToast('Retirement action failed', message)
+    store.error = ''
+  },
+)
+
+onMounted(() => {
+  if (workspace.value) void store.fetch(workspace.value)
+})
+watch(workspace, (ws) => {
+  if (ws) void store.fetch(ws)
+})
+
+function refresh() {
+  if (workspace.value) void store.fetch(workspace.value, { force: true })
+}
+
+// "Later" needs a day count per row. Kept local: it is input state, not
+// server state, and it must survive a queue refresh while the user types.
+const deferDays = ref<Record<string, number>>({})
+function daysFor(id: string): number {
+  return deferDays.value[id] ?? 7
+}
+function clampDays(id: string): number {
+  const n = Math.floor(Number(daysFor(id)))
+  return Number.isFinite(n) ? Math.max(1, Math.min(90, n)) : 7
+}
+
+// A candidate carries no content — only its path and why it was flagged —
+// so each row lazy-loads an excerpt behind a disclosure, the way the Memory
+// Map's detail panel does. Frontmatter is stripped: tags and dates already
+// surface as structured rows above the excerpt.
+interface ExcerptState {
+  loading: boolean
+  error: string
+  text: string
+}
+const excerpts = ref<Record<string, ExcerptState>>({})
+const EXCERPT_LIMIT = 1200
+
+async function ensureExcerpt(candidate: VaultReviewCandidate) {
+  const id = candidate.candidate_id
+  if (excerpts.value[id]) return
+  excerpts.value[id] = { loading: true, error: '', text: '' }
+  try {
+    const resp = await fetch(`/api/workspace-file?path=${encodeURIComponent(candidate.path)}`, {
+      credentials: 'same-origin',
+    })
+    if (!resp.ok) {
+      excerpts.value[id] = {
+        loading: false,
+        error: resp.status === 404 ? 'File not found — it may have been moved.' : `Could not load (HTTP ${resp.status}).`,
+        text: '',
+      }
+      return
+    }
+    let text = await resp.text()
+    if (text.startsWith('---')) {
+      const end = text.indexOf('\n---', 3)
+      if (end !== -1) {
+        const after = text.indexOf('\n', end + 4)
+        if (after !== -1) text = text.slice(after + 1)
+      }
+    }
+    text = text.trimStart()
+    excerpts.value[id] = {
+      loading: false,
+      error: '',
+      text: text.length > EXCERPT_LIMIT ? `${text.slice(0, EXCERPT_LIMIT).trimEnd()} …` : text,
+    }
+  } catch (e) {
+    excerpts.value[id] = {
+      loading: false,
+      error: e instanceof Error ? e.message : 'Could not load the excerpt.',
+      text: '',
+    }
+  }
+}
+
+function onExcerptToggle(candidate: VaultReviewCandidate, event: Event) {
+  if ((event.target as HTMLDetailsElement).open) void ensureExcerpt(candidate)
+}
+
+async function openNote(path: string) {
+  await fileViewer.open(path)
+}
+
+function verifyLabelOf(candidate: VaultReviewCandidate): string {
+  return verificationLabel(candidate.evidence.age_days, candidate.evidence.last_update)
+}
+
+async function keepRow(candidate: VaultReviewCandidate) {
+  await store.decide(workspace.value, candidate.candidate_id, 'keep')
+}
+
+async function deferRow(candidate: VaultReviewCandidate) {
+  await store.decide(workspace.value, candidate.candidate_id, 'defer', clampDays(candidate.candidate_id))
+}
+
+async function linkFixedRow(candidate: VaultReviewCandidate) {
+  await store.decide(workspace.value, candidate.candidate_id, 'improve_link')
+}
+
+async function trashRow(candidate: VaultReviewCandidate) {
+  // No confirm here: trash is reversible for 30 days and one click restores
+  // it. The confirm budget is spent on permanent deletion instead.
+  await store.trash(workspace.value, candidate.candidate_id)
+}
+
+async function restoreRow(note: VaultTrashedNote) {
+  await store.restore(workspace.value, note.candidate_id)
+}
+
+async function deleteRow(note: VaultTrashedNote) {
+  const title = note.original_path.split('/').pop() || note.original_path
+  if (!await askConfirm(
+    `Permanently delete "${title}"? The trash copy is removed and every link to it is rewritten. This cannot be undone.`,
+    { title: 'Delete forever', confirmLabel: 'Delete forever', destructive: true },
+  )) return
+  await store.remove(workspace.value, note.candidate_id)
+}
+
+function trashedTitle(note: VaultTrashedNote): string {
+  return candidateLeaf(note.original_path)
+}
+
+function trashedDate(note: VaultTrashedNote): string {
+  if (!note.trashed_at) return ''
+  return note.trashed_at.slice(0, 10)
+}
+</script>
+
+<template>
+  <div class="vault-review">
+    <header class="vr-head">
+      <p class="vr-summary">
+        <strong>{{ store.candidates.length }}</strong> to review in {{ workspace }}
+        · <strong>{{ store.trashed.length }}</strong> in trash
+      </p>
+      <button
+        type="button"
+        class="btn-small btn-chip"
+        :disabled="store.loading"
+        @click="refresh"
+      >{{ store.loading ? 'loading…' : 'refresh' }}</button>
+    </header>
+
+    <p class="vr-hint">
+      Stale notes the nightly curation flagged. <strong>Still true</strong> re-verifies a
+      note; <strong>Retire</strong> moves it to the trash, where one click brings it
+      back for 30 days. <strong>Later</strong> snoozes a candidate; <strong>Link
+      fixed</strong> records that you re-linked it elsewhere. Nothing here deletes
+      permanently except the trash's own delete control, which asks first.
+    </p>
+
+    <p v-if="store.loading && !store.candidates.length" class="vr-empty" role="status">Loading candidates…</p>
+    <p v-else-if="!store.candidates.length" class="vr-empty">
+      Nothing flagged here. Notes land here when curation finds them unlinked,
+      duplicated, superseded, or unverified — and leave when you or that run resolves them.
+    </p>
+
+    <ul v-else class="vr-rows">
+      <li
+        v-for="candidate in store.candidates"
+        :key="candidate.candidate_id"
+        class="vr-row"
+        :class="{ 'vr-row--busy': store.isBusy(candidate.candidate_id) }"
+      >
+        <div class="vr-row-body">
+          <div class="vr-row-top">
+            <span class="vr-title">{{ candidateLeaf(candidate.path) }}</span>
+          </div>
+          <button
+            type="button"
+            class="vr-path"
+            :title="candidate.path"
+            @click="openNote(candidate.path)"
+          >{{ candidate.path }}</button>
+          <ul class="vr-reasons">
+            <li v-for="reason in signalReasons(candidate.signals)" :key="reason">{{ reason }}</li>
+          </ul>
+          <p class="vr-meta">
+            {{ candidate.evidence.type }} · {{ verifyLabelOf(candidate) }}
+            <span v-if="candidate.evidence.backlinks.length">
+              · {{ candidate.evidence.backlinks.length }} backlink{{ candidate.evidence.backlinks.length === 1 ? '' : 's' }}
+            </span>
+            <span v-if="candidate.evidence.bridge" class="vr-badge --warn">bridges clusters — think twice</span>
+          </p>
+          <p v-if="candidate.evidence.duplicate_group.length" class="vr-meta">
+            Possible {{ candidate.evidence.duplicate_group.length === 1 ? 'duplicate' : 'duplicates' }}:
+            {{ candidate.evidence.duplicate_group.filter(p => p !== candidate.path).slice(0, 3).join(', ') || 'see evidence' }}
+          </p>
+          <details class="vr-excerpt" @toggle="onExcerptToggle(candidate, $event)">
+            <summary>excerpt</summary>
+            <p v-if="excerpts[candidate.candidate_id]?.loading" class="vr-meta">Loading…</p>
+            <p v-else-if="excerpts[candidate.candidate_id]?.error" class="vr-error">
+              {{ excerpts[candidate.candidate_id].error }}
+            </p>
+            <pre v-else-if="excerpts[candidate.candidate_id]?.text" class="vr-excerpt-text">{{ excerpts[candidate.candidate_id].text }}</pre>
+          </details>
+        </div>
+
+        <div class="vr-actions">
+          <button
+            type="button"
+            class="btn-small btn-primary"
+            :disabled="store.isBusy(candidate.candidate_id)"
+            @click="keepRow(candidate)"
+          >{{ store.isBusy(candidate.candidate_id) ? 'working…' : 'Still true' }}</button>
+          <button
+            type="button"
+            class="btn-small btn-chip"
+            :disabled="store.isBusy(candidate.candidate_id)"
+            @click="trashRow(candidate)"
+          >Retire</button>
+          <label class="vr-defer">
+            <button
+              type="button"
+              class="btn-small btn-chip"
+              :disabled="store.isBusy(candidate.candidate_id)"
+              @click="deferRow(candidate)"
+            >Later</button>
+            <input
+              :value="daysFor(candidate.candidate_id)"
+              type="number"
+              min="1"
+              max="90"
+              aria-label="Snooze days"
+              class="vr-defer-input"
+              :disabled="store.isBusy(candidate.candidate_id)"
+              @input="deferDays[candidate.candidate_id] = Number(($event.target as HTMLInputElement).value)"
+            />
+            <span class="vr-defer-unit">days</span>
+          </label>
+          <button
+            type="button"
+            class="btn-small btn-chip"
+            :disabled="store.isBusy(candidate.candidate_id)"
+            title="Record that you re-linked this note elsewhere"
+            @click="linkFixedRow(candidate)"
+          >Link fixed</button>
+        </div>
+      </li>
+    </ul>
+
+    <section v-if="store.trashed.length" class="vr-trash" aria-label="Trash">
+      <h3 class="vr-trash-title">Trash ({{ store.trashed.length }})</h3>
+      <p class="vr-hint">Retired notes stay restorable for 30 days. Restore is one click; permanent deletion asks first.</p>
+      <ul class="vr-rows">
+        <li
+          v-for="note in store.trashed"
+          :key="note.candidate_id"
+          class="vr-row"
+          :class="{ 'vr-row--busy': store.isBusy(note.candidate_id) }"
+        >
+          <div class="vr-row-body">
+            <div class="vr-row-top">
+              <span class="vr-title">{{ trashedTitle(note) }}</span>
+            </div>
+            <p class="vr-meta">{{ note.original_path }}<span v-if="trashedDate(note)"> · retired {{ trashedDate(note) }}</span></p>
+          </div>
+          <div class="vr-actions">
+            <button
+              type="button"
+              class="btn-small btn-primary"
+              :disabled="store.isBusy(note.candidate_id)"
+              @click="restoreRow(note)"
+            >{{ store.isBusy(note.candidate_id) ? 'working…' : 'Restore' }}</button>
+            <button
+              type="button"
+              class="btn-small btn-chip vr-danger"
+              :disabled="store.isBusy(note.candidate_id)"
+              @click="deleteRow(note)"
+            >Delete forever</button>
+          </div>
+        </li>
+      </ul>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+/* Same one-column rhythm as the proposal queue: generous vertical spacing,
+   one shape per row, actions stacked so the text column keeps the width. */
+.vault-review {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.vr-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.vr-summary {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.vr-hint {
+  margin: 0;
+  color: var(--fg2);
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.vr-empty {
+  color: var(--fg2);
+  font-size: 0.9rem;
+  padding: var(--space-4) 0;
+}
+
+.vr-error {
+  color: var(--error);
+  font-size: 0.85rem;
+}
+
+.vr-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.vr-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: start;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg2);
+}
+
+.vr-row--busy {
+  opacity: 0.72;
+  pointer-events: none;
+}
+
+.vr-row-body {
+  min-width: 0;
+}
+
+.vr-row-top {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.vr-title {
+  font-size: 0.95rem;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.vr-path {
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.72rem;
+  color: var(--accent);
+  text-align: left;
+  cursor: pointer;
+  overflow-wrap: anywhere;
+  min-height: var(--touch);
+}
+
+.vr-path:hover {
+  text-decoration: underline;
+}
+
+.vr-reasons {
+  margin: var(--space-1) 0 0;
+  padding-left: 1.1rem;
+  color: var(--fg);
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.vr-meta {
+  margin: 0.25rem 0 0;
+  color: var(--fg2);
+  font-size: 0.8rem;
+}
+
+.vr-badge {
+  margin-left: var(--space-2);
+  font-size: 0.7rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+}
+
+.vr-badge.--warn {
+  background: rgba(210, 153, 34, 0.18);
+  color: var(--warning);
+}
+
+.vr-excerpt {
+  margin-top: var(--space-2);
+  font-size: 0.8rem;
+  color: var(--fg2);
+}
+
+.vr-excerpt summary {
+  cursor: pointer;
+  min-height: var(--touch);
+  display: inline-flex;
+  align-items: center;
+}
+
+.vr-excerpt-text {
+  margin: var(--space-2) 0 0;
+  padding: var(--space-2);
+  max-height: 12rem;
+  overflow: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: var(--fg2);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
+.vr-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--space-1);
+  flex: none;
+  min-width: 8.5rem;
+}
+
+.vr-defer {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.vr-defer-input {
+  width: 3.5rem;
+  min-height: var(--touch);
+}
+
+.vr-defer-unit {
+  font-size: 0.75rem;
+  color: var(--fg2);
+}
+
+/* Destructive, but not competing-pink: neutral chip in the error colour. */
+.vr-danger {
+  color: var(--error);
+  border-color: var(--error);
+}
+
+.vr-trash {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border);
+}
+
+.vr-trash-title {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+/* Stacked column keeps text full-width on both desktop and mobile. */
+@media (max-width: 640px) {
+  .vr-row {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/web/src/components/__tests__/VaultReviewPanel.test.ts
+++ b/web/src/components/__tests__/VaultReviewPanel.test.ts
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { flushPromises, mount } from '@vue/test-utils'
+import VaultReviewPanel from '../VaultReviewPanel.vue'
+import { useVaultReviewStore } from '../../stores/vaultReview'
+import { pendingConfirm } from '../../lib/confirm'
+import type { VaultReviewCandidate, VaultTrashedNote } from '../../lib/types'
+
+const apiGet = vi.hoisted(() => vi.fn())
+const apiPost = vi.hoisted(() => vi.fn())
+
+vi.mock('../../lib/api', () => ({
+  api: { get: apiGet, post: apiPost, patch: vi.fn(), del: vi.fn() },
+}))
+
+function candidate(overrides: Partial<VaultReviewCandidate> = {}): VaultReviewCandidate {
+  return {
+    candidate_id: 'abc123abc123abc123abc123',
+    workspace: 'personal',
+    path: 'memory-vault/People/Mo.md',
+    content_hash: 'deadbeef',
+    signals: ['unlinked', 'weak_provenance'],
+    priority: 1,
+    evidence: {
+      backlinks: [],
+      outbound_links: [],
+      bridge: false,
+      duplicate_group: [],
+      last_update: '',
+      type: 'note',
+      age_days: null,
+    },
+    status: 'candidate',
+    disposition: '',
+    deferred_until: '',
+    ...overrides,
+  }
+}
+
+function trashed(overrides: Partial<VaultTrashedNote> = {}): VaultTrashedNote {
+  return {
+    candidate_id: 'def456def456def456def456',
+    workspace: 'personal',
+    original_path: 'memory-vault/People/Old.md',
+    content_hash: 'cafef00d',
+    trashed_at: '2026-09-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function buttonByText(wrapper: ReturnType<typeof mount>, text: string) {
+  const found = wrapper.findAll('button').find(b => b.text() === text)
+  if (!found) throw new Error(`button "${text}" not found`)
+  return found
+}
+
+describe('VaultReviewPanel', () => {
+  let pinia: ReturnType<typeof createPinia>
+
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+    apiGet.mockReset()
+    apiPost.mockReset()
+    apiPost.mockResolvedValue({ ok: true })
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    pendingConfirm.value?.resolve(false)
+    vi.restoreAllMocks()
+  })
+
+  it('renders candidates with plain-language reasons from a mocked GET', async () => {
+    apiGet.mockResolvedValue({ candidates: [candidate()], trashed: [] })
+    const wrapper = mount(VaultReviewPanel, { global: { plugins: [pinia] } })
+    await flushPromises()
+
+    expect(apiGet).toHaveBeenCalledWith('/api/vault/review?workspace=personal&include=trashed')
+    expect(wrapper.findAll('.vr-row')).toHaveLength(1)
+    expect(wrapper.text()).toContain('Mo')
+    expect(wrapper.text()).toContain('no other note links to it')
+    expect(wrapper.text()).toContain('never verified')
+    wrapper.unmount()
+  })
+
+  it('shows an empty state when nothing is flagged', async () => {
+    apiGet.mockResolvedValue({ candidates: [], trashed: [] })
+    const wrapper = mount(VaultReviewPanel, { global: { plugins: [pinia] } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Nothing flagged here')
+    wrapper.unmount()
+  })
+
+  it('sends keep and trash through their own actions', async () => {
+    apiGet.mockResolvedValue({ candidates: [candidate({ candidate_id: 'cid-keep' })], trashed: [] })
+    const wrapper = mount(VaultReviewPanel, { global: { plugins: [pinia] } })
+    await flushPromises()
+
+    await buttonByText(wrapper, 'Still true').trigger('click')
+    await flushPromises()
+    expect(apiPost).toHaveBeenCalledWith('/api/vault/review?workspace=personal', {
+      action: 'decide',
+      candidate_id: 'cid-keep',
+      disposition: 'keep',
+    })
+
+    await buttonByText(wrapper, 'Retire').trigger('click')
+    await flushPromises()
+    expect(apiPost).toHaveBeenCalledWith('/api/vault/review?workspace=personal', {
+      action: 'trash',
+      candidate_id: 'cid-keep',
+    })
+    wrapper.unmount()
+  })
+
+  it('renders the trash inventory with restore and a confirmed permanent delete', async () => {
+    apiGet.mockResolvedValue({ candidates: [], trashed: [trashed()] })
+    const wrapper = mount(VaultReviewPanel, { global: { plugins: [pinia] } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Trash (1)')
+    expect(wrapper.text()).toContain('Old')
+
+    await buttonByText(wrapper, 'Restore').trigger('click')
+    await flushPromises()
+    expect(apiPost).toHaveBeenCalledWith('/api/vault/review?workspace=personal', {
+      action: 'restore',
+      candidate_id: 'def456def456def456def456',
+    })
+
+    // Permanent deletion waits on the explicit confirm first.
+    const deleteClicked = buttonByText(wrapper, 'Delete forever').trigger('click')
+    await flushPromises()
+    expect(apiPost).not.toHaveBeenCalledWith(
+      '/api/vault/review?workspace=personal',
+      expect.objectContaining({ action: 'delete' }),
+    )
+    pendingConfirm.value?.resolve(true)
+    await deleteClicked
+    await flushPromises()
+    expect(apiPost).toHaveBeenCalledWith('/api/vault/review?workspace=personal', {
+      action: 'delete',
+      candidate_id: 'def456def456def456def456',
+      confirm: 'def456def456def456def456',
+    })
+    wrapper.unmount()
+  })
+
+  it('marks the store busy while a decision is in flight', async () => {
+    apiGet.mockResolvedValue({ candidates: [candidate()], trashed: [] })
+    const wrapper = mount(VaultReviewPanel, { global: { plugins: [pinia] } })
+    await flushPromises()
+    const store = useVaultReviewStore()
+
+    let release!: () => void
+    apiPost.mockImplementationOnce(() => new Promise(resolve => { release = () => resolve({ ok: true }) }))
+    const clicked = buttonByText(wrapper, 'Still true').trigger('click')
+    await flushPromises()
+    expect(store.isBusy('abc123abc123abc123abc123')).toBe(true)
+    release!()
+    await clicked
+    await flushPromises()
+    expect(store.isBusy('abc123abc123abc123abc123')).toBe(false)
+    wrapper.unmount()
+  })
+})

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1200,3 +1200,48 @@ export interface ProposalHistoryResponse {
    * same page. Paging must stop on this, not on `truncated`. */
   at_max?: boolean
 }
+
+// ── Vault review (stale-note retirement) ─────────────────────────────────
+// Backed by `GET|POST /api/vault/review` (`ciao/vault_review.py`), not by the
+// proposal queue: candidates are hash-identified vault notes with explainable
+// detection signals, and dispositions land in the append-only
+// `Workspace/Vault-Review.jsonl` ledger rather than the proposal sidecars.
+
+/** Explainable detection evidence behind one retirement candidate. */
+export interface VaultReviewEvidence {
+  backlinks: string[]
+  outbound_links: string[]
+  bridge: boolean
+  duplicate_group: string[]
+  last_update: string
+  type: string
+  age_days: number | null
+}
+
+/** One stale-note retirement candidate from `GET /api/vault/review`. */
+export interface VaultReviewCandidate {
+  candidate_id: string
+  workspace: string
+  path: string
+  content_hash: string
+  signals: string[]
+  priority: number
+  evidence: VaultReviewEvidence
+  status: string
+  disposition: string
+  deferred_until: string
+}
+
+/** One restorable note in `.vault-trash`, from `GET /api/vault/review?include=trashed`. */
+export interface VaultTrashedNote {
+  candidate_id: string
+  workspace: string
+  original_path: string
+  content_hash: string
+  trashed_at: string
+}
+
+export interface VaultReviewResponse {
+  candidates: VaultReviewCandidate[]
+  trashed?: VaultTrashedNote[]
+}

--- a/web/src/lib/vaultReviewLabels.test.ts
+++ b/web/src/lib/vaultReviewLabels.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { candidateLeaf, signalLabel, signalReasons, verificationLabel } from './vaultReviewLabels'
+
+describe('vault review labels', () => {
+  it('names every known detection signal in plain language', () => {
+    expect(signalLabel('unlinked')).toBe('no other note links to it')
+    expect(signalLabel('possible_duplicate')).toBe('it may duplicate another note')
+    expect(signalLabel('superseded_language')).toBe('its wording says it was superseded')
+    expect(signalLabel('weak_provenance')).toBe('it carries no date, tags, or aliases')
+  })
+
+  it('humanizes an unknown signal instead of dropping it', () => {
+    expect(signalLabel('stale_horizon')).toBe('stale horizon')
+  })
+
+  it('orders reasons stably regardless of server order', () => {
+    expect(signalReasons(['weak_provenance', 'unlinked'])).toEqual([
+      'no other note links to it',
+      'it carries no date, tags, or aliases',
+    ])
+  })
+
+  it('reads the note title off the path leaf', () => {
+    expect(candidateLeaf('memory-vault/People/Mo.md')).toBe('Mo')
+    expect(candidateLeaf('Mo.md')).toBe('Mo')
+  })
+
+  it('phrases verification age like the memory map does', () => {
+    expect(verificationLabel(0, '')).toBe('verified today')
+    expect(verificationLabel(5, '')).toBe('unverified for 5d')
+    expect(verificationLabel(65, '')).toBe('unverified for 2mo')
+    expect(verificationLabel(null, '2025-01-01')).toBe('last verified 2025-01-01')
+    expect(verificationLabel(null, '')).toBe('never verified')
+  })
+})

--- a/web/src/lib/vaultReviewLabels.ts
+++ b/web/src/lib/vaultReviewLabels.ts
@@ -1,0 +1,48 @@
+/** Plain-language reasons for vault-review detection signals, in one place.
+ *
+ * The panel used to risk interpolating raw signal names (`weak_provenance`)
+ * into the UI. A registry keeps the wording consistent and testable without
+ * mounting the panel, the same way `proposalKinds.ts` does for proposal rows.
+ * Unknown signals (a server newer than the client) fall back to a
+ * humanized form rather than disappearing.
+ */
+
+const SIGNAL_LABELS: Record<string, string> = {
+  unlinked: 'no other note links to it',
+  possible_duplicate: 'it may duplicate another note',
+  superseded_language: 'its wording says it was superseded',
+  weak_provenance: 'it carries no date, tags, or aliases',
+}
+
+/** One signal in words the UI can show. */
+export function signalLabel(signal: string): string {
+  return SIGNAL_LABELS[signal] ?? signal.replace(/_/g, ' ')
+}
+
+/** Every reason a candidate was flagged, in stable order. */
+export function signalReasons(signals: string[]): string[] {
+  return [...signals].sort().map(signalLabel)
+}
+
+/** The last path segment without its extension — the only part that differs
+ * between candidate rows. */
+export function candidateLeaf(path: string): string {
+  const leaf = path.split('/').pop() ?? path
+  return leaf.replace(/\.md$/, '') || path
+}
+
+/** When the note's facts were last verified, in words.
+ *
+ * Prefers the server-computed `age_days`; falls back to the raw
+ * `last_update` date, which is still more useful than silence.
+ */
+export function verificationLabel(ageDays: number | null, lastUpdate: string): string {
+  if (typeof ageDays === 'number' && Number.isFinite(ageDays)) {
+    if (ageDays < 1) return 'verified today'
+    if (ageDays < 30) return `unverified for ${ageDays}d`
+    if (ageDays < 365) return `unverified for ${Math.floor(ageDays / 30)}mo`
+    const years = ageDays / 365
+    return `unverified for ${years >= 2 ? Math.floor(years) : years.toFixed(1)}y`
+  }
+  return lastUpdate ? `last verified ${lastUpdate}` : 'never verified'
+}

--- a/web/src/stores/memoryMap.ts
+++ b/web/src/stores/memoryMap.ts
@@ -157,6 +157,13 @@ export const useMemoryMapStore = defineStore('memoryMap', () => {
    * `ProjectSidebar` (the buttons) and `MemoryMapView` (the surfaces).
    */
   const view = ref<'graph' | 'list' | 'review'>('graph')
+  /**
+   * Which pane the Review surface shows: the agent-proposal queue or the
+   * stale-note retirement queue. Defaults to proposals; entry points that
+   * are about retiring a note (the sidebar's "Needs review" list, a stale
+   * note's detail panel) select retirement directly.
+   */
+  const reviewTab = ref<'proposals' | 'retirement'>('proposals')
   // Bumped whenever something outside the canvas (the sidebar's "most
   // connected" list, a neighbor link) asks the canvas to pan/zoom onto a
   // node. The canvas owns camera state and only needs to watch this signal.
@@ -630,7 +637,7 @@ export const useMemoryMapStore = defineStore('memoryMap', () => {
   return {
     nodes, edges, loading, loadError, search, activeCats, selectedId, pathStart, pathEnd, focusSignal,
     pendingFocus,
-    hideOrphans, orphanFilter, colorMode, view,
+    hideOrphans, orphanFilter, colorMode, view, reviewTab,
     nodesById, adjacency, categoryList, visibleNodes, visibleIds, visibleEdgeCount, orphanCount,
     mostConnected, selectedNode, pathIds, pathHint,
     clusters, clusterById, orphanNotes, bridgeNotes, recentNotes, staleNotes, ageLabelOf,

--- a/web/src/stores/vaultReview.test.ts
+++ b/web/src/stores/vaultReview.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { api } from '../lib/api'
+import { useVaultReviewStore } from './vaultReview'
+import type { VaultReviewCandidate, VaultTrashedNote } from '../lib/types'
+
+vi.mock('../lib/api', () => ({
+  api: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), del: vi.fn() },
+}))
+
+const get = vi.mocked(api.get)
+const post = vi.mocked(api.post)
+
+function candidate(overrides: Partial<VaultReviewCandidate> = {}): VaultReviewCandidate {
+  return {
+    candidate_id: 'abc123abc123abc123abc123',
+    workspace: 'personal',
+    path: 'memory-vault/People/Mo.md',
+    content_hash: 'deadbeef',
+    signals: ['unlinked'],
+    priority: 1,
+    evidence: {
+      backlinks: [],
+      outbound_links: [],
+      bridge: false,
+      duplicate_group: [],
+      last_update: '',
+      type: 'note',
+      age_days: null,
+    },
+    status: 'candidate',
+    disposition: '',
+    deferred_until: '',
+    ...overrides,
+  }
+}
+
+function trashed(overrides: Partial<VaultTrashedNote> = {}): VaultTrashedNote {
+  return {
+    candidate_id: 'abc123abc123abc123abc123',
+    workspace: 'personal',
+    original_path: 'memory-vault/People/Mo.md',
+    content_hash: 'deadbeef',
+    trashed_at: '2026-09-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('vaultReview store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('loads candidates and the trash inventory for one workspace', async () => {
+    get.mockResolvedValue({ candidates: [candidate()], trashed: [trashed()] })
+    const store = useVaultReviewStore()
+
+    await store.fetch('personal')
+
+    expect(get).toHaveBeenCalledWith('/api/vault/review?workspace=personal&include=trashed')
+    expect(store.candidates).toHaveLength(1)
+    expect(store.trashed).toHaveLength(1)
+    expect(store.loadedWorkspace).toBe('personal')
+  })
+
+  it('drops a stale response when the workspace changed mid-flight', async () => {
+    let release!: () => void
+    get.mockImplementationOnce(
+      () => new Promise(resolve => { release = () => resolve({ candidates: [candidate()], trashed: [] }) }),
+    )
+    get.mockResolvedValue({ candidates: [], trashed: [] })
+    const store = useVaultReviewStore()
+
+    const first = store.fetch('personal')
+    await store.fetch('work', { force: true })
+    release()
+    await first
+
+    expect(store.loadedWorkspace).toBe('work')
+    expect(store.candidates).toEqual([])
+  })
+
+  it('records a keep decision and refreshes the queue', async () => {
+    get.mockResolvedValue({ candidates: [], trashed: [] })
+    post.mockResolvedValue({ ok: true })
+    const store = useVaultReviewStore()
+
+    const ok = await store.decide('personal', 'cid1', 'keep')
+
+    expect(ok).toBe(true)
+    expect(post).toHaveBeenCalledWith('/api/vault/review?workspace=personal', {
+      action: 'decide',
+      candidate_id: 'cid1',
+      disposition: 'keep',
+    })
+  })
+
+  it('sends defer_days only for a defer decision', async () => {
+    get.mockResolvedValue({ candidates: [], trashed: [] })
+    post.mockResolvedValue({ ok: true })
+    const store = useVaultReviewStore()
+
+    await store.decide('personal', 'cid1', 'defer', 14)
+
+    expect(post).toHaveBeenCalledWith('/api/vault/review?workspace=personal', {
+      action: 'decide',
+      candidate_id: 'cid1',
+      disposition: 'defer',
+      defer_days: 14,
+    })
+  })
+
+  it('trashes, restores, and permanently deletes through their own actions', async () => {
+    get.mockResolvedValue({ candidates: [], trashed: [] })
+    post.mockResolvedValue({ ok: true })
+    const store = useVaultReviewStore()
+
+    await store.trash('personal', 'cid1')
+    await store.restore('personal', 'cid2')
+    await store.remove('personal', 'cid3')
+
+    expect(post).toHaveBeenNthCalledWith(1, '/api/vault/review?workspace=personal', {
+      action: 'trash',
+      candidate_id: 'cid1',
+    })
+    expect(post).toHaveBeenNthCalledWith(2, '/api/vault/review?workspace=personal', {
+      action: 'restore',
+      candidate_id: 'cid2',
+    })
+    // Permanent deletion carries the exact candidate id as confirmation,
+    // which is what the server gates on.
+    expect(post).toHaveBeenNthCalledWith(3, '/api/vault/review?workspace=personal', {
+      action: 'delete',
+      candidate_id: 'cid3',
+      confirm: 'cid3',
+    })
+  })
+
+  it('reports a failed mutation without throwing', async () => {
+    post.mockRejectedValue(new Error('candidate changed or no longer exists'))
+    const store = useVaultReviewStore()
+
+    const ok = await store.trash('personal', 'cid1')
+
+    expect(ok).toBe(false)
+    expect(store.error).toBe('candidate changed or no longer exists')
+    expect(store.isBusy('cid1')).toBe(false)
+  })
+})

--- a/web/src/stores/vaultReview.ts
+++ b/web/src/stores/vaultReview.ts
@@ -33,6 +33,7 @@ export const useVaultReviewStore = defineStore('vaultReview', () => {
   const error = ref('')
   const loadedWorkspace = ref<string | null>(null)
   let fetchPromise: Promise<void> | null = null
+  let fetchWorkspace: string | null = null
   /** Ticket for the newest in-flight list request; older responses are dropped. */
   let fetchSeq = 0
 
@@ -51,12 +52,15 @@ export const useVaultReviewStore = defineStore('vaultReview', () => {
    * Load the queue for one workspace. `force` starts a fresh request even
    * when one is in flight — the refresh after a mutation must never join a
    * GET issued before its own POST, or the decided row stays queued as if
-   * nothing happened.
+   * nothing happened. A request for a different workspace never joins either:
+   * otherwise flipping workspaces mid-flight would leave the new scope
+   * showing the old scope's rows with no refetch until manual refresh.
    */
   async function fetch(workspace: string, opts?: { force?: boolean }): Promise<void> {
     if (!workspace) return
-    if (fetchPromise && !opts?.force) return fetchPromise
+    if (fetchPromise && !opts?.force && fetchWorkspace === workspace) return fetchPromise
     const seq = ++fetchSeq
+    fetchWorkspace = workspace
     const request = (async () => {
       loading.value = true
       error.value = ''

--- a/web/src/stores/vaultReview.ts
+++ b/web/src/stores/vaultReview.ts
@@ -1,0 +1,148 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import { api } from '../lib/api'
+import type {
+  VaultReviewCandidate,
+  VaultReviewResponse,
+  VaultTrashedNote,
+} from '../lib/types'
+
+export type VaultReviewDisposition = 'keep' | 'improve_link' | 'defer'
+
+function reviewUrl(workspace: string, includeTrashed: boolean): string {
+  const query = `workspace=${encodeURIComponent(workspace)}${includeTrashed ? '&include=trashed' : ''}`
+  return `/api/vault/review?${query}`
+}
+
+/**
+ * Stale-note retirement queue. Mirrors the proposals store's best-effort
+ * contract: a failed fetch leaves the list as it was rather than throwing,
+ * and every mutation re-fetches so the panel reflects what the server kept.
+ *
+ * Scoped by the server, not the client: every request names the workspace
+ * (`GET /api/vault/review` requires it) and the store remembers which scope
+ * it holds, so a response for a workspace the user has left cannot overwrite
+ * the one they are looking at.
+ */
+export const useVaultReviewStore = defineStore('vaultReview', () => {
+  const candidates = ref<VaultReviewCandidate[]>([])
+  const trashed = ref<VaultTrashedNote[]>([])
+  const loading = ref(false)
+  const busyIds = ref<Set<string>>(new Set())
+  const busy = computed(() => busyIds.value.size > 0)
+  const error = ref('')
+  const loadedWorkspace = ref<string | null>(null)
+  let fetchPromise: Promise<void> | null = null
+  /** Ticket for the newest in-flight list request; older responses are dropped. */
+  let fetchSeq = 0
+
+  function isBusy(id: string): boolean {
+    return busyIds.value.has(id)
+  }
+
+  function setBusy(id: string, on: boolean) {
+    const next = new Set(busyIds.value)
+    if (on) next.add(id)
+    else next.delete(id)
+    busyIds.value = next
+  }
+
+  /**
+   * Load the queue for one workspace. `force` starts a fresh request even
+   * when one is in flight — the refresh after a mutation must never join a
+   * GET issued before its own POST, or the decided row stays queued as if
+   * nothing happened.
+   */
+  async function fetch(workspace: string, opts?: { force?: boolean }): Promise<void> {
+    if (!workspace) return
+    if (fetchPromise && !opts?.force) return fetchPromise
+    const seq = ++fetchSeq
+    const request = (async () => {
+      loading.value = true
+      error.value = ''
+      try {
+        const data = await api.get<VaultReviewResponse>(reviewUrl(workspace, true))
+        if (seq !== fetchSeq) return
+        candidates.value = data.candidates ?? []
+        trashed.value = data.trashed ?? []
+        loadedWorkspace.value = workspace
+      } catch (e) {
+        if (seq !== fetchSeq) return
+        error.value = e instanceof Error ? e.message : 'Could not load retirement candidates'
+      } finally {
+        if (seq === fetchSeq) loading.value = false
+      }
+    })()
+    fetchPromise = request
+    try {
+      await request
+    } finally {
+      if (fetchPromise === request) fetchPromise = null
+    }
+  }
+
+  /** Run one mutation and refresh the queue it changes. */
+  async function mutate(workspace: string, id: string, body: Record<string, unknown>): Promise<boolean> {
+    setBusy(id, true)
+    error.value = ''
+    try {
+      await api.post<{ ok: boolean }>(reviewUrl(workspace, false), body)
+      await fetch(workspace, { force: true })
+      return true
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Action failed'
+      return false
+    } finally {
+      setBusy(id, false)
+    }
+  }
+
+  /** Record keep / improve_link / defer. Trash/restore/delete are separate actions. */
+  async function decide(
+    workspace: string,
+    id: string,
+    disposition: VaultReviewDisposition,
+    deferDays = 7,
+  ): Promise<boolean> {
+    return mutate(workspace, id, {
+      action: 'decide',
+      candidate_id: id,
+      disposition,
+      ...(disposition === 'defer' ? { defer_days: deferDays } : {}),
+    })
+  }
+
+  /** Retire a note into the reversible 30-day trash. */
+  async function trash(workspace: string, id: string): Promise<boolean> {
+    return mutate(workspace, id, { action: 'trash', candidate_id: id })
+  }
+
+  /** Bring a trashed note back to its original path. */
+  async function restore(workspace: string, id: string): Promise<boolean> {
+    return mutate(workspace, id, { action: 'restore', candidate_id: id })
+  }
+
+  /** Permanently delete a trashed note. The server requires the exact
+   * candidate id as confirmation; the panel collects the explicit confirm
+   * before calling. */
+  async function remove(workspace: string, id: string): Promise<boolean> {
+    return mutate(workspace, id, { action: 'delete', candidate_id: id, confirm: id })
+  }
+
+  return {
+    candidates,
+    trashed,
+    loading,
+    busy,
+    busyIds,
+    isBusy,
+    setBusy,
+    error,
+    loadedWorkspace,
+    fetch,
+    decide,
+    trash,
+    restore,
+    remove,
+  }
+})


### PR DESCRIPTION
Closes #417.

The vault_review backend (candidates, ledger, reversible trash, attended delete) had no PWA surface. This adds one, reusing the existing endpoint and ledger with no new state.

Backend:
- New read-only trash inventory: GET /api/vault/review?include=trashed lists restorable notes (a trashed note is no longer in the vault, so candidate generation can never return it). GET stays side-effect-free.
- Tests for scoping, restore tracking, and malformed sidecars.

Frontend:
- Review surface (/proposals) gains Proposals and Retirement tabs with workspace-scoped counts.
- VaultReviewPanel: per candidate title/path, why flagged, last verified, excerpt; Still true (keep), Retire (trash, one click, reversible 30 days), Later (1-90 day snooze), Link fixed; trash section with one-click Restore and confirmation-gated Delete forever.
- Entry points: sidebar Needs review list and stale note detail panels land directly on Retirement.

Verification:
- pytest tests/test_vault_review.py: 15 passed; full suite: 3439 passed with 6 pre-existing failures (chat_stop/push_notification_log, identical on clean tree).
- mypy ciao: touched files clean; 13 pre-existing mcp SDK drift errors in untouched mcp_server.py.
- web: npm test 91 files/1074 tests pass, npm run build passes, lint 0 errors.
- Browser visual pass still pending before merge.